### PR TITLE
docs: link regression test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ npm test
 - `npm run build` — Compile the contracts with Truffle.
 - `npm run lint` — Lint Solidity sources with Solhint.
 - `npm test` — Run the test suite.
+- `docs/REGRESSION_TESTS.md` — Better-only regression coverage comparing current vs original contract behavior.
 
 ## Configuration
 Truffle networks and compiler settings are configured in `truffle-config.js`. The following environment variables are used for deployments and verification:


### PR DESCRIPTION
### Motivation
- Surface the new “better-only” regression suite in the README so contributors can find and run the tests that compare the current contract against the original vulnerable v0 implementation.

### Description
- Add a single README entry pointing to `docs/REGRESSION_TESTS.md` which documents the six regression tests and the legacy contract used for comparison (no production contracts were modified).

### Testing
- Ran `npm run build` (Truffle compile) and `npm test` (Truffle tests + smoke), and the regression suite completed: `6 passing` (build and tests succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697960238e7483338b6fe991cd7ae8c6)