### PR TITLE
docs: clarify job status helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ stateDiagram-v2
 - **Validated**: `validatorApprovals >= requiredValidatorApprovals` (triggers `_completeJob`).
 - **Disputed**: `disputed=true` set by disapprove threshold or manual dispute.
 - **Completed**: `completed=true` (set by `_completeJob` or employer-win resolution).
+- **Convenience helper**: `getJobStatus(jobId)` returns `(completed, completionRequested, ipfsHash)` for lightweight polling.
 
 ---
 

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -59,6 +59,10 @@ Job state is encoded in the following fields:
 
 These flags are observable via the public `jobs(jobId)` getter and lifecycle events.
 
+### Read-only helpers
+- `getJobStatus(jobId)` returns `(completed, completionRequested, ipfsHash)` for lightweight polling.
+- `jobs(jobId)` returns the fixed fields of the `Job` struct (it omits the internal validator list and approval mappings).
+
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` pulls the payout from the employer via `transferFrom`.
 - **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is the highest AGI type percentage owned by the agent. If no AGI types apply, this can be zero.


### PR DESCRIPTION
### Motivation
- Make it explicit that a lightweight, read-only helper exists for polling job status so integrators and UIs can avoid reading internal mappings directly.
- Improve documentation parity between the root `README.md` and the contract specification in `docs/AGIJobManager.md` without touching the contract source.
- Reduce confusion for indexers/consumers about what `jobs(jobId)` exposes versus what `getJobStatus(jobId)` returns.

### Description
- Documented the convenience helper in `README.md` by adding `getJobStatus(jobId)` as a recommended lightweight polling method.
- Updated `docs/AGIJobManager.md` to add a `Read-only helpers` section that describes `getJobStatus(jobId)` and clarifies that `jobs(jobId)` omits internal validator lists and approval mappings.
- No contract code was modified; changes are documentation-only and minimal in scope (two files changed).

### Testing
- Ran `npm install`; installation completed successfully with dependency warnings and audit output (vulnerabilities reported but unrelated to this doc change).
- Ran `npx truffle compile`; compilation succeeded and artifacts were written using `solc 0.8.33`.
- Ran `node scripts/generate-interface-doc.js`; the script executed and wrote `docs/Interface.md`.
- Ran `npm test`; test suite completed successfully (truffle regressions: 6 passing and ABI smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2245bf748333a790941b3d13e959)