### PR TITLE
Add comprehensive AGIJobManager documentation and ABI reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ AGIJobManager is a single-contract system for managing employer/agent jobs, vali
 - [Scripts](#scripts)
 - [Configuration](#configuration)
 - [Deployment](#deployment)
+- [Contract documentation](#contract-documentation)
 - [Security](#security)
 - [License](#license)
 
@@ -87,6 +88,12 @@ npx truffle migrate --network sepolia
 ```
 
 Replace `sepolia` with `mainnet` or `development` as needed. Ensure the environment variables above are set for the selected network.
+
+## Contract documentation
+- `docs/AGIJobManager.md` — Primary contract overview, lifecycle, roles, and usage.
+- `docs/AGIJobManager_Interface.md` — ABI-accurate interface reference (functions, events, errors).
+- `docs/AGIJobManager_Operator_Guide.md` — Deployment and admin runbook.
+- `docs/AGIJobManager_Security.md` — Security considerations and known fixes vs v0.
 
 ## Security
 This repository is experimental. Review the contract code and run your own audits before deploying to production networks. Never commit private keys or secrets to version control.

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -1,0 +1,277 @@
+# AGIJobManager Contract Documentation
+
+This document is the primary, code-accurate guide to `AGIJobManager` as compiled from `contracts/AGIJobManager.sol`.
+
+## 1) High-level overview
+
+**What it is**
+- A single-contract escrow job manager that:
+  - Holds ERC-20 funds for jobs.
+  - Tracks job lifecycle, validation, disputes, and reputation.
+  - Mints an ERC-721 NFT to the employer when a job completes.
+  - Provides a lightweight NFT listing + purchase flow using the same ERC-20 token.
+  - Verifies agent/validator eligibility via Merkle roots and ENS/NameWrapper ownership checks.
+
+**What it is not**
+- Not an ERC-8004 on-chain registry. The ERC-8004 adapter lives off-chain and is documented separately.
+- Not a full marketplace or escrow for arbitrary NFTs—only the job-minted ERC-721s are listed.
+- Not a generalized identity registry; it relies on external ENS/NameWrapper behavior and Merkle roots.
+
+## 2) Key components
+
+- **Jobs**: Employer-funded entries with an IPFS hash, payout, duration, and status flags.
+- **Agents**: Apply for jobs if allowlisted (Merkle/ENS/NameWrapper) or explicitly added.
+- **Validators**: Validate or disapprove jobs, also allowlisted via Merkle/ENS/NameWrapper or explicitly added.
+- **Moderators**: Resolve disputes with a canonical resolution string.
+- **Dispute flow**: Disputes can be opened by employer/agent or triggered by validator disapprovals.
+- **Reputation**: Earned by agents (and validators) based on payout/duration; capped with diminishing returns.
+- **NFT issuance**: Completion mints ERC-721 to employer and sets tokenURI using base IPFS URL + job hash.
+- **Marketplace**: Listing/purchase/delist functions for minted NFTs (payments in `agiToken`).
+
+## 3) Roles & permissions
+
+### Roles
+- **Owner**: Contract-level admin (pause/unpause, set parameters, blacklist, withdraw, manage allowlists and AGI types, rotate token address).
+- **Moderator**: Resolves disputes via `resolveDispute`.
+- **Employer**: Creates/cancels jobs; can dispute jobs; receives NFT on completion.
+- **Agent**: Applies for jobs and requests completion.
+- **Validator**: Validates or disapproves jobs; earns rewards if the job completes.
+- **NFT holder**: Uses ERC-721 functions and marketplace listing.
+
+### Function access matrix
+The table below lists **all public/external functions** and captures who can call them, the most important preconditions, and observable effects. “Anyone” includes EOAs and contracts.
+
+| Function | Who can call | Preconditions (key checks) | Effects |
+| --- | --- | --- | --- |
+| `pause()` | Owner | None | Pauses job/validation/reward-pool flows guarded by `whenNotPaused`. |
+| `unpause()` | Owner | None | Unpauses guarded flows. |
+| `createJob(string,uint256,uint256,string)` | Anyone | Not paused; payout/duration > 0 and within `maxJobPayout`/`jobDurationLimit` | Creates job, escrow pulls ERC-20, emits `JobCreated`. |
+| `applyForJob(uint256,string,bytes32[])` | Anyone | Not paused; job exists; unassigned; not blacklisted; authorized via allowlist/ENS | Assigns agent, sets `assignedAt`, emits `JobApplied`. |
+| `requestJobCompletion(uint256,string)` | Assigned agent | Not paused; before `assignedAt + duration` | Updates job IPFS hash, sets `completionRequested`, emits `JobCompletionRequested`. |
+| `validateJob(uint256,string,bytes32[])` | Validator | Not paused; job exists; assigned; not completed; not blacklisted; authorized; has not voted | Records approval, emits `JobValidated`; may complete job when approvals threshold met. |
+| `disapproveJob(uint256,string,bytes32[])` | Validator | Not paused; job exists; assigned; not completed; not blacklisted; authorized; has not voted | Records disapproval, emits `JobDisapproved`; may mark job disputed when disapprovals threshold met. |
+| `disputeJob(uint256)` | Employer or agent | Not paused; job exists; not completed; not already disputed | Sets `disputed`, emits `JobDisputed`. |
+| `resolveDispute(uint256,string)` | Moderator | Job exists; `disputed == true` | If resolution is `"agent win"` → completes job; if `"employer win"` → refunds employer + marks completed; otherwise only clears `disputed`. Emits `DisputeResolved`. |
+| `blacklistAgent(address,bool)` | Owner | None | Updates agent blacklist. |
+| `blacklistValidator(address,bool)` | Owner | None | Updates validator blacklist. |
+| `delistJob(uint256)` | Owner | Job exists; not completed; no agent assigned | Refunds employer, deletes job, emits `JobCancelled`. |
+| `addModerator(address)` | Owner | None | Grants moderator role. |
+| `removeModerator(address)` | Owner | None | Revokes moderator role. |
+| `updateAGITokenAddress(address)` | Owner | None | Updates ERC-20 token used for escrow/payments. |
+| `setBaseIpfsUrl(string)` | Owner | None | Updates base IPFS URL for minted tokenURI. |
+| `setRequiredValidatorApprovals(uint256)` | Owner | None | Updates approval threshold. |
+| `setRequiredValidatorDisapprovals(uint256)` | Owner | None | Updates disapproval threshold. |
+| `setPremiumReputationThreshold(uint256)` | Owner | None | Updates premium feature threshold. |
+| `setMaxJobPayout(uint256)` | Owner | None | Updates max payout. |
+| `setJobDurationLimit(uint256)` | Owner | None | Updates max duration. |
+| `updateTermsAndConditionsIpfsHash(string)` | Owner | None | Updates on-chain terms hash string. |
+| `updateContactEmail(string)` | Owner | None | Updates on-chain contact string. |
+| `updateAdditionalText1(string)` | Owner | None | Updates on-chain text field. |
+| `updateAdditionalText2(string)` | Owner | None | Updates on-chain text field. |
+| `updateAdditionalText3(string)` | Owner | None | Updates on-chain text field. |
+| `getJobStatus(uint256)` | Anyone | None | Returns `(completed, completionRequested, ipfsHash)` (no job existence guard). |
+| `setValidationRewardPercentage(uint256)` | Owner | `0 < percentage <= 100` | Updates validator reward percentage. |
+| `cancelJob(uint256)` | Employer | Job exists; not completed; no agent assigned | Refunds employer, deletes job, emits `JobCancelled`. |
+| `listNFT(uint256,uint256)` | NFT owner | `price > 0`; caller owns token | Creates/overwrites listing, emits `NFTListed`. |
+| `purchaseNFT(uint256)` | Anyone | Listing active | Transfers ERC-20 payment and NFT, emits `NFTPurchased`. |
+| `delistNFT(uint256)` | Listing seller | Listing active; caller is seller | Deactivates listing, emits `NFTDelisted`. |
+| `addAdditionalValidator(address)` | Owner | None | Adds validator allowlist bypass. |
+| `removeAdditionalValidator(address)` | Owner | None | Removes validator allowlist bypass. |
+| `addAdditionalAgent(address)` | Owner | None | Adds agent allowlist bypass. |
+| `removeAdditionalAgent(address)` | Owner | None | Removes agent allowlist bypass. |
+| `withdrawAGI(uint256)` | Owner | `amount > 0` and `amount <= agiToken.balanceOf(this)` | Transfers ERC-20 to owner. |
+| `canAccessPremiumFeature(address)` | Anyone | None | Returns true if reputation >= threshold. |
+| `contributeToRewardPool(uint256)` | Anyone | Not paused; `amount > 0` | Transfers ERC-20 to contract, emits `RewardPoolContribution`. |
+| `addAGIType(address,uint256)` | Owner | `nftAddress != 0`; `0 < payoutPercentage <= 100` | Adds/updates AGI type payout percent, emits `AGITypeUpdated`. |
+| `getHighestPayoutPercentage(address)` | Anyone | None | Returns highest payout % for agent based on ERC-721 balances. |
+| `jobs(uint256)` | Anyone | Job may or may not exist | Returns job fields (no mappings/validators array). |
+| `listings(uint256)` | Anyone | None | Returns listing fields. |
+| `reputation(address)` | Anyone | None | Returns current reputation. |
+| `validatorApprovedJobs(address,uint256)` | Anyone | Index in array must exist | Returns job ID at index. |
+| `agiTypes(uint256)` | Anyone | Index in array must exist | Returns AGI type at index. |
+| `additionalAgents(address)` | Anyone | None | Returns allowlist bypass flag. |
+| `additionalValidators(address)` | Anyone | None | Returns allowlist bypass flag. |
+| `blacklistedAgents(address)` | Anyone | None | Returns blacklist flag. |
+| `blacklistedValidators(address)` | Anyone | None | Returns blacklist flag. |
+| `moderators(address)` | Anyone | None | Returns moderator flag. |
+| `requiredValidatorApprovals()` | Anyone | None | Returns approval threshold. |
+| `requiredValidatorDisapprovals()` | Anyone | None | Returns disapproval threshold. |
+| `validationRewardPercentage()` | Anyone | None | Returns validator reward percentage. |
+| `premiumReputationThreshold()` | Anyone | None | Returns premium threshold. |
+| `maxJobPayout()` | Anyone | None | Returns max payout. |
+| `jobDurationLimit()` | Anyone | None | Returns duration limit. |
+| `agiToken()` | Anyone | None | Returns current ERC-20 token address. |
+| `ens()` | Anyone | None | Returns ENS registry address. |
+| `nameWrapper()` | Anyone | None | Returns NameWrapper address. |
+| `clubRootNode()` | Anyone | None | Returns validator ENS root node. |
+| `agentRootNode()` | Anyone | None | Returns agent ENS root node. |
+| `validatorMerkleRoot()` | Anyone | None | Returns validator Merkle root. |
+| `agentMerkleRoot()` | Anyone | None | Returns agent Merkle root. |
+| `nextJobId()` | Anyone | None | Returns next job ID. |
+| `nextTokenId()` | Anyone | None | Returns next token ID. |
+| `termsAndConditionsIpfsHash()` | Anyone | None | Returns terms hash string. |
+| `contactEmail()` | Anyone | None | Returns contact email string. |
+| `additionalText1()` | Anyone | None | Returns text field. |
+| `additionalText2()` | Anyone | None | Returns text field. |
+| `additionalText3()` | Anyone | None | Returns text field. |
+| `owner()` | Anyone | None | Returns owner address (Ownable). |
+| `transferOwnership(address)` | Owner | `newOwner != 0` | Transfers ownership (Ownable). |
+| `renounceOwnership()` | Owner | None | Renounces ownership (Ownable). |
+| `paused()` | Anyone | None | Returns paused state. |
+| `name()` | Anyone | None | Returns ERC-721 name. |
+| `symbol()` | Anyone | None | Returns ERC-721 symbol. |
+| `balanceOf(address)` | Anyone | `owner != 0` (ERC-721) | Returns ERC-721 balance. |
+| `ownerOf(uint256)` | Anyone | Token must exist | Returns ERC-721 owner. |
+| `tokenURI(uint256)` | Anyone | Token must exist | Returns token URI (ERC-721). |
+| `approve(address,uint256)` | Token owner/approved | Token must exist (ERC-721) | Approves operator for token. |
+| `getApproved(uint256)` | Anyone | Token must exist (ERC-721) | Returns approved address. |
+| `setApprovalForAll(address,bool)` | Token owner | None | Sets operator approval. |
+| `isApprovedForAll(address,address)` | Anyone | None | Returns operator approval status. |
+| `transferFrom(address,address,uint256)` | Authorized operator | Token must exist; caller authorized (ERC-721) | Transfers token. |
+| `safeTransferFrom(address,address,uint256)` | Authorized operator | Token must exist; caller authorized (ERC-721) | Safe transfer. |
+| `safeTransferFrom(address,address,uint256,bytes)` | Authorized operator | Token must exist; caller authorized (ERC-721) | Safe transfer with data. |
+| `supportsInterface(bytes4)` | Anyone | None | ERC-165 interface check. |
+
+## 4) Lifecycle / state machine
+
+### State transitions
+
+```
+Created (job exists, no agent) 
+  ├─ applyForJob → Assigned
+  ├─ cancelJob (employer) → Deleted + refunded
+  └─ delistJob (owner) → Deleted + refunded
+
+Assigned (assignedAgent set)
+  ├─ requestJobCompletion → CompletionRequested (flag only)
+  ├─ validateJob approvals >= threshold → Completed
+  ├─ disapproveJob disapprovals >= threshold → Disputed
+  └─ disputeJob (employer/agent) → Disputed
+
+Disputed
+  ├─ resolveDispute("agent win") → Completed
+  ├─ resolveDispute("employer win") → Completed + employer refund
+  └─ resolveDispute(other) → Dispute cleared (job remains incomplete)
+
+Completed
+  └─ terminal
+```
+
+### Flags and counters
+- `assignedAgent` + `assignedAt`: Set once on `applyForJob`.
+- `completionRequested`: Set to true on `requestJobCompletion` (does not gate validation).
+- `validatorApprovals` / `validatorDisapprovals`: Incremented on vote (one per validator). Validators are appended to `validators` array on both approval and disapproval.
+- `disputed`: Set when dispute is opened or disapproval threshold reached; cleared by `_completeJob` and `resolveDispute`.
+- `completed`: Set in `_completeJob` or when moderator resolves in employer’s favor.
+
+## 5) Token & accounting semantics
+
+- **Escrow funding**: `createJob` pulls `payout` via `agiToken.transferFrom`.
+- **Agent payout**: On completion, agent receives `payout * highestPayoutPercentage / 100`.
+  - The percentage is determined by ERC-721 balances across `agiTypes` (see `getHighestPayoutPercentage`).
+- **Validator payouts**: If any validators participated, the contract pays `payout * validationRewardPercentage / 100` total, split evenly across validators.
+- **Totals can exceed 100%**: If agent payout % + validator reward % > 100, the contract pays more than the job’s escrow amount, using pooled contract balances.
+- **Unused escrow**: If totals are less than 100% of payout, the remaining ERC-20 stays in the contract balance and can be withdrawn by the owner.
+- **Refund paths**:
+  - `cancelJob` (employer) or `delistJob` (owner) refunds escrow and deletes the job.
+  - `resolveDispute("employer win")` refunds employer and closes the job.
+- **ERC-20 expectations**: The contract requires `transfer`/`transferFrom` to return `true` and reverts with `TransferFailed` otherwise.
+
+## 6) ENS / NameWrapper / Merkle ownership verification
+
+Ownership checks are performed in `_verifyOwnership` and used by `applyForJob`, `validateJob`, and `disapproveJob`.
+
+1. **Merkle allowlist**
+   - Leaf: `keccak256(abi.encodePacked(claimant))`.
+   - Merkle root:
+     - If `rootNode == agentRootNode`, then `agentMerkleRoot` is used.
+     - Otherwise, `validatorMerkleRoot` is used (validators pass `clubRootNode`).
+   - Successful proof emits `OwnershipVerified` and returns `true`.
+
+2. **NameWrapper ownership**
+   - `subnode = keccak256(abi.encodePacked(rootNode, keccak256(bytes(subdomain))))`.
+   - If `nameWrapper.ownerOf(uint256(subnode)) == claimant`, emits `OwnershipVerified`.
+   - Any `Error(string)` or unexpected error triggers `RecoveryInitiated(reason)` or `RecoveryInitiated("NW_FAIL")`.
+
+3. **ENS resolver**
+   - If `ens.resolver(subnode)` is non-zero, `resolver.addr(subnode)` is checked against `claimant`.
+   - Resolver call errors emit `RecoveryInitiated("RES_FAIL")`; missing resolver emits `RecoveryInitiated("NO_RES")`.
+
+**Note:** `RecoveryInitiated` is informational only; ownership is not granted unless a proof/ownership check succeeds.
+
+## 7) NFT issuance & marketplace
+
+- **Minting**: `_completeJob` mints a new ERC-721 token to the employer.
+- **Token URI**: `tokenURI = baseIpfsUrl + "/" + job.ipfsHash`.
+- **Listing**: `listNFT` records a listing price in `agiToken` for the seller’s token.
+- **Purchase**: `purchaseNFT` pulls `agiToken` from buyer to seller, then transfers the NFT.
+- **Delisting**: `delistNFT` disables the listing for the seller.
+
+## 8) Quickstart examples (ethers.js)
+
+> These snippets assume you already have a signer and the deployed contract address.
+
+### Approve + create job (employer)
+```js
+import { ethers } from "ethers";
+
+const agi = new ethers.Contract(agiTokenAddress, erc20Abi, employerSigner);
+const mgr = new ethers.Contract(jobManagerAddress, agiJobManagerAbi, employerSigner);
+
+// Approve escrow
+await agi.approve(jobManagerAddress, payout);
+
+// Create job
+await mgr.createJob(ipfsHash, payout, durationSeconds, details);
+```
+
+### Apply for job (agent)
+```js
+const mgr = new ethers.Contract(jobManagerAddress, agiJobManagerAbi, agentSigner);
+
+await mgr.applyForJob(jobId, subdomain, merkleProof);
+```
+
+### Request completion (agent)
+```js
+await mgr.requestJobCompletion(jobId, completionIpfsHash);
+```
+
+### Validate job (validator)
+```js
+const mgr = new ethers.Contract(jobManagerAddress, agiJobManagerAbi, validatorSigner);
+
+await mgr.validateJob(jobId, subdomain, merkleProof);
+```
+
+### Dispute + resolve (moderator)
+```js
+const mgr = new ethers.Contract(jobManagerAddress, agiJobManagerAbi, moderatorSigner);
+
+await mgr.disputeJob(jobId); // by employer or agent
+await mgr.resolveDispute(jobId, "agent win");
+```
+
+### Event subscriptions (ethers.js)
+```js
+mgr.on("JobCreated", (jobId, ipfsHash, payout, duration, details) => {
+  console.log("JobCreated", jobId.toString());
+});
+
+mgr.on("JobCompleted", (jobId, agent, reputationPoints) => {
+  console.log("JobCompleted", jobId.toString(), agent, reputationPoints.toString());
+});
+
+mgr.on("JobDisputed", (jobId, disputant) => {
+  console.log("JobDisputed", jobId.toString(), disputant);
+});
+
+mgr.on("DisputeResolved", (jobId, resolver, resolution) => {
+  console.log("DisputeResolved", jobId.toString(), resolution);
+});
+```
+
+For the full ABI reference and detailed admin guidance, see:
+- `docs/AGIJobManager_Interface.md`
+- `docs/AGIJobManager_Operator_Guide.md`
+- `docs/AGIJobManager_Security.md`

--- a/docs/AGIJobManager_Interface.md
+++ b/docs/AGIJobManager_Interface.md
@@ -1,0 +1,198 @@
+# AGIJobManager Interface Reference
+
+This file is derived from the compiled ABI (`build/contracts/AGIJobManager.json`) and the contract source. It covers all public/external functions, events, custom errors, and public state variables.
+
+## Custom errors
+These errors are used instead of revert strings. Integrators should decode error selectors to surface failures.
+
+| Error | Meaning |
+| --- | --- |
+| `NotModerator()` | Caller is not a moderator. |
+| `NotAuthorized()` | Caller is not permitted to perform the action. |
+| `Blacklisted()` | Caller is blacklisted as agent/validator. |
+| `InvalidParameters()` | Input values fail validation or a required amount is zero. |
+| `InvalidState()` | Job or listing state does not allow the action. |
+| `JobNotFound()` | Job ID does not exist (employer address is zero). |
+| `TransferFailed()` | ERC-20 transfer/transferFrom returned false. |
+
+## Events
+
+| Event (indexed args shown) | Emitted when |
+| --- | --- |
+| `JobCreated(uint256 jobId, string ipfsHash, uint256 payout, uint256 duration, string details)` | A job is created. |
+| `JobApplied(uint256 jobId, address agent)` | An agent applies and is assigned. |
+| `JobCompletionRequested(uint256 jobId, address agent)` | Assigned agent requests completion. |
+| `JobValidated(uint256 jobId, address validator)` | A validator approves a job. |
+| `JobDisapproved(uint256 jobId, address validator)` | A validator disapproves a job. |
+| `JobDisputed(uint256 jobId, address disputant)` | A dispute is opened or disapproval threshold is reached. |
+| `DisputeResolved(uint256 jobId, address resolver, string resolution)` | Moderator resolves dispute. |
+| `JobCompleted(uint256 jobId, address agent, uint256 reputationPoints)` | Job is completed via validation or dispute resolution. |
+| `JobCancelled(uint256 jobId)` | Job is cancelled/delisted and deleted. |
+| `ReputationUpdated(address user, uint256 newReputation)` | Reputation is recalculated/updated. |
+| `OwnershipVerified(address claimant, string subdomain)` | Ownership verification succeeded. |
+| `RecoveryInitiated(string reason)` | ENS/NameWrapper fallback path emitted a diagnostic reason. |
+| `AGITypeUpdated(indexed address nftAddress, uint256 payoutPercentage)` | AGI type added or updated. |
+| `NFTIssued(indexed uint256 tokenId, indexed address employer, string tokenURI)` | ERC-721 token minted to employer. |
+| `NFTListed(indexed uint256 tokenId, indexed address seller, uint256 price)` | NFT listed in marketplace. |
+| `NFTPurchased(indexed uint256 tokenId, indexed address buyer, uint256 price)` | NFT purchased. |
+| `NFTDelisted(indexed uint256 tokenId)` | NFT listing delisted. |
+| `RewardPoolContribution(indexed address contributor, uint256 amount)` | ERC-20 added to reward pool. |
+| `RootNodeUpdated(indexed bytes32 newRootNode)` | **Declared but not emitted in current code.** |
+| `MerkleRootUpdated(indexed bytes32 newMerkleRoot)` | **Declared but not emitted in current code.** |
+| `Approval(indexed address owner, indexed address approved, indexed uint256 tokenId)` | ERC-721 approval (standard). |
+| `ApprovalForAll(indexed address owner, indexed address operator, bool approved)` | ERC-721 approval-for-all (standard). |
+| `Transfer(indexed address from, indexed address to, indexed uint256 tokenId)` | ERC-721 transfer (standard). |
+| `MetadataUpdate(uint256 _tokenId)` | ERC-4906 metadata update (standard). |
+| `BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId)` | ERC-4906 metadata update (standard). |
+| `OwnershipTransferred(indexed address previousOwner, indexed address newOwner)` | Ownable transfer (standard). |
+| `Paused(address account)` | Pausable pause (standard). |
+| `Unpaused(address account)` | Pausable unpause (standard). |
+
+## Public state variables
+
+| Getter | Type | Meaning |
+| --- | --- | --- |
+| `agiToken()` | `address` | ERC-20 used for escrow and marketplace payments. |
+| `requiredValidatorApprovals()` | `uint256` | Approvals needed to complete a job. |
+| `requiredValidatorDisapprovals()` | `uint256` | Disapprovals needed to mark a job disputed. |
+| `premiumReputationThreshold()` | `uint256` | Reputation threshold for premium features. |
+| `validationRewardPercentage()` | `uint256` | % of payout reserved for validators. |
+| `maxJobPayout()` | `uint256` | Maximum allowed payout for a job. |
+| `jobDurationLimit()` | `uint256` | Maximum allowed job duration. |
+| `termsAndConditionsIpfsHash()` | `string` | Terms hash string (admin-set). |
+| `contactEmail()` | `string` | Contact email string (admin-set). |
+| `additionalText1()` | `string` | Admin text field. |
+| `additionalText2()` | `string` | Admin text field. |
+| `additionalText3()` | `string` | Admin text field. |
+| `clubRootNode()` | `bytes32` | ENS root node for validator subdomains. |
+| `agentRootNode()` | `bytes32` | ENS root node for agent subdomains. |
+| `validatorMerkleRoot()` | `bytes32` | Merkle root for validators. |
+| `agentMerkleRoot()` | `bytes32` | Merkle root for agents. |
+| `ens()` | `address` | ENS registry address. |
+| `nameWrapper()` | `address` | ENS NameWrapper address. |
+| `nextJobId()` | `uint256` | Next job ID to allocate. |
+| `nextTokenId()` | `uint256` | Next ERC-721 token ID to mint. |
+| `jobs(uint256)` | `Job` | Job fields (does not expose mappings/arrays). |
+| `reputation(address)` | `uint256` | Reputation for a user. |
+| `moderators(address)` | `bool` | Moderator allowlist. |
+| `additionalValidators(address)` | `bool` | Validator allowlist bypass. |
+| `additionalAgents(address)` | `bool` | Agent allowlist bypass. |
+| `validatorApprovedJobs(address,uint256)` | `uint256` | Job IDs a validator has voted on. |
+| `listings(uint256)` | `Listing` | Marketplace listing state. |
+| `blacklistedAgents(address)` | `bool` | Blacklisted agents. |
+| `blacklistedValidators(address)` | `bool` | Blacklisted validators. |
+| `agiTypes(uint256)` | `AGIType` | AGI type list (NFT address + payout %). |
+
+## Functions
+
+### Job lifecycle
+
+- `createJob(string _ipfsHash, uint256 _payout, uint256 _duration, string _details)` (nonpayable)
+  - Reverts: `InvalidParameters`, `TransferFailed`.
+  - Effects: creates a new job, stores details, pulls escrow, emits `JobCreated`.
+
+- `applyForJob(uint256 _jobId, string subdomain, bytes32[] proof)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `Blacklisted`, `NotAuthorized`.
+  - Effects: sets `assignedAgent` + `assignedAt`, emits `JobApplied`.
+
+- `requestJobCompletion(uint256 _jobId, string _ipfsHash)` (nonpayable)
+  - Reverts: `JobNotFound`, `NotAuthorized`, `InvalidState` (if past duration).
+  - Effects: updates job IPFS hash, sets `completionRequested`, emits `JobCompletionRequested`.
+
+- `validateJob(uint256 _jobId, string subdomain, bytes32[] proof)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `Blacklisted`, `NotAuthorized`.
+  - Effects: records approval, emits `JobValidated`, may call `_completeJob`.
+
+- `disapproveJob(uint256 _jobId, string subdomain, bytes32[] proof)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `Blacklisted`, `NotAuthorized`.
+  - Effects: records disapproval, emits `JobDisapproved`, may set `disputed` and emit `JobDisputed`.
+
+- `disputeJob(uint256 _jobId)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `NotAuthorized`.
+  - Effects: sets `disputed`, emits `JobDisputed`.
+
+- `resolveDispute(uint256 _jobId, string resolution)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `NotModerator`, `TransferFailed`.
+  - Effects: if resolution is `"agent win"` → completes job; if `"employer win"` → refunds employer + marks completed; clears dispute and emits `DisputeResolved`.
+
+- `cancelJob(uint256 _jobId)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `NotAuthorized`, `TransferFailed`.
+  - Effects: refunds employer, deletes job, emits `JobCancelled`.
+
+- `delistJob(uint256 _jobId)` (nonpayable)
+  - Reverts: `JobNotFound`, `InvalidState`, `TransferFailed`.
+  - Effects: refunds employer, deletes job, emits `JobCancelled`.
+
+- `getJobStatus(uint256 _jobId)` (view) → `(bool completed, bool completionRequested, string ipfsHash)`
+  - Note: does **not** revert if job does not exist; returns default values for empty storage.
+
+### Reputation & premium
+
+- `canAccessPremiumFeature(address user)` (view) → `bool`
+- `reputation(address user)` (view) → `uint256`
+
+### Validators & allowlists
+
+- `addAdditionalValidator(address validator)` (nonpayable) — owner only
+- `removeAdditionalValidator(address validator)` (nonpayable) — owner only
+- `addAdditionalAgent(address agent)` (nonpayable) — owner only
+- `removeAdditionalAgent(address agent)` (nonpayable) — owner only
+- `blacklistAgent(address _agent, bool _status)` (nonpayable) — owner only
+- `blacklistValidator(address _validator, bool _status)` (nonpayable) — owner only
+
+### Parameters & admin metadata
+
+- `updateAGITokenAddress(address _newTokenAddress)` (nonpayable) — owner only
+- `setBaseIpfsUrl(string _url)` (nonpayable) — owner only
+- `setRequiredValidatorApprovals(uint256 _approvals)` (nonpayable) — owner only
+- `setRequiredValidatorDisapprovals(uint256 _disapprovals)` (nonpayable) — owner only
+- `setPremiumReputationThreshold(uint256 _threshold)` (nonpayable) — owner only
+- `setMaxJobPayout(uint256 _maxPayout)` (nonpayable) — owner only
+- `setJobDurationLimit(uint256 _limit)` (nonpayable) — owner only
+- `setValidationRewardPercentage(uint256 _percentage)` (nonpayable) — owner only; reverts `InvalidParameters` if `percentage == 0` or `percentage > 100`.
+- `updateTermsAndConditionsIpfsHash(string _hash)` (nonpayable) — owner only
+- `updateContactEmail(string _email)` (nonpayable) — owner only
+- `updateAdditionalText1(string _text)` (nonpayable) — owner only
+- `updateAdditionalText2(string _text)` (nonpayable) — owner only
+- `updateAdditionalText3(string _text)` (nonpayable) — owner only
+
+### Reward pool / treasury
+
+- `contributeToRewardPool(uint256 amount)` (nonpayable)
+  - Reverts: `InvalidParameters`, `TransferFailed`.
+  - Effects: pulls ERC-20 into contract, emits `RewardPoolContribution`.
+
+- `withdrawAGI(uint256 amount)` (nonpayable) — owner only
+  - Reverts: `InvalidParameters`, `TransferFailed`.
+  - Effects: transfers ERC-20 from contract to owner.
+
+### AGI types
+
+- `addAGIType(address nftAddress, uint256 payoutPercentage)` (nonpayable)
+  - Reverts: `InvalidParameters`.
+  - Effects: adds or updates AGI type, emits `AGITypeUpdated`.
+
+- `getHighestPayoutPercentage(address agent)` (view) → `uint256`
+  - Reads ERC-721 balances across `agiTypes` and returns the max payout percentage.
+
+### NFT marketplace
+
+- `listNFT(uint256 tokenId, uint256 price)` (nonpayable)
+  - Reverts: `NotAuthorized`, `InvalidParameters`.
+  - Effects: sets listing active, emits `NFTListed`.
+
+- `purchaseNFT(uint256 tokenId)` (nonpayable)
+  - Reverts: `InvalidState`, `TransferFailed`.
+  - Effects: transfers ERC-20 payment and NFT, emits `NFTPurchased`.
+
+- `delistNFT(uint256 tokenId)` (nonpayable)
+  - Reverts: `NotAuthorized`.
+  - Effects: disables listing, emits `NFTDelisted`.
+
+### Pausable
+
+- `pause()` / `unpause()` (nonpayable) — owner only
+
+### ERC-721 / ERC-165 / Ownable
+
+All standard ERC-721 functions are exposed (name, symbol, balanceOf, ownerOf, approve, getApproved, setApprovalForAll, isApprovedForAll, transferFrom, safeTransferFrom, tokenURI) plus `supportsInterface` and Ownable functions (`owner`, `transferOwnership`, `renounceOwnership`). These follow OpenZeppelin’s revert behavior for missing tokens and unauthorized transfers.

--- a/docs/AGIJobManager_Operator_Guide.md
+++ b/docs/AGIJobManager_Operator_Guide.md
@@ -1,0 +1,90 @@
+# AGIJobManager Operator Guide
+
+This runbook is for operators deploying and administering `AGIJobManager`.
+
+## Deployment
+
+### Constructor arguments
+```
+constructor(
+  address _agiTokenAddress,
+  string _baseIpfsUrl,
+  address _ensAddress,
+  address _nameWrapperAddress,
+  bytes32 _clubRootNode,
+  bytes32 _agentRootNode,
+  bytes32 _validatorMerkleRoot,
+  bytes32 _agentMerkleRoot
+)
+```
+
+| Arg | Description |
+| --- | --- |
+| `_agiTokenAddress` | ERC-20 token used for job escrow and NFT marketplace payments. |
+| `_baseIpfsUrl` | Base URL used to build token URI (e.g., `ipfs://`). |
+| `_ensAddress` | ENS registry address for the target chain. |
+| `_nameWrapperAddress` | ENS NameWrapper address for the target chain. |
+| `_clubRootNode` | ENS root node for validator subdomains. |
+| `_agentRootNode` | ENS root node for agent subdomains. |
+| `_validatorMerkleRoot` | Merkle root allowlisting validators. |
+| `_agentMerkleRoot` | Merkle root allowlisting agents. |
+
+### Recommended deployment checklist
+1. Confirm the ERC-20 token is live and returns `true` on `transfer`/`transferFrom`.
+2. Set ENS + NameWrapper addresses that match the deployment network.
+3. Validate `clubRootNode` and `agentRootNode` against expected ENS names.
+4. Build Merkle roots from allowlisted addresses (see docs in `AGIJobManager.md`).
+5. Deploy, then set optional metadata (terms hash, contact email, additional text) as needed.
+
+## Default parameters
+The contract has the following defaults (can be updated by the owner):
+
+| Parameter | Default | Purpose |
+| --- | --- | --- |
+| `requiredValidatorApprovals` | `3` | Approvals to complete a job. |
+| `requiredValidatorDisapprovals` | `3` | Disapprovals to mark dispute. |
+| `premiumReputationThreshold` | `10000` | Reputation required for premium feature access. |
+| `validationRewardPercentage` | `8` | % of payout reserved for validators. |
+| `maxJobPayout` | `4888e18` | Max ERC-20 payout per job. |
+| `jobDurationLimit` | `10000000` | Max duration (seconds). |
+
+## Admin operations
+
+### Pausing
+- `pause()` / `unpause()` are owner-only.
+- **Paused** blocks: `createJob`, `applyForJob`, `requestJobCompletion`, `validateJob`, `disapproveJob`, `disputeJob`, and `contributeToRewardPool`.
+- **Paused** does **not** block: `cancelJob`, `resolveDispute`, `listNFT`, `purchaseNFT`, `delistNFT`, or admin setters.
+
+### Blacklists
+- `blacklistAgent(address,bool)` and `blacklistValidator(address,bool)` are owner-only.
+- Blacklisted users cannot apply or validate/disapprove.
+
+### Moderator management
+- `addModerator` / `removeModerator` control who can resolve disputes.
+
+### Allowlist bypass
+- `addAdditionalAgent` / `addAdditionalValidator` allow addresses to skip ENS/Merkle checks.
+- Use sparingly to avoid bypassing identity expectations.
+
+### AGI types
+- `addAGIType(nftAddress, payoutPercentage)` sets the payout percentage for holders of a specific ERC-721.
+- The highest percentage across all `agiTypes` is used for agent payout.
+
+### Withdrawing funds
+- `withdrawAGI(amount)` transfers ERC-20 from the contract to the owner.
+- **Caveat:** This can reduce the contract’s ability to pay out jobs if escrow totals are exceeded by payouts. Treat it as a treasury operation.
+
+### Rotating the ERC-20 token
+- `updateAGITokenAddress` changes the token used for all future escrow and marketplace payments.
+- **Operational risk:** Existing escrow balances are held in the old token. Consider withdrawing or reconciling before rotating.
+
+## Operational guidance
+
+### Safe parameter tuning
+- Keep `requiredValidatorApprovals` and `requiredValidatorDisapprovals` balanced to prevent trivial disputes.
+- Ensure `validationRewardPercentage + max expected agent payout %` does not exceed 100 unless you are intentionally subsidizing with treasury funds.
+- Use `jobDurationLimit` to prevent long-running unbounded jobs.
+
+### Disaster recovery
+- If a validator or agent allowlist is compromised, rotate the Merkle roots by redeploying (no on-chain root update in current code).
+- For disputes that need off-chain intervention, add a moderator and use `resolveDispute` with clear resolution strings.

--- a/docs/AGIJobManager_Security.md
+++ b/docs/AGIJobManager_Security.md
@@ -1,0 +1,34 @@
+# AGIJobManager Security Considerations
+
+This document highlights security properties, assumptions, and known fixes relative to the legacy v0 contract.
+
+## Reentrancy posture
+- `nonReentrant` is applied to: `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `cancelJob`, `withdrawAGI`, and `contributeToRewardPool`.
+- Functions **without** `nonReentrant` include `requestJobCompletion`, `listNFT`, `purchaseNFT`, `delistNFT`, and admin setters.
+  - `purchaseNFT` performs an external ERC-20 `transferFrom` prior to NFT transfer; this relies on the ERC-20 token being well-behaved.
+
+## Known fixes vs legacy v0
+The regression suite documents the following issues fixed in the current contract:
+- **Pre-apply takeover**: Prevents agents from applying before a job exists (`JobNotFound`).
+- **Double-complete on disputed jobs**: Clears `disputed` and enforces `completed` to prevent double payout.
+- **Division-by-zero on zero validators**: Skips validator payout when no validators participated.
+- **Double-vote validator edge case**: Prevents the same validator from both approving and disapproving.
+- **Employer-win dispute still completing**: Employer refund now closes the job to prevent later completion.
+- **Unchecked ERC-20 transfer on refunds**: Refunds now revert if ERC-20 transfers fail.
+
+See `docs/REGRESSION_TESTS.md` for detailed coverage and test intent.
+
+## Remaining risks & assumptions
+
+- **Centralized powers**: The owner can pause, blacklist, withdraw funds, add moderators, and rotate the ERC-20 token. This is an intentional trust model.
+- **Moderator trust**: Moderators can finalize disputes with resolution strings that control payout behavior.
+- **ENS / NameWrapper dependencies**: Ownership checks rely on external ENS and NameWrapper contracts and resolver responses.
+- **Merkle root management**: The current contract has no on-chain root update; changing allowlists requires redeploying or using `additionalAgents`/`additionalValidators`.
+- **ERC-20 behavior**: The escrow token must return `true` on transfers; non-standard tokens can break flows.
+- **Payout exceeding escrow**: If agent payout percentage + validator reward percentage exceeds 100%, the contract pays from its pooled balance.
+- **Validation without completion request**: Validators can approve/disapprove even if the agent hasn’t called `requestJobCompletion`.
+
+## Best-practice guidance
+- Use a standard ERC-20 token with strict `transfer`/`transferFrom` semantics.
+- Ensure validator + agent payout percentages are sustainable.
+- Use additional allowlists sparingly and audit moderator actions off-chain.


### PR DESCRIPTION
### Motivation
- Provide a complete, code-accurate documentation set so engineers, dApp integrators, auditors, and operators can understand and safely use `AGIJobManager` without editing the contract.
- Ensure the docs match the compiled ABI and emitted events/errors so integrators can rely on exact function signatures and event shapes.
- Surface lifecycle, roles, accounting, ENS/Merkle ownership checks, NFT issuance/marketplace, operator runbook, and security guidance in separate focused docs.

### Description
- Added a primary spec `docs/AGIJobManager.md` describing the contract purpose, components, lifecycle/state machine, roles, ENS/Merkle ownership verification, accounting semantics, NFT issuance, and quickstart examples.
- Added an ABI-accurate interface reference `docs/AGIJobManager_Interface.md` that documents all public/external functions, events (including indexed args), custom errors, and public state variables using the compiled artifact for accuracy.
- Added operator runbook `docs/AGIJobManager_Operator_Guide.md` covering constructor args, safe defaults, admin operations, and operational guidance, and `docs/AGIJobManager_Security.md` covering reentrancy posture, known fixes vs legacy v0, and remaining risks.
- Linked the new documentation from `README.md`; no changes were made to `contracts/AGIJobManager.sol` and no Solidity or ABI/behavior changes were introduced.

### Testing
- Ran `npm install` which completed successfully and installed dev dependencies.
- Ran `npx truffle compile` which completed successfully and wrote artifacts to `build/contracts/AGIJobManager.json`, and the ABI from that artifact was used to author `docs/AGIJobManager_Interface.md`.
- Ran `npx truffle test` which failed with: `CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545.`; likely cause is that a local test node (Ganache/eth node) was not running on the configured RPC endpoint, so tests could not connect; next steps: start a local Ganache instance or adjust Truffle network configuration and re-run `npx truffle test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979816231d083339cde874123e4bbb0)