### PR TITLE
Rewrite README with deployment, operator, and security guidance

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,40 @@
-# ERC-8004 adapter configuration
+# -----------------------------------------------------------------------------
+# AGIJobManager deployment + tooling (dotenv is loaded by truffle-config.js)
+# -----------------------------------------------------------------------------
+# Comma-separated private keys (no spaces). Example format:
+# PRIVATE_KEYS=0xabc...,0xdef...
+PRIVATE_KEYS=
+
+# RPC configuration (choose one per network)
+# SEPOLIA_RPC_URL=
+# MAINNET_RPC_URL=
+# ALCHEMY_KEY=
+# ALCHEMY_KEY_MAIN=
+# INFURA_KEY=
+
+# Optional deployment tuning
+# SEPOLIA_GAS=8000000
+# MAINNET_GAS=8000000
+# SEPOLIA_GAS_PRICE_GWEI=
+# MAINNET_GAS_PRICE_GWEI=
+# SEPOLIA_CONFIRMATIONS=2
+# MAINNET_CONFIRMATIONS=2
+# SEPOLIA_TIMEOUT_BLOCKS=500
+# MAINNET_TIMEOUT_BLOCKS=500
+# RPC_POLLING_INTERVAL_MS=8000
+
+# Compiler configuration (optional overrides)
+# SOLC_VERSION=0.8.33
+# SOLC_RUNS=200
+# SOLC_VIA_IR=false
+# SOLC_EVM_VERSION=london
+
+# Verification
+# ETHERSCAN_API_KEY=
+
+# -----------------------------------------------------------------------------
+# ERC-8004 adapter configuration (scripts/ + integrations/erc8004)
+# -----------------------------------------------------------------------------
 AGIJOBMANAGER_ADDRESS=0xYourAGIJobManager
 FROM_BLOCK=0
 TO_BLOCK=latest

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+## Reporting a vulnerability
+If you discover a security issue, please use GitHub Security Advisories for this repository (preferred) or open a private report through the repository maintainers if available. If you are unable to use the advisory flow, you may open a public issue with minimal details and request a secure channel.
+
+## Scope
+This policy covers the smart contracts and related tooling in this repository. Please include:
+- A clear description of the issue and affected components
+- Steps to reproduce or a proof-of-concept
+- Impact analysis (what could be lost or corrupted)
+
+## Response expectations
+This is an experimental research repository and response timelines are best-effort. We will acknowledge reports when possible and coordinate fixes and disclosures as appropriate.


### PR DESCRIPTION
### Motivation
- Make the repository's root README the canonical, practical entry point for engineers, integrators, operators, and security reviewers. 
- Ensure all documentation matches the repo's actual Truffle-based tooling and contract behavior (no invented features). 
- Provide explicit deployment, environment, and verification guidance to reduce operational errors and risky defaults. 

### Description
- Rewrote `README.md` to a structured, role-focused document that includes a short tagline and warning banner, quick links, a precise "what it is / what it isn't" section, key concepts (roles, assets, authorization), an architecture diagram, a Mermaid job lifecycle diagram, a compact contract interface summary, deployment and testing instructions for Truffle (Sepolia + mainnet + local), environment variable documentation, security considerations, project layout, and links to the existing `docs/` content. 
- Added and expanded `.env.example` to document `PRIVATE_KEYS`, RPC options (`SEPOLIA_RPC_URL`, `MAINNET_RPC_URL`, `ALCHEMY_KEY`, `INFURA_KEY`), compiler overrides (`SOLC_*`), verification key (`ETHERSCAN_API_KEY`) and deployment tuning variables. 
- Added a minimal `SECURITY.md` responsible-disclosure policy appropriate for this experimental research repo. 
- Changes are documentation-only: no Solidity sources or contract logic were modified. Files changed: `README.md`, `.env.example`, and added `SECURITY.md`.

### Testing
- Installed dependencies and compiled the contracts with `npm run build` (Truffle compile), which completed successfully and wrote artifacts to `build/contracts` using `solc 0.8.33`. 
- Ran the repository test suite with `npm test` (`truffle test --network test` plus the ABI smoke test), which completed successfully: the regression tests show `6 passing` and the ABI smoke test also passed. 
- Notes: compilation emitted OpenZeppelin-related Natspec warnings but no build failures; `npm install` reported dependency advisories (vulnerability notices) unrelated to the documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979925b412083338e79706324abe4f5)