### PR TITLE
Enhance AGIJobManager documentation (ABI, events, lifecycle, operator guide)

### DIFF
--- a/docs/AGIJobManager_Operator_Guide.md
+++ b/docs/AGIJobManager_Operator_Guide.md
@@ -25,6 +25,16 @@ The contract’s initial values are:
 - `maxJobPayout = 4888e18`
 - `jobDurationLimit = 10000000`
 
+### Parameter meanings (operator notes)
+| Parameter | Meaning | Operational notes |
+| --- | --- | --- |
+| `requiredValidatorApprovals` | Number of validator approvals required for completion. | Higher values increase validation confidence but slow completion. |
+| `requiredValidatorDisapprovals` | Number of validator disapprovals required to auto-dispute. | Setting too low can trigger frequent disputes. |
+| `validationRewardPercentage` | Percentage of payout allocated to validators. | Split equally across all validators who voted. |
+| `premiumReputationThreshold` | Minimum reputation for `canAccessPremiumFeature`. | Affects only off-chain integrations. |
+| `maxJobPayout` | Hard cap on job payouts in `createJob`. | Must align with escrow risk tolerance. |
+| `jobDurationLimit` | Maximum job duration in seconds. | Enforcement occurs during `createJob`. |
+
 ## Operational configuration
 ### Admin controls (owner-only)
 - **Pause/unpause**
@@ -46,6 +56,7 @@ The contract’s initial values are:
   - Moderators: `addModerator` / `removeModerator`.
   - Explicit allowlists: `addAdditionalAgent`, `removeAdditionalAgent`, `addAdditionalValidator`, `removeAdditionalValidator`.
   - Blacklists: `blacklistAgent`, `blacklistValidator`.
+  - **Blacklist usage**: blacklisted agents cannot apply, and blacklisted validators cannot approve/disapprove. Existing assignments are not auto-cleared.
 
 - **AGI types**
   - `addAGIType(nftAddress, payoutPercentage)` adds or updates a payout multiplier tied to owning an ERC-721.
@@ -58,6 +69,11 @@ The contract’s initial values are:
 - **Withdrawals**
   - `withdrawAGI(amount)` allows the owner to move ERC-20 balance out of the contract.
   - It reverts on `amount == 0` or `amount > balance`.
+  - **Caveat**: withdrawals reduce escrow safety for open jobs; monitor outstanding `job.payout` values.
+
+- **Reward pool contributions**
+  - `contributeToRewardPool` allows anyone to send ERC-20 to the contract.
+  - There is **no automatic distribution** of contributed funds.
 
 ### Job controls
 - Employers can `cancelJob` before assignment (refunds escrow, deletes job).
@@ -78,4 +94,3 @@ The contract’s initial values are:
 - **Token rotation mismatch**: escrowed balance remains in old ERC-20.
 - **Zero validator count**: no validator rewards are distributed on completion.
 - **Agent with no AGI type**: agent payout percentage can be zero.
-

--- a/docs/AGIJobManager_Security.md
+++ b/docs/AGIJobManager_Security.md
@@ -19,10 +19,12 @@ Functions **without** `nonReentrant` include `requestJobCompletion`, `listNFT`, 
 ## Fixed issues vs. historical behavior
 The repository test suite documents several behavior improvements over a prior version. The following improvements are baked into the current code:
 - **Pre-apply takeover blocked**: a job cannot be reassigned once an agent is set.
+- **Phantom job IDs blocked**: functions using `_job` revert if the job does not exist instead of acting on default data.
 - **Disputed double-complete blocked**: disputes resolved with employer win close the job to prevent later completion.
 - **Division-by-zero avoided**: agent-win dispute completion handles zero-validator cases safely.
 - **Validator double-votes blocked**: validators cannot approve and disapprove the same job (or double vote).
 - **Employer-win dispute properly closes** the job and refunds escrow.
+- **Unchecked transfers fixed**: ERC-20 `transfer`/`transferFrom` return values are checked and revert on failure.
 - **Failed refunds revert** instead of silently deleting jobs when token transfers fail.
 
 ## Remaining risks & assumptions
@@ -39,4 +41,3 @@ The repository test suite documents several behavior improvements over a prior v
 - **Dispute strings** must match exactly: `"agent win"` or `"employer win"` (case-sensitive, ASCII). Otherwise no payout/refund occurs.
 - **Handle custom errors**: integrators should decode custom errors (e.g., `InvalidState`, `NotAuthorized`, `TransferFailed`) when calls revert.
 - **Monitor events**: state changes are best tracked via events (`JobCreated`, `JobCompleted`, `JobDisputed`, `DisputeResolved`, NFT events, etc.).
-


### PR DESCRIPTION
### Motivation
- Make the on-chain `AGIJobManager` behaviour explicit and machine-accurate for integrators, auditors, and operators by reflecting the compiled ABI and concrete code paths. 
- Clarify roles, preconditions (including custom error selectors), payouts, ENS/Merkle checks, and NFT marketplace semantics so callers can safely interact without changing the contract.
- Provide an operator runbook and security notes tied to the actual implementation to reduce operational risk.

### Description
- Updated `docs/AGIJobManager.md` to clarify job lifecycle details, the `validators` array behaviour (both approvals and disapprovals appended), creation preconditions (`payout > 0`, `duration > 0` and configured limits), validator payout splitting, and NFT listing ownership semantics. 
- Expanded `docs/AGIJobManager_Interface.md` with ABI-derived details: indexed event fields, a table-style event summary, explicit function preconditions linked to the contract's custom errors (e.g., `NotAuthorized`, `InvalidState`, `JobNotFound`, `TransferFailed`), and precise notes about which checks revert and why. 
- Enhanced `docs/AGIJobManager_Operator_Guide.md` with a parameter meaning table, blacklist usage, reward-pool behaviour, token-rotation caveats, and operational runbook recommendations. 
- Extended `docs/AGIJobManager_Security.md` to list fixed issues present in the current implementation (e.g., phantom-job ID handling, checked ERC-20 transfers) and reiterated remaining risks and assumptions (owner/moderator power, ENS dependency, ERC-20 return assumptions).

### Testing
- `npm install` — succeeded (packages installed; audit warnings reported but unrelated to docs). 
- `npx truffle compile` — succeeded and produced artifacts in `build/contracts` using solc `0.8.33`; ABI was inspected (`build/contracts/AGIJobManager.json`) to confirm event/function signatures used in the docs. 
- `npx truffle test` — failed to run due to environment/network issue: "CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545." (Truffle could not reach a local test node; no contract/test behavior was modified to remedy test runner environment). 

Files changed:
- `docs/AGIJobManager.md` (clarified lifecycle, payouts, validators, NFT listing)
- `docs/AGIJobManager_Interface.md` (ABI-derived event/indexing table, explicit revert/error mapping, function preconditions)
- `docs/AGIJobManager_Operator_Guide.md` (parameter table, blacklist/reward-runbook notes)
- `docs/AGIJobManager_Security.md` (added fixed-issue summaries and ERC-20 transfer checks)

Limitations / next steps:
- `truffle test` requires a running local node (e.g., Ganache) at `http://127.0.0.1:8545`; set up the local test node and re-run tests to validate runtime behaviors end-to-end.
- The docs were produced strictly from the compiled ABI and source; no contract changes were made as required.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69798a61f36c8333a07945f45fc06357)