### PR TITLE
Add ERC‑8004 off‑chain adapter, docs, and Truffle scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# ERC-8004 adapter configuration
+AGIJOBMANAGER_ADDRESS=
+FROM_BLOCK=
+TO_BLOCK=latest
+OUT_DIR=integrations/erc8004/out
+INCLUDE_VALIDATORS=false
+
+# Feedback action generation (optional)
+METRICS_FILE=

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ web_modules/
 .env.*
 !.env.example
 
+# ERC-8004 adapter outputs
+integrations/erc8004/out/
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/README.md
+++ b/README.md
@@ -50,6 +50,12 @@ npm test
 - `npm test` — Run the test suite.
 - `docs/REGRESSION_TESTS.md` — Better-only regression coverage comparing current vs original contract behavior.
 
+## ERC-8004 integration (off-chain)
+AGIJobManager can interoperate with the ERC-8004 identity + reputation ecosystem via a lightweight off-chain adapter. See:
+
+- [`docs/ERC8004.md`](docs/ERC8004.md) — integration overview and guidance.
+- [`integrations/erc8004/`](integrations/erc8004/) — adapter spec, scripts, and examples.
+
 ## Configuration
 Truffle networks and compiler settings are configured in `truffle-config.js`. The following environment variables are used for deployments and verification:
 

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -1,0 +1,49 @@
+# ERC-8004 integration (off-chain)
+
+AGIJobManager can interoperate with the ERC-8004 agent identity + reputation ecosystem without coupling any critical escrow logic to external calls. This repo provides an **off-chain adapter** that reads AGIJobManager events and emits ERC-8004-friendly reputation artifacts, plus optional tooling hooks for composing feedback actions.
+
+## What is ERC-8004?
+ERC-8004 defines a registry for agent identities and a standardized way to publish reputation signals (tags + numeric values) for those identities. In practice, it lets multiple observers (watchers/rankers) publish comparable metrics for the same agent, so consumers can build trust scores and rankings across ecosystems.
+
+## Why no on-chain dependency from AGIJobManager
+AGIJobManager’s escrow, dispute resolution, and payout flows must remain **self-contained**. Calling external ERC-8004 contracts in those paths would introduce liveness and dependency risks (e.g., registry downtime, reverts, gas spikes) and could block critical job finalization. This integration is intentionally **off-chain** and **optional**, with no new contract calls or events added to `AGIJobManager.sol`.
+
+## Agent/validator registration
+ERC-8004 identities typically expose a JSON registration file referenced by the identity’s `tokenURI`. Use the **`services`** field (not `endpoints`) to advertise how the agent can be reached.
+
+Example registration file: [`integrations/erc8004/examples/registration.json`](../integrations/erc8004/examples/registration.json).
+
+Hosting guidance:
+- Host the JSON on IPFS or HTTPS.
+- Set the ERC-8004 identity’s `tokenURI` to the hosted file URL.
+- Keep `services` stable and update only when contact details change.
+
+## Reputation signals from AGIJobManager events
+Watchers/rankers can ingest AGIJobManager events and publish ERC-8004 feedback signals using the `value` + `valueDecimals` scheme. Decimals and negative values are allowed.
+
+Example tag/value encodings:
+- `successRate` 99.80% → `value=9980`, `valueDecimals=2`
+- `downvote` −1 → `value=-1`, `valueDecimals=0`
+- `revenues` $556,000 → `value=556000`, `valueDecimals=0`
+
+Recommended tags (aligned with ERC-8004 best practices):
+- `successRate`
+- `disputeRate`
+- `jobsCompleted`
+- `jobsDisputed`
+- `responseTime`
+- `blocktimeFreshness`
+- `revenues`
+- `ownerVerified`
+
+See the adapter mapping in [`integrations/erc8004/adapter_spec.md`](../integrations/erc8004/adapter_spec.md).
+
+## Trusted client set (anti-sybil guidance)
+For AGIJobManager, a strong eligibility set for submitting feedback is **“addresses that actually created paid jobs.”** Concretely, the trusted set can be derived from `JobCreated` events, using each event’s transaction sender as the employer address. This filters out unverified accounts that never funded jobs.
+
+## Official ERC-8004 sources
+- EIP spec: https://eips.ethereum.org/EIPS/eip-8004
+- Best practices: https://github.com/erc-8004/best-practices
+- Reference contracts: https://github.com/erc-8004/erc-8004-contracts
+
+**Assumptions:** The best-practices and contracts repositories above are maintained by the ERC-8004 authors/maintainers (org `erc-8004`). If your deployment relies on alternative sources, update these links accordingly.

--- a/integrations/erc8004/README.md
+++ b/integrations/erc8004/README.md
@@ -1,0 +1,41 @@
+# ERC-8004 adapter (AGIJobManager)
+
+This folder contains a lightweight, **off-chain** adapter for exporting ERC-8004-friendly reputation artifacts from AGIJobManager events. No on-chain AGIJobManager logic is modified.
+
+## Quickstart
+```bash
+npm install
+npm run build
+
+# Export metrics (dry-run, writes JSON only)
+AGIJOBMANAGER_ADDRESS=0x... \
+FROM_BLOCK=0 \
+TO_BLOCK=latest \
+OUT_DIR=integrations/erc8004/out \
+truffle exec scripts/erc8004/export_metrics.js --network sepolia
+```
+
+Optional:
+```bash
+# Generate intended feedback actions (no transactions by default)
+METRICS_FILE=integrations/erc8004/out/erc8004_metrics_*.json \
+OUT_DIR=integrations/erc8004/out \
+node scripts/erc8004/generate_feedback_calldata.js
+```
+
+## Configuration
+Environment variables (see `.env.example`):
+- `AGIJOBMANAGER_ADDRESS` — contract address to scan.
+- `FROM_BLOCK` / `TO_BLOCK` — block range (use `latest` for current tip).
+- `OUT_DIR` — output directory for JSON artifacts.
+- `INCLUDE_VALIDATORS` — set to `true` to include validator stats.
+
+## Outputs
+- `erc8004_metrics_*.json` — aggregated metrics per agent (and optionally validator stats).
+- `erc8004_feedback_actions_*.json` — intended feedback actions for ERC-8004 (dry-run).
+
+## Notes
+- Revenue is a **proxy** derived from `JobCreated` payout values that later complete successfully.
+- Employer addresses are inferred from `JobCreated` transactions, since the event does not carry the employer address.
+- See `adapter_spec.md` for the full mapping.
+- For on-chain submission of feedback, use the official ERC-8004 tooling/SDK referenced in `docs/ERC8004.md` and map the generated actions accordingly.

--- a/integrations/erc8004/adapter_spec.md
+++ b/integrations/erc8004/adapter_spec.md
@@ -1,0 +1,50 @@
+# Adapter specification (AGIJobManager → ERC-8004)
+
+This document describes how the adapter script aggregates AGIJobManager events into ERC-8004-compatible metrics.
+
+## Data sources (events)
+- `JobCreated(jobId, ipfsHash, payout, duration, details)`
+- `JobApplied(jobId, agent)`
+- `JobCompletionRequested(jobId, agent)`
+- `JobValidated(jobId, validator)`
+- `JobDisapproved(jobId, validator)`
+- `JobCompleted(jobId, agent, reputationPoints)`
+- `JobDisputed(jobId, disputant)`
+- `DisputeResolved(jobId, resolver, resolution)`
+
+## Primary aggregation keys
+- **Agent address** (from `JobApplied` / `JobCompleted`).
+- **Employer address** (from `JobCreated` transaction sender; used for trusted client set).
+- **Validator address** (optional; from `JobValidated` / `JobDisapproved`).
+
+## Per-agent metrics
+| Metric | Source | Definition | ERC-8004 tag | valueDecimals |
+| --- | --- | --- | --- | --- |
+| jobsAssigned | `JobApplied` | Count of jobs where agent was assigned | `jobsAssigned` | 0 |
+| jobsCompleted | `JobCompleted` | Count of completed jobs | `jobsCompleted` | 0 |
+| jobsDisputed | `JobDisputed` | Count of jobs with a dispute flag | `jobsDisputed` | 0 |
+| employerWins | `DisputeResolved` | Resolution string == `"employer win"` (case-insensitive) | `employerWins` | 0 |
+| agentWins | `DisputeResolved` | Resolution string == `"agent win"` (case-insensitive) | `agentWins` | 0 |
+| unknownResolutions | `DisputeResolved` | Any other resolution string | `unknownResolutions` | 0 |
+| successRate | derived | `jobsCompleted / jobsAssigned` | `successRate` | 2 (percent with 2 decimals) |
+| disputeRate | derived | `jobsDisputed / jobsAssigned` | `disputeRate` | 2 (percent with 2 decimals) |
+| revenues | derived | Sum of `JobCreated.payout` for completed jobs | `revenues` | 0 |
+
+**Note:** `successRate` and `disputeRate` are emitted as percentages with 2 decimal places (e.g., 99.80% → value 9980, valueDecimals 2).
+
+## Optional validator metrics
+If `INCLUDE_VALIDATORS=true`:
+- `jobsValidated` — count of `JobValidated` per validator.
+- `jobsDisapproved` — count of `JobDisapproved` per validator.
+
+These are output under a `validators` map in the JSON artifact.
+
+## Resolution handling
+`DisputeResolved` accepts any resolution string. The adapter only categorizes two canonical values:
+- `agent win`
+- `employer win`
+
+All other values are counted as `unknownResolutions`.
+
+## Trusted client set
+To derive a trusted eligibility set for ERC-8004 feedback submission, use **employer addresses** extracted from `JobCreated` transactions (i.e., the `from` address). Only addresses that actually funded jobs are included.

--- a/integrations/erc8004/examples/registration.json
+++ b/integrations/erc8004/examples/registration.json
@@ -1,0 +1,26 @@
+{
+  "name": "Example AGI Agent",
+  "description": "Demonstration registration for an AGIJobManager agent identity.",
+  "services": [
+    {
+      "type": "a2a",
+      "uri": "https://example.com/agent-card.json",
+      "name": "A2A card"
+    },
+    {
+      "type": "mcp",
+      "uri": "https://mcp.example.com/agent",
+      "name": "MCP endpoint"
+    },
+    {
+      "type": "ens",
+      "uri": "ens:example-agent.eth",
+      "name": "ENS"
+    },
+    {
+      "type": "email",
+      "uri": "mailto:agent@example.com",
+      "name": "Contact"
+    }
+  ]
+}

--- a/scripts/erc8004/export_metrics.js
+++ b/scripts/erc8004/export_metrics.js
@@ -1,0 +1,219 @@
+const fs = require('fs');
+const path = require('path');
+
+function getArgValue(name) {
+  const withEquals = process.argv.find((arg) => arg.startsWith(`--${name}=`));
+  if (withEquals) return withEquals.split('=')[1];
+  const index = process.argv.findIndex((arg) => arg === `--${name}`);
+  if (index !== -1 && process.argv[index + 1]) return process.argv[index + 1];
+  return undefined;
+}
+
+function normalizeBool(value, fallback = false) {
+  if (value === undefined || value === null) return fallback;
+  return String(value).toLowerCase() === 'true';
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function formatRate(numerator, denominator) {
+  if (!denominator) return 0;
+  return Math.round((numerator / denominator) * 10000) / 1;
+}
+
+function getStats(map, address, web3Instance) {
+  if (!map.has(address)) {
+    map.set(address, {
+      jobsApplied: 0,
+      jobsAssigned: 0,
+      jobsCompleted: 0,
+      jobsDisputed: 0,
+      employerWins: 0,
+      agentWins: 0,
+      unknownResolutions: 0,
+      revenues: web3Instance.utils.toBN(0),
+    });
+  }
+  return map.get(address);
+}
+
+module.exports = async function exportMetrics(callback) {
+  try {
+    const web3Instance = typeof web3 !== 'undefined' ? web3 : global.web3;
+    const truffleArtifacts = typeof artifacts !== 'undefined' ? artifacts : global.artifacts;
+    if (!web3Instance || !truffleArtifacts) throw new Error('Truffle globals (web3, artifacts) not found.');
+
+    const AGIJobManager = truffleArtifacts.require('AGIJobManager');
+    const address = process.env.AGIJOBMANAGER_ADDRESS || getArgValue('AGIJOBMANAGER_ADDRESS');
+    if (!address) throw new Error('Missing AGIJOBMANAGER_ADDRESS');
+
+    const includeValidators = normalizeBool(process.env.INCLUDE_VALIDATORS || getArgValue('INCLUDE_VALIDATORS'));
+
+    const fromBlockRaw = process.env.FROM_BLOCK || getArgValue('FROM_BLOCK') || '0';
+    const toBlockRaw = process.env.TO_BLOCK || getArgValue('TO_BLOCK') || 'latest';
+
+    const fromBlock = Number(fromBlockRaw);
+    if (!Number.isFinite(fromBlock) || fromBlock < 0) throw new Error(`Invalid FROM_BLOCK: ${fromBlockRaw}`);
+
+    const latestBlock = await web3Instance.eth.getBlockNumber();
+    const toBlock = toBlockRaw === 'latest' ? latestBlock : Number(toBlockRaw);
+    if (!Number.isFinite(toBlock) || toBlock < fromBlock) throw new Error(`Invalid TO_BLOCK: ${toBlockRaw}`);
+
+    const outDir = process.env.OUT_DIR || getArgValue('OUT_DIR') || path.join('integrations', 'erc8004', 'out');
+    ensureDir(outDir);
+
+    const contract = await AGIJobManager.at(address);
+    const events = await contract.getPastEvents('allEvents', { fromBlock, toBlock });
+    events.sort((a, b) => (a.blockNumber - b.blockNumber) || (a.logIndex - b.logIndex));
+
+    const jobData = new Map();
+    const jobDisputed = new Set();
+    const jobResolved = new Set();
+    const txCache = new Map();
+
+    const agents = new Map();
+    const validators = new Map();
+    const trustedEmployers = new Set();
+
+    for (const event of events) {
+      const jobId = event.returnValues.jobId !== undefined ? String(event.returnValues.jobId) : undefined;
+
+      if (event.event === 'JobCreated') {
+        const payout = web3Instance.utils.toBN(event.returnValues.payout);
+        let employer = '0x0000000000000000000000000000000000000000';
+        if (event.transactionHash) {
+          if (!txCache.has(event.transactionHash)) {
+            txCache.set(event.transactionHash, await web3Instance.eth.getTransaction(event.transactionHash));
+          }
+          const tx = txCache.get(event.transactionHash);
+          if (tx && tx.from) employer = tx.from;
+        }
+        jobData.set(jobId, { payout, employer, agent: null });
+        trustedEmployers.add(employer.toLowerCase());
+        continue;
+      }
+
+      if (event.event === 'JobApplied') {
+        const agent = event.returnValues.agent;
+        const stats = getStats(agents, agent.toLowerCase(), web3Instance);
+        stats.jobsApplied += 1;
+        stats.jobsAssigned += 1;
+        const data = jobData.get(jobId) || { payout: web3Instance.utils.toBN(0), employer: null, agent: null };
+        data.agent = agent;
+        jobData.set(jobId, data);
+        continue;
+      }
+
+      if (event.event === 'JobDisputed') {
+        if (jobId && !jobDisputed.has(jobId)) {
+          jobDisputed.add(jobId);
+          const data = jobData.get(jobId);
+          if (data && data.agent) {
+            const stats = getStats(agents, data.agent.toLowerCase(), web3Instance);
+            stats.jobsDisputed += 1;
+          }
+        }
+        continue;
+      }
+
+      if (event.event === 'DisputeResolved') {
+        if (jobId && !jobResolved.has(jobId)) {
+          jobResolved.add(jobId);
+          const data = jobData.get(jobId);
+          if (data && data.agent) {
+            const stats = getStats(agents, data.agent.toLowerCase(), web3Instance);
+            const resolution = String(event.returnValues.resolution || '').trim().toLowerCase();
+            if (resolution === 'agent win') stats.agentWins += 1;
+            else if (resolution === 'employer win') stats.employerWins += 1;
+            else stats.unknownResolutions += 1;
+          }
+        }
+        continue;
+      }
+
+      if (event.event === 'JobCompleted') {
+        const agent = event.returnValues.agent;
+        const stats = getStats(agents, agent.toLowerCase(), web3Instance);
+        stats.jobsCompleted += 1;
+        const data = jobData.get(jobId);
+        if (data && data.payout) {
+          stats.revenues = stats.revenues.add(data.payout);
+        }
+        continue;
+      }
+
+      if (includeValidators && event.event === 'JobValidated') {
+        const validator = event.returnValues.validator;
+        if (!validators.has(validator.toLowerCase())) {
+          validators.set(validator.toLowerCase(), { jobsValidated: 0, jobsDisapproved: 0 });
+        }
+        validators.get(validator.toLowerCase()).jobsValidated += 1;
+        continue;
+      }
+
+      if (includeValidators && event.event === 'JobDisapproved') {
+        const validator = event.returnValues.validator;
+        if (!validators.has(validator.toLowerCase())) {
+          validators.set(validator.toLowerCase(), { jobsValidated: 0, jobsDisapproved: 0 });
+        }
+        validators.get(validator.toLowerCase()).jobsDisapproved += 1;
+      }
+    }
+
+    const agentsOut = {};
+    for (const [addressKey, stats] of agents.entries()) {
+      const successRate = formatRate(stats.jobsCompleted, stats.jobsAssigned);
+      const disputeRate = formatRate(stats.jobsDisputed, stats.jobsAssigned);
+      agentsOut[addressKey] = {
+        jobsApplied: stats.jobsApplied,
+        jobsAssigned: stats.jobsAssigned,
+        jobsCompleted: stats.jobsCompleted,
+        jobsDisputed: stats.jobsDisputed,
+        employerWins: stats.employerWins,
+        agentWins: stats.agentWins,
+        unknownResolutions: stats.unknownResolutions,
+        successRate: { value: successRate, valueDecimals: 2 },
+        disputeRate: { value: disputeRate, valueDecimals: 2 },
+        revenues: { value: stats.revenues.toString(), valueDecimals: 0 },
+      };
+    }
+
+    const validatorsOut = {};
+    if (includeValidators) {
+      for (const [addressKey, stats] of validators.entries()) {
+        validatorsOut[addressKey] = stats;
+      }
+    }
+
+    const chainId = await web3Instance.eth.getChainId();
+    const networkId = await web3Instance.eth.net.getId();
+    const networkName = getArgValue('network') || process.env.TRUFFLE_NETWORK || 'unknown';
+
+    const output = {
+      metadata: {
+        version: '1.0.0',
+        chainId,
+        networkId,
+        network: networkName,
+        fromBlock,
+        toBlock,
+        generatedAt: new Date().toISOString(),
+        contract: address,
+      },
+      agents: agentsOut,
+      validators: includeValidators ? validatorsOut : undefined,
+      trustedEmployers: Array.from(trustedEmployers),
+    };
+
+    const fileName = `erc8004_metrics_${chainId}_${fromBlock}_${toBlock}.json`;
+    const filePath = path.join(outDir, fileName);
+    fs.writeFileSync(filePath, JSON.stringify(output, null, 2));
+
+    console.log(`ERC-8004 metrics exported to ${filePath}`);
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};

--- a/scripts/erc8004/generate_feedback_calldata.js
+++ b/scripts/erc8004/generate_feedback_calldata.js
@@ -1,0 +1,88 @@
+const fs = require('fs');
+const path = require('path');
+
+function getArgValue(name) {
+  const withEquals = process.argv.find((arg) => arg.startsWith(`--${name}=`));
+  if (withEquals) return withEquals.split('=')[1];
+  const index = process.argv.findIndex((arg) => arg === `--${name}`);
+  if (index !== -1 && process.argv[index + 1]) return process.argv[index + 1];
+  return undefined;
+}
+
+function ensureDir(dir) {
+  fs.mkdirSync(dir, { recursive: true });
+}
+
+function loadJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function buildActions(metrics) {
+  const actions = [];
+  const agents = metrics.agents || {};
+
+  for (const [address, stats] of Object.entries(agents)) {
+    actions.push({
+      subject: address,
+      tag: 'jobsCompleted',
+      value: stats.jobsCompleted,
+      valueDecimals: 0,
+      evidence: '',
+    });
+    actions.push({
+      subject: address,
+      tag: 'jobsDisputed',
+      value: stats.jobsDisputed,
+      valueDecimals: 0,
+      evidence: '',
+    });
+    actions.push({
+      subject: address,
+      tag: 'successRate',
+      value: stats.successRate.value,
+      valueDecimals: stats.successRate.valueDecimals,
+      evidence: '',
+    });
+    actions.push({
+      subject: address,
+      tag: 'disputeRate',
+      value: stats.disputeRate.value,
+      valueDecimals: stats.disputeRate.valueDecimals,
+      evidence: '',
+    });
+    actions.push({
+      subject: address,
+      tag: 'revenues',
+      value: stats.revenues.value,
+      valueDecimals: stats.revenues.valueDecimals,
+      evidence: '',
+    });
+  }
+
+  return actions;
+}
+
+const metricsFile = process.env.METRICS_FILE || getArgValue('METRICS_FILE');
+if (!metricsFile) {
+  console.error('Missing METRICS_FILE');
+  process.exit(1);
+}
+
+const outDir = process.env.OUT_DIR || getArgValue('OUT_DIR') || path.join('integrations', 'erc8004', 'out');
+ensureDir(outDir);
+
+const metrics = loadJson(metricsFile);
+const actions = buildActions(metrics);
+
+const fileName = `erc8004_feedback_actions_${Date.now()}.json`;
+const filePath = path.join(outDir, fileName);
+fs.writeFileSync(filePath, JSON.stringify({
+  metadata: {
+    source: metricsFile,
+    generatedAt: new Date().toISOString(),
+    chainId: metrics.metadata ? metrics.metadata.chainId : undefined,
+  },
+  actions,
+}, null, 2));
+
+console.log(`Feedback actions written to ${filePath}`);


### PR DESCRIPTION
### Motivation
- Provide an opt-in integration path so AGIJobManager can participate in the ERC‑8004 identity + reputation ecosystem without coupling on‑chain escrow or dispute flows to external registries.
- Offer a simple, auditable off‑chain adapter that consumes contract events and produces ERC‑8004‑friendly metrics/artifacts while preserving contract behavior and liveness.
- Surface practical guidance and examples for agent registration, trusted client sets, tag encodings, and how to convert adapter output into ERC‑8004 feedback actions.

### Description
- Added `docs/ERC8004.md` describing ERC‑8004, reasons for keeping integration off‑chain, tagging/encoding examples, and trusted client guidance. No on‑chain contract changes were made.
- Added `integrations/erc8004/` with `README.md`, `adapter_spec.md`, and `examples/registration.json` that document the event→metric mapping, recommended tags, and a sample registration JSON using `services` (not endpoints).
- Implemented two Truffle‑friendly scripts under `scripts/erc8004/`: `export_metrics.js` (reads AGIJobManager events over a block range and writes aggregated per‑agent metrics JSON, dry‑run by default) and `generate_feedback_calldata.js` (creates intended feedback actions JSON from exported metrics, still dry‑run).
- Added `.env.example` with adapter placeholders and updated `.gitignore` to exclude adapter output (`integrations/erc8004/out/`) and minimally updated the root `README.md` to link the new docs.

### Testing
- `npm install` completed (dependencies installed; dev warnings reported but not blocking). — succeeded.
- `npm run build` (Truffle compile) completed and wrote artifacts to `build/contracts/`. — succeeded.
- `npm test` ran the repository tests and the included ABI smoke test; test output shows `6 passing`. — succeeded.
- Smoke export: ran a local Truffle smoke script which deployed a test manager, generated events, and executed `scripts/erc8004/export_metrics.js`; the adapter wrote `integrations/erc8004/out/erc8004_metrics_1337_0_10.json` and printed a success message. — succeeded.

Notes/limitations: the adapter emits a simple JSON artifact compatible with ERC‑8004 workflows and includes guidance for converting to the official off‑chain feedback format; final alignment with the latest ERC‑8004 toolchain (Agent0 SDK / on‑chain registry ABIs) may require minor mapping changes which are documented in `integrations/erc8004/README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796864f2488333815f5fc3f4b556e7)