### PR TITLE
docs: note .env setup for ERC-8004 adapter

### DIFF
--- a/integrations/erc8004/README.md
+++ b/integrations/erc8004/README.md
@@ -8,6 +8,9 @@ This adapter consumes AGIJobManager events and produces ERC-8004-friendly reputa
 npm install
 npm run build
 
+# optional: copy the sample env file
+cp .env.example .env
+
 # export metrics from a deployed AGIJobManager
 AGIJOBMANAGER_ADDRESS=0xYourContract \
 FROM_BLOCK=0 \


### PR DESCRIPTION
### Motivation
- Make the ERC-8004 adapter quickstart friendlier by documenting the optional `.env` setup so users can easily run the export scripts locally.

### Description
- Add an instruction to `integrations/erc8004/README.md` showing how to copy the sample `.env.example` to `.env` (no on-chain contract or production code changes were made).

### Testing
- Ran the repository smoke CI commands: `npm run build` (Truffle compile) succeeded and `npm test` completed with the existing test suite passing (6 passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979748bf78c83338f25cb7f8f7ef50c)