### PR TITLE
Add ERC-8004 integration docs and off-chain adapter + export scripts

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,9 @@
+# ERC-8004 adapter configuration
+AGIJOBMANAGER_ADDRESS=0xYourAGIJobManager
+FROM_BLOCK=0
+TO_BLOCK=latest
+OUT_DIR=integrations/erc8004/out
+INCLUDE_VALIDATORS=false
+
+# Optional: feedback intent generation
+METRICS_JSON=integrations/erc8004/out/erc8004_metrics.json

--- a/.gitignore
+++ b/.gitignore
@@ -71,6 +71,9 @@ web_modules/
 .env.*
 !.env.example
 
+# ERC-8004 adapter outputs
+integrations/erc8004/out/
+
 # parcel-bundler cache (https://parceljs.org/)
 .cache
 .parcel-cache

--- a/README.md
+++ b/README.md
@@ -49,6 +49,14 @@ npm test
 - `npm run lint` — Lint Solidity sources with Solhint.
 - `npm test` — Run the test suite.
 - `docs/REGRESSION_TESTS.md` — Better-only regression coverage comparing current vs original contract behavior.
+- `scripts/erc8004/export_metrics.js` — Export ERC-8004-friendly metrics from AGIJobManager events.
+- `scripts/erc8004/generate_feedback_calldata.js` — Generate dry-run ERC-8004 feedback intents from metrics JSON.
+
+## ERC-8004 integration
+AGIJobManager ships an off-chain adapter and documentation for ERC-8004 identity + reputation workflows without changing on-chain escrow logic.
+
+- Docs: `docs/ERC8004.md`
+- Adapter: `integrations/erc8004/`
 
 ## Configuration
 Truffle networks and compiler settings are configured in `truffle-config.js`. The following environment variables are used for deployments and verification:

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -1,0 +1,46 @@
+# ERC-8004 integration (off-chain)
+
+This repository keeps AGIJobManager’s escrow and settlement logic fully on-chain and free of any external ERC-8004 dependency. Instead, it provides documentation and off-chain tooling to **bridge AGIJobManager events into ERC-8004 identity + reputation workflows**.
+
+## What is ERC-8004?
+ERC-8004 defines an agent identity registry plus a standardized reputation signal format. It enables agents, validators, and external observers to publish reputation artifacts (e.g., success rates, dispute rates, or revenue proxies) in a consistent schema that other systems can consume. For the canonical spec, see the EIP and ERC-8004 best-practices guidance. The contracts repo is linked below. (Assumption: the “best practices” guidance lives in the ERC-8004 spec document.)
+
+- EIP: https://eips.ethereum.org/EIPS/eip-8004
+- Best practices (spec doc): https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md
+- Reference contracts: https://github.com/erc-8004/erc-8004-contracts
+
+## Why the contract is NOT hardwired to ERC-8004
+AGIJobManager intentionally avoids external contract calls in critical escrow paths. Coupling job completion, dispute resolution, or payouts to an external ERC-8004 registry would introduce **liveness and dependency risks** that could block escrow settlement or allow a third-party registry outage to halt payouts. Therefore, ERC-8004 integration is **strictly off-chain** in this repo.
+
+## Agent/validator registration guidance
+Agents and validators should register in ERC-8004 using a **registration file** that includes a `services` array (not `endpoints`). A minimal example lives in:
+
+- `integrations/erc8004/examples/registration.json`
+
+Host the registration JSON via HTTPS or IPFS and reference it from the ERC-8004 identity token’s `tokenURI` (or the registry’s metadata field, depending on the specific registry contract you use). Keep URLs stable so watchers can resolve it reliably.
+
+## Metrics from AGIJobManager → ERC-8004 signals
+AGIJobManager emits job lifecycle events that can be mapped to reputation metrics. The adapter in `integrations/erc8004/` aggregates these into per-agent metrics, then encodes them as ERC-8004 signals with `value` and `valueDecimals`. **Decimals and negative values are supported** for rate and feedback signals.
+
+Recommended tag1 examples:
+- `successRate`
+- `disputeRate`
+- `uptime`
+- `responseTime`
+- `blocktimeFreshness`
+- `revenues`
+- `ownerVerified`
+
+Concrete encoding examples:
+- successRate 99.80% → `value=9980`, `valueDecimals=2`
+- downvote −1 → `value=-1`, `valueDecimals=0`
+- revenues $556,000 → `value=556000`, `valueDecimals=0`
+
+## Trusted client set guidance
+For AGIJobManager feedback, a strong eligibility set for “trusted clients” is: **addresses that actually created paid jobs** (derived from `JobCreated` events). This reduces sybil feedback and mirrors real economic participation in the system.
+
+## Off-chain adapter
+See the adapter README and spec for how events map into metrics and how to export JSON artifacts:
+
+- `integrations/erc8004/README.md`
+- `integrations/erc8004/adapter_spec.md`

--- a/integrations/erc8004/README.md
+++ b/integrations/erc8004/README.md
@@ -1,0 +1,38 @@
+# ERC-8004 adapter (AGIJobManager)
+
+This adapter consumes AGIJobManager events and produces ERC-8004-friendly reputation artifacts **without changing any on-chain AGIJobManager logic**.
+
+## Quick start
+```bash
+# from repo root
+npm install
+npm run build
+
+# export metrics from a deployed AGIJobManager
+AGIJOBMANAGER_ADDRESS=0xYourContract \
+FROM_BLOCK=0 \
+TO_BLOCK=latest \
+OUT_DIR=integrations/erc8004/out \
+truffle exec scripts/erc8004/export_metrics.js --network sepolia
+```
+
+Optional validator aggregation:
+```bash
+INCLUDE_VALIDATORS=true \
+truffle exec scripts/erc8004/export_metrics.js --network sepolia
+```
+
+## Output
+The export script writes a JSON file containing per-agent metrics, computed rates, and metadata. See `adapter_spec.md` for field definitions.
+
+## Next step: feedback intent generation
+```bash
+METRICS_JSON=integrations/erc8004/out/erc8004_metrics.json \
+OUT_DIR=integrations/erc8004/out \
+node scripts/erc8004/generate_feedback_calldata.js
+```
+
+This generates a dry-run list of intended ERC-8004 feedback signals (no transactions are sent). For on-chain submission, use the official ERC-8004 tooling (e.g., Agent0 SDK) and the JSON output as input.
+
+## Example registration file
+See `integrations/erc8004/examples/registration.json` for a sample ERC-8004 registration JSON with a `services` array.

--- a/integrations/erc8004/adapter_spec.md
+++ b/integrations/erc8004/adapter_spec.md
@@ -1,0 +1,73 @@
+# Adapter spec: AGIJobManager → ERC-8004 metrics
+
+This adapter reads AGIJobManager events over a block range and aggregates **per-agent** reputation metrics, with optional **per-validator** aggregates.
+
+## Event → metric mapping
+- `JobCreated(jobId, ...)`
+  - Employer addresses are recorded for the “trusted client set.”
+- `JobApplied(jobId, agent)`
+  - Increments `jobsApplied` and `jobsAssigned` for the agent (AGIJobManager assigns on apply).
+- `JobCompleted(jobId, agent, ...)`
+  - Increments `jobsCompleted` for the agent.
+  - Adds `job.payout` (proxy for revenue) to `revenuesProxy`.
+- `JobDisputed(jobId, ...)`
+  - Increments `jobsDisputed` for the assigned agent.
+- `DisputeResolved(jobId, resolution)`
+  - Increments `agentWins`, `employerWins`, or `unknownResolutions` for the assigned agent depending on the resolution string.
+- `JobValidated(jobId, validator)` (optional)
+  - Increments `jobsValidated` for the validator.
+- `JobDisapproved(jobId, validator)` (optional)
+  - Increments `jobsDisapproved` for the validator.
+
+## Computed rates
+Rates are expressed as percentages with `valueDecimals=2` (basis points of percent):
+- `successRate` = `jobsCompleted / jobsAssigned * 100`
+- `disputeRate` = `jobsDisputed / jobsAssigned * 100`
+
+If `jobsAssigned` is 0, rates are omitted.
+
+## Output schema (intermediate JSON)
+```json
+{
+  "version": "0.1",
+  "metadata": {
+    "chainId": 11155111,
+    "network": "sepolia",
+    "fromBlock": 0,
+    "toBlock": 123456,
+    "generatedAt": "2024-05-01T00:00:00.000Z",
+    "sourceContract": "0x...",
+    "adapterVersion": "0.1.0"
+  },
+  "trustedClientSet": {
+    "criteria": "addresses that created paid jobs in range",
+    "addresses": ["0x..."]
+  },
+  "agents": {
+    "0xAgent": {
+      "jobsApplied": 2,
+      "jobsAssigned": 2,
+      "jobsCompleted": 1,
+      "jobsDisputed": 0,
+      "employerWins": 0,
+      "agentWins": 1,
+      "unknownResolutions": 0,
+      "revenuesProxy": "1000000000000000000",
+      "rates": {
+        "successRate": {"value": 5000, "valueDecimals": 2},
+        "disputeRate": {"value": 0, "valueDecimals": 2}
+      }
+    }
+  },
+  "validators": {
+    "0xValidator": {
+      "jobsValidated": 3,
+      "jobsDisapproved": 1
+    }
+  }
+}
+```
+
+## Notes
+- `revenuesProxy` is the sum of job `payout` values for completed jobs. This is a **proxy** for actual transfers.
+- Resolution strings are treated case-insensitively and mapped to `agent win` / `employer win`.

--- a/integrations/erc8004/examples/registration.json
+++ b/integrations/erc8004/examples/registration.json
@@ -1,0 +1,22 @@
+{
+  "name": "Example AGI Agent",
+  "description": "Example ERC-8004 registration metadata for an AGIJobManager agent.",
+  "services": [
+    {
+      "type": "a2a",
+      "url": "https://example.com/a2a.json"
+    },
+    {
+      "type": "mcp",
+      "url": "https://example.com/mcp"
+    },
+    {
+      "type": "ens",
+      "value": "example-agent.eth"
+    },
+    {
+      "type": "email",
+      "value": "ops@example.com"
+    }
+  ]
+}

--- a/scripts/erc8004/export_metrics.js
+++ b/scripts/erc8004/export_metrics.js
@@ -1,0 +1,225 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+
+const ARG_PREFIX = '--';
+
+function getArgValue(name) {
+  const idx = process.argv.indexOf(`${ARG_PREFIX}${name}`);
+  if (idx === -1) return null;
+  return process.argv[idx + 1] || null;
+}
+
+function parseBoolean(value, fallback = false) {
+  if (value === null || value === undefined) return fallback;
+  return String(value).toLowerCase() === 'true';
+}
+
+function normalizeAddress(address) {
+  return address ? address.toLowerCase() : address;
+}
+
+function toNumber(value) {
+  return Number(value);
+}
+
+function formatRate(numerator, denominator) {
+  if (!denominator || denominator === 0) return null;
+  const ratio = (numerator / denominator) * 100;
+  return {
+    value: Math.round(ratio * 100),
+    valueDecimals: 2,
+  };
+}
+
+async function main() {
+  const address = process.env.AGIJOBMANAGER_ADDRESS || getArgValue('address');
+  const fromBlockRaw = process.env.FROM_BLOCK || getArgValue('from-block') || '0';
+  const toBlockRaw = process.env.TO_BLOCK || getArgValue('to-block') || 'latest';
+  const outDir = process.env.OUT_DIR || getArgValue('out-dir') || path.join(__dirname, '../../integrations/erc8004/out');
+  const includeValidators = parseBoolean(process.env.INCLUDE_VALIDATORS || getArgValue('include-validators'), false);
+
+  const contract = address ? await AGIJobManager.at(address) : await AGIJobManager.deployed();
+
+  const latestBlock = await web3.eth.getBlockNumber();
+  const fromBlock = fromBlockRaw === 'latest' ? latestBlock : toNumber(fromBlockRaw);
+  const toBlock = toBlockRaw === 'latest' ? latestBlock : toNumber(toBlockRaw);
+
+  if (!Number.isFinite(fromBlock) || !Number.isFinite(toBlock)) {
+    throw new Error('Invalid block range. FROM_BLOCK/TO_BLOCK must be numbers or "latest".');
+  }
+
+  const [jobCreated, jobApplied, jobCompleted, jobDisputed, disputeResolved] = await Promise.all([
+    contract.getPastEvents('JobCreated', { fromBlock, toBlock }),
+    contract.getPastEvents('JobApplied', { fromBlock, toBlock }),
+    contract.getPastEvents('JobCompleted', { fromBlock, toBlock }),
+    contract.getPastEvents('JobDisputed', { fromBlock, toBlock }),
+    contract.getPastEvents('DisputeResolved', { fromBlock, toBlock }),
+  ]);
+
+  let jobValidated = [];
+  let jobDisapproved = [];
+  if (includeValidators) {
+    [jobValidated, jobDisapproved] = await Promise.all([
+      contract.getPastEvents('JobValidated', { fromBlock, toBlock }),
+      contract.getPastEvents('JobDisapproved', { fromBlock, toBlock }),
+    ]);
+  }
+
+  const jobCache = new Map();
+  const agents = new Map();
+  const validators = new Map();
+  const employerSet = new Set();
+
+  const getAgent = (addressKey) => {
+    const key = normalizeAddress(addressKey);
+    if (!agents.has(key)) {
+      agents.set(key, {
+        jobsApplied: 0,
+        jobsAssigned: 0,
+        jobsCompleted: 0,
+        jobsDisputed: 0,
+        employerWins: 0,
+        agentWins: 0,
+        unknownResolutions: 0,
+        revenuesProxy: web3.utils.toBN(0),
+        rates: {},
+      });
+    }
+    return agents.get(key);
+  };
+
+  const getValidator = (addressKey) => {
+    const key = normalizeAddress(addressKey);
+    if (!validators.has(key)) {
+      validators.set(key, {
+        jobsValidated: 0,
+        jobsDisapproved: 0,
+      });
+    }
+    return validators.get(key);
+  };
+
+  const getJob = async (jobId) => {
+    if (jobCache.has(jobId)) return jobCache.get(jobId);
+    const job = await contract.jobs(jobId);
+    const normalized = {
+      employer: normalizeAddress(job.employer),
+      assignedAgent: normalizeAddress(job.assignedAgent),
+      payout: web3.utils.toBN(job.payout),
+    };
+    jobCache.set(jobId, normalized);
+    return normalized;
+  };
+
+  for (const ev of jobCreated) {
+    const jobId = ev.returnValues.jobId || ev.returnValues[0];
+    const job = await getJob(jobId);
+    if (job.employer) employerSet.add(job.employer);
+  }
+
+  for (const ev of jobApplied) {
+    const jobId = ev.returnValues.jobId || ev.returnValues[0];
+    const agent = ev.returnValues.agent || ev.returnValues[1];
+    const metrics = getAgent(agent);
+    metrics.jobsApplied += 1;
+    metrics.jobsAssigned += 1;
+    const job = await getJob(jobId);
+    if (job.assignedAgent && job.assignedAgent !== normalizeAddress(agent)) {
+      job.assignedAgent = normalizeAddress(agent);
+      jobCache.set(jobId, job);
+    }
+  }
+
+  for (const ev of jobCompleted) {
+    const jobId = ev.returnValues.jobId || ev.returnValues[0];
+    const agent = ev.returnValues.agent || ev.returnValues[1];
+    const metrics = getAgent(agent);
+    metrics.jobsCompleted += 1;
+    const job = await getJob(jobId);
+    metrics.revenuesProxy = metrics.revenuesProxy.add(job.payout);
+  }
+
+  for (const ev of jobDisputed) {
+    const jobId = ev.returnValues.jobId || ev.returnValues[0];
+    const job = await getJob(jobId);
+    if (!job.assignedAgent) continue;
+    const metrics = getAgent(job.assignedAgent);
+    metrics.jobsDisputed += 1;
+  }
+
+  for (const ev of disputeResolved) {
+    const jobId = ev.returnValues.jobId || ev.returnValues[0];
+    const resolutionRaw = ev.returnValues.resolution || ev.returnValues[2] || '';
+    const resolution = String(resolutionRaw).toLowerCase();
+    const job = await getJob(jobId);
+    if (!job.assignedAgent) continue;
+    const metrics = getAgent(job.assignedAgent);
+    if (resolution === 'agent win') {
+      metrics.agentWins += 1;
+    } else if (resolution === 'employer win') {
+      metrics.employerWins += 1;
+    } else {
+      metrics.unknownResolutions += 1;
+    }
+  }
+
+  if (includeValidators) {
+    for (const ev of jobValidated) {
+      const validator = ev.returnValues.validator || ev.returnValues[1];
+      getValidator(validator).jobsValidated += 1;
+    }
+    for (const ev of jobDisapproved) {
+      const validator = ev.returnValues.validator || ev.returnValues[1];
+      getValidator(validator).jobsDisapproved += 1;
+    }
+  }
+
+  for (const [addressKey, metrics] of agents.entries()) {
+    const successRate = formatRate(metrics.jobsCompleted, metrics.jobsAssigned);
+    const disputeRate = formatRate(metrics.jobsDisputed, metrics.jobsAssigned);
+    if (successRate) metrics.rates.successRate = successRate;
+    if (disputeRate) metrics.rates.disputeRate = disputeRate;
+    metrics.revenuesProxy = metrics.revenuesProxy.toString();
+    agents.set(addressKey, metrics);
+  }
+
+  const packageJson = JSON.parse(fs.readFileSync(path.join(__dirname, '../../package.json'), 'utf8'));
+  const chainId = await web3.eth.getChainId();
+
+  const output = {
+    version: '0.1',
+    metadata: {
+      chainId,
+      network: (typeof config !== 'undefined' && config.network) ? config.network : 'unknown',
+      fromBlock,
+      toBlock,
+      generatedAt: new Date().toISOString(),
+      sourceContract: contract.address,
+      adapterVersion: packageJson.version,
+    },
+    trustedClientSet: {
+      criteria: 'addresses that created paid jobs in range',
+      addresses: Array.from(employerSet).sort(),
+    },
+    agents: Object.fromEntries(agents),
+  };
+
+  if (includeValidators) {
+    output.validators = Object.fromEntries(validators);
+  }
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'erc8004_metrics.json');
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+
+  console.log(`ERC-8004 metrics written to ${outPath}`);
+}
+
+module.exports = function (callback) {
+  main()
+    .then(() => callback())
+    .catch((err) => callback(err));
+};

--- a/scripts/erc8004/generate_feedback_calldata.js
+++ b/scripts/erc8004/generate_feedback_calldata.js
@@ -1,0 +1,90 @@
+/* eslint-disable no-console */
+const fs = require('fs');
+const path = require('path');
+
+function getArgValue(name) {
+  const idx = process.argv.indexOf(`--${name}`);
+  if (idx === -1) return null;
+  return process.argv[idx + 1] || null;
+}
+
+function readJson(filePath) {
+  return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+}
+
+function buildFeedbackEntry(address, metrics) {
+  const signals = [];
+
+  if (metrics.rates?.successRate) {
+    signals.push({
+      tag1: 'successRate',
+      value: metrics.rates.successRate.value,
+      valueDecimals: metrics.rates.successRate.valueDecimals,
+    });
+  }
+
+  if (metrics.rates?.disputeRate) {
+    signals.push({
+      tag1: 'disputeRate',
+      value: metrics.rates.disputeRate.value,
+      valueDecimals: metrics.rates.disputeRate.valueDecimals,
+    });
+  }
+
+  if (metrics.revenuesProxy) {
+    signals.push({
+      tag1: 'revenues',
+      value: metrics.revenuesProxy,
+      valueDecimals: 0,
+      note: 'Proxy: sum of job payout values for completed jobs (raw token units).',
+    });
+  }
+
+  return {
+    subject: address,
+    signals,
+    evidence: 'TODO: add evidence hash or IPFS CID',
+    notes: {
+      jobsApplied: metrics.jobsApplied,
+      jobsAssigned: metrics.jobsAssigned,
+      jobsCompleted: metrics.jobsCompleted,
+      jobsDisputed: metrics.jobsDisputed,
+      employerWins: metrics.employerWins,
+      agentWins: metrics.agentWins,
+      unknownResolutions: metrics.unknownResolutions,
+    },
+  };
+}
+
+function main() {
+  const metricsPath = process.env.METRICS_JSON || getArgValue('metrics-json');
+  if (!metricsPath) {
+    throw new Error('Missing METRICS_JSON or --metrics-json');
+  }
+
+  const outDir = process.env.OUT_DIR || getArgValue('out-dir') || path.dirname(metricsPath);
+  const metrics = readJson(metricsPath);
+
+  const entries = Object.entries(metrics.agents || {}).map(([address, data]) => buildFeedbackEntry(address, data));
+
+  const output = {
+    source: metrics.metadata || {},
+    generatedAt: new Date().toISOString(),
+    feedback: entries,
+    notes: 'Dry-run output only. Use official ERC-8004 tooling (e.g., Agent0 SDK) for on-chain submission.',
+  };
+
+  fs.mkdirSync(outDir, { recursive: true });
+  const outPath = path.join(outDir, 'erc8004_feedback_intents.json');
+  fs.writeFileSync(outPath, JSON.stringify(output, null, 2));
+  console.log(`Feedback intents written to ${outPath}`);
+}
+
+if (require.main === module) {
+  try {
+    main();
+  } catch (error) {
+    console.error(error.message || error);
+    process.exit(1);
+  }
+}


### PR DESCRIPTION
### Motivation
- Provide an off-chain integration path to make AGIJobManager interoperable with ERC-8004 identity and reputation workflows while avoiding any runtime dependency in critical escrow/payout paths.
- Offer a minimal, auditable adapter that consumes on-chain `AGIJobManager` events and emits ERC-8004-friendly reputation artifacts in JSON form so registries/watchers can publish signals independently.
- Surface practical guidance (registration, tag examples, trusted-client criteria) and small tooling so maintainers and integrators can adopt ERC-8004 without modifying Solidity contract logic.

### Description
- Add `docs/ERC8004.md` describing what ERC-8004 is, why AGIJobManager is intentionally not hardwired to it, registration guidance (use `services`), tag/value encoding examples, and a recommended trusted-client rule based on `JobCreated` events.
- Add an adapter package under `integrations/erc8004/` with `README.md`, `adapter_spec.md`, and an example registration JSON at `integrations/erc8004/examples/registration.json` documenting mappings from AGIJobManager events → reputation metrics.
- Add two Truffle-compatible scripts under `scripts/erc8004/`: `export_metrics.js` to read events over a block range and produce a per-agent metrics JSON (rates, counts, `revenuesProxy`, metadata) and `generate_feedback_calldata.js` to turn metrics into dry-run ERC-8004 feedback intent JSONs; both default to dry-run file outputs.
- Add `.env.example` with adapter placeholders, update `README.md` to reference the integration, and ensure `integrations/erc8004/out/` is ignored in `.gitignore`; no Solidity contract logic or public/external functions/events were changed.

### Testing
- Installed dependencies with `npm install`, which completed successfully (audit warnings noted but not blocking automated tests).
- Built the project with `npm run build` (Truffle compile), which completed successfully and produced artifacts.
- Ran the test suite with `npm test` (Truffle tests + ABI smoke test), which passed (`6 passing` for the regression suite and ABI smoke test succeeded).
- Performed a local smoke deploy and adapter run: a Truffle smoke script deployed `AGIJobManager` on the local `development` chain and `export_metrics.js` ran with `INCLUDE_VALIDATORS=true`, producing `integrations/erc8004/out/erc8004_metrics.json` (success).
- One attempted invocation of `export_metrics.js` against the transient in-memory `test` exec address failed because the prior exec-run deployment address did not persist between separate Truffle exec invocations (no on-chain code found at that address), which is an environment limitation rather than an adapter defect.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69796fa4831c8333b6e9fcb82e83ea45)