### PR TITLE
Overhaul documentation: trust‑layer framing, README refresh, and docs expansion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,45 @@
 # AGIJobManager
 
-AGIJobManager is a single-contract escrow and workflow engine for employer–agent jobs, validation, dispute resolution, reputation, and job NFT issuance on Ethereum-compatible networks.
-
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![Solidity](https://img.shields.io/badge/solidity-%5E0.8.17-363636.svg)](contracts/AGIJobManager.sol)
 [![Truffle](https://img.shields.io/badge/truffle-5.x-3fe0c5.svg)](https://trufflesuite.com/)
 [![CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml)
 
+AGIJobManager is a single-contract escrow and workflow engine for employer–agent jobs, validator approvals/disapprovals, dispute resolution, reputation, and job NFT issuance on Ethereum-compatible networks.
+
 > **Status / Caution**
-> This repository is **research/experimental**. Use caution, review the contract and tests, and do not deploy to production without independent security review.
+> This repository is **research/experimental**. Review the contract and tests, and do not deploy to production without independent security review.
 
-## Quick links
-
-| Resource | Link |
-| --- | --- |
-| Contract source | [`contracts/AGIJobManager.sol`](contracts/AGIJobManager.sol) |
-| Docs index | [`docs/README.md`](docs/README.md) |
-| Deployment guide | [`docs/Deployment.md`](docs/Deployment.md) |
-| Security notes | [`docs/Security.md`](docs/Security.md) |
-| Interface reference (ABI-derived) | [`docs/Interface.md`](docs/Interface.md) |
-| Original mainnet contract (historical v0) | [0x0178b6bad606aaf908f72135b8ec32fc1d5ba477](https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477) |
-
----
-
-## What it is / what it is not
+## At a glance
 
 **What it is**
-- **Job escrow + workflow**: employers lock ERC‑20 funds into jobs, agents are assigned, validators review outcomes, and disputes are resolved on-chain.
-- **Reputation tracking**: on-chain reputation updates for agents and validators based on payout and completion time.
-- **Job NFT issuance + marketplace**: successful completion mints an ERC‑721 to the employer, which can be listed and purchased via a simple listing flow.
-- **Eligibility gating**: agents and validators are gated by Merkle roots and ENS NameWrapper + Resolver ownership checks.
+- **Job escrow + workflow**: employers escrow ERC‑20 payouts, agents are assigned, validators approve/disapprove, and moderators resolve disputes.
+- **Reputation mapping**: on-chain reputation points for agents and validators driven by job outcomes.
+- **Job NFT issuance + marketplace**: successful completion mints an ERC‑721 to the employer; listings/purchases are supported for those job NFTs.
+- **Eligibility gating**: ENS NameWrapper/Resolver ownership checks plus Merkle allowlists and explicit allowlists/blacklists.
 
 **What it is not**
-- **Not a generalized identity registry**: no on-chain ERC‑8004 registry is implemented here.
-- **Not a full-featured marketplace**: listings apply only to job NFTs minted by this contract.
-- **Not a permissionless validator network**: validators are gated by allowlists and ownership checks.
+- **Not an on-chain ERC‑8004 registry**: ERC‑8004 is an off-chain signaling layer; this repo does not implement it on-chain.
+- **Not a general NFT marketplace**: listings apply only to job NFTs minted by this contract.
+- **Not a permissionless validator network**: validators are gated by allowlists and ENS/Merkle checks.
 
----
+## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
-## Concepts and roles
+**ERC‑8004 (signaling layer)** standardizes how agent identity, reputation, and validation signals are published off-chain in a consistent schema. These signals are meant to be indexed, ranked, and consumed by external policy engines.
 
-**Roles**
-- **Owner**: contract administrator (pausing, parameters, allowlists/blacklists, AGI types, withdrawals).
-- **Moderator**: resolves disputes.
-- **Employer**: creates and funds jobs.
-- **Agent**: applies for and completes jobs.
-- **Validator**: approves or disapproves jobs.
+**AGIJobManager (enforcement layer)** is the on-chain settlement anchor: it escrows funds, enforces validator thresholds, gates access via ENS/Merkle checks, resolves disputes, and updates reputation.
 
-**Core primitives**
-- **Job**: escrowed payout + metadata + lifecycle state.
-- **Reputation mapping**: on-chain reputation points stored per address.
-- **AGI types**: optional ERC‑721 NFTs that raise the agent payout percentage.
-- **Job NFTs**: ERC‑721 tokens minted to employers when a job completes.
-- **Marketplace listing**: non-escrow listing/purchase for job NFTs.
+**Recommended integration pattern (no contract changes required)**
+1. Publish ERC‑8004 trust signals (identity, reputation, validation outcomes).
+2. Index and rank those signals off-chain.
+3. Use the ranked results to decide who is allowed to validate or be assigned work.
+4. Encode those decisions via Merkle roots at deployment and explicit allowlists/blacklists during operation.
 
----
+> **Important**: ERC‑8004 is **not** wired on-chain in this repo. The integration is intentionally off-chain; AGIJobManager remains the enforcement/settlement anchor.
 
-## Job lifecycle (state machine)
+## Architecture + illustrations
 
+### Job lifecycle (state machine)
 ```mermaid
 stateDiagram-v2
     [*] --> Created: createJob
@@ -81,31 +63,31 @@ stateDiagram-v2
     Created --> Cancelled: delistJob (owner)
 ```
 
-**State variables and flags that encode stages**
-- **Created**: `assignedAgent == address(0)`, `completed=false`, `disputed=false`.
-- **Assigned**: `assignedAgent != address(0)`, `assignedAt > 0`.
-- **CompletionRequested**: `completionRequested=true` (and `ipfsHash` updated).
-- **Validated**: `validatorApprovals >= requiredValidatorApprovals` (triggers `_completeJob`).
-- **Disputed**: `disputed=true` set by disapprove threshold or manual dispute.
-- **Completed**: `completed=true` (set by `_completeJob` or employer-win resolution).
-- **Convenience helper**: `getJobStatus(jobId)` returns `(completed, completionRequested, ipfsHash)` for lightweight polling.
-
----
-
-## Architecture overview
-
+### Full‑stack trust layer (signaling → enforcement)
 ```mermaid
 flowchart LR
-    Employer -->|ERC-20 escrow| AGIJobManager
-    Agent -->|apply and complete| AGIJobManager
-    Validator -->|approve and disapprove| AGIJobManager
-    Moderator -->|resolve disputes| AGIJobManager
-    AGIJobManager -->|mint job NFT| JobNFT[ERC-721 Job NFT]
-    AGIJobManager <-->|ENS + NameWrapper + Resolver| ENS[ENS contracts]
-    AGIJobManager <-->|Merkle allowlists| Merkle[Validator and Agent roots]
+    subgraph Off-chain trust signaling
+        A[Agents/Validators/Observers] --> B[ERC-8004 signals]
+        B --> C[Indexers & rankers]
+        C --> D[Policy decisions
+(allowlists / trust tiers)]
+    end
+
+    D -->|Merkle roots & allowlists| E[AGIJobManager (on-chain)]
+    E <-->|ENS NameWrapper/Resolver| F[ENS contracts]
+    E --> G[Escrow, payout, reputation,
+job NFT issuance]
 ```
 
----
+## Roles & permissions
+
+| Role | Capabilities |
+| --- | --- |
+| **Owner** | Pause/unpause, set thresholds, update token address, manage allowlists/blacklists, add moderators, add AGI types, withdraw escrowed ERC‑20. |
+| **Moderator** | Resolve disputes (only `agent win` / `employer win` trigger on-chain settlement). |
+| **Employer** | Create and fund jobs, cancel before assignment, dispute jobs, receive job NFT. |
+| **Agent** | Apply for jobs, request completion, earn payouts and reputation. |
+| **Validator** | Approve/disapprove jobs, receive payouts and reputation when voting. |
 
 ## Quickstart
 
@@ -130,14 +112,12 @@ npx ganache -p 8545
 npx truffle migrate --network development
 ```
 
----
-
-## Deployment and verification (Truffle)
+## Deployment & verification (Truffle)
 
 > Full details: [`docs/Deployment.md`](docs/Deployment.md)
 
 **Environment variables (from `truffle-config.js`)**
-- **RPC + keys**: `PRIVATE_KEYS` (comma-separated), `SEPOLIA_RPC_URL`, `MAINNET_RPC_URL`, `ALCHEMY_KEY`, `ALCHEMY_KEY_MAIN`, `INFURA_KEY`.
+- **RPC + keys**: `PRIVATE_KEYS`, `SEPOLIA_RPC_URL`, `MAINNET_RPC_URL`, `ALCHEMY_KEY`, `ALCHEMY_KEY_MAIN`, `INFURA_KEY`.
 - **Verification**: `ETHERSCAN_API_KEY`.
 - **Optional tuning**: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`, `RPC_POLLING_INTERVAL_MS`.
 - **Compiler**: `SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`.
@@ -155,46 +135,21 @@ npx truffle run verify AGIJobManager --network sepolia
 
 > ⚠️ The migration script (`migrations/2_deploy_contracts.js`) hardcodes constructor parameters. Edit before deploying to production networks.
 
----
+## Security considerations
 
-## Security model (high-signal)
+- **Centralization risk**: the owner can pause flows, change allowlists, update token address, and withdraw escrowed ERC‑20.
+- **Moderator power**: moderators resolve disputes; only `agent win` or `employer win` trigger on-chain payout/refund.
+- **Reputation rules are deterministic** but not a substitute for off-chain validation or auditing.
 
-**Trust assumptions**
-- **Owner powers**: can pause flows, update token address, thresholds, allowlists/blacklists, metadata fields, add AGI types, and withdraw ERC‑20 from escrow.
-- **Moderator powers**: can resolve disputes. Only the canonical strings `agent win` and `employer win` trigger on-chain payout or refund.
+See [`docs/Security.md`](docs/Security.md) for the full threat model and limitations.
 
-**Hardened evolution vs. historical v0** (see `docs/REGRESSION_TESTS.md`)
-- Prevents phantom job ID access via `_job` checks.
-- Prevents reassignment after an agent is set.
-- Prevents double completion after employer-win dispute resolution.
-- Avoids division-by-zero when no validators voted.
-- Enforces one vote per validator (approve or disapprove).
-- Checks ERC‑20 transfer return values and reverts on failure.
+## Ecosystem links
 
-**Responsible disclosure**
-- Report security issues privately. See [`SECURITY.md`](SECURITY.md).
-
----
-
-## ABI and events (indexer notes)
-
-**High-value events**
-- **Job lifecycle**: `JobCreated`, `JobApplied`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `DisputeResolved`, `JobCompleted`, `JobCancelled`.
-- **Reputation**: `ReputationUpdated` (agents and validators).
-- **NFT and marketplace**: `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`.
-- **Access signals**: `OwnershipVerified`, `RecoveryInitiated`.
-
-Most job events are not indexed, so indexers should scan by block range and build their own derived indices. See the ABI-derived event list in [`docs/Interface.md`](docs/Interface.md).
-
----
-
-## Ecosystem and related projects
-
-- **Legacy v0 contract**: historical deployment at `0x0178b6bad606aaf908f72135b8ec32fc1d5ba477` (for comparison and regression tests).
-- **ERC‑8004 adapter**: off-chain adapter and docs in [`integrations/erc8004/`](integrations/erc8004/).
-- **ERC‑8004 overview**: [`docs/Integrations.md`](docs/Integrations.md).
-
----
+- **Contract source**: [`contracts/AGIJobManager.sol`](contracts/AGIJobManager.sol)
+- **Docs index**: [`docs/README.md`](docs/README.md)
+- **ERC‑8004 overview**: https://eips.ethereum.org/EIPS/eip-8004
+- **ERC‑8004 deck (framing)**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/presentation/MONTREALAI_x_ERC8004_v0.pdf
+- **Historical mainnet deployment (v0)**: https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477
 
 ## Project structure
 
@@ -208,8 +163,6 @@ test/           # Truffle + regression tests
 ```
 
 Artifacts and ABIs are written to `build/contracts/` after compilation.
-
----
 
 ## Contributing and license
 

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -8,20 +8,26 @@ This document describes the on-chain behavior of `AGIJobManager` as implemented 
 - [Lifecycle state machine](#lifecycle-state-machine)
 - [State variables and flags](#state-variables-and-flags)
 - [Escrow and payout mechanics](#escrow-and-payout-mechanics)
+- [Validation and dispute flow](#validation-and-dispute-flow)
+- [Reputation mechanics](#reputation-mechanics)
 - [Eligibility and identity checks](#eligibility-and-identity-checks)
 - [NFT issuance and marketplace](#nft-issuance-and-marketplace)
-- [Architecture overview](#architecture-overview)
+- [Events](#events)
+- [Error handling](#error-handling)
+- [Invariants and constraints](#invariants-and-constraints)
 - [References](#references)
 
 ## Overview
 AGIJobManager coordinates employer-funded jobs, agent assignment, validator review, dispute resolution, reputation updates, and job NFT issuance. The contract holds ERC‑20 escrow for job payouts and mints an ERC‑721 to the employer when a job completes.
 
 ## Roles and permissions
-- **Owner**: pause/unpause flows, update parameters, change ERC‑20 address, manage allowlists and blacklists, assign moderators, add AGI types, withdraw escrowed ERC‑20.
-- **Moderator**: resolves disputes via `resolveDispute`.
-- **Employer**: creates jobs, disputes jobs, cancels before assignment.
-- **Agent**: applies to eligible jobs, requests completion.
-- **Validator**: validates or disapproves eligible jobs.
+| Role | Capabilities |
+| --- | --- |
+| **Owner** | Pause/unpause flows, update parameters, change ERC‑20 address, manage allowlists/blacklists, assign moderators, add AGI types, withdraw escrowed ERC‑20. |
+| **Moderator** | Resolve disputes via `resolveDispute`. |
+| **Employer** | Create jobs, cancel before assignment, dispute jobs, receive job NFTs. |
+| **Agent** | Apply to eligible jobs, request completion, earn payouts and reputation. |
+| **Validator** | Validate or disapprove jobs, earn payouts and reputation when voting. |
 
 Refer to the ABI-derived access map in [`Interface.md`](Interface.md).
 
@@ -64,36 +70,62 @@ These flags are observable via the public `jobs(jobId)` getter and lifecycle eve
 - `jobs(jobId)` returns the fixed fields of the `Job` struct (it omits the internal validator list and approval mappings).
 
 ## Escrow and payout mechanics
-- **Escrow on creation**: `createJob` pulls the payout from the employer via `transferFrom`.
-- **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is the highest AGI type percentage owned by the agent. If no AGI types apply, this can be zero.
-- **Validator payout**: when validators exist, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
+- **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.
+- **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is the highest AGI type percentage owned by the agent (may be zero).
+- **Validator payout**: if validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
 - **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner.
 - **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with employer win refunds and closes the job.
+
+## Validation and dispute flow
+- `validateJob` increments approval count, records validator participation, and auto-completes when approvals reach the required threshold.
+- `disapproveJob` increments disapproval count, records validator participation, and flips `disputed` when disapprovals reach the required threshold.
+- `disputeJob` can be called by employer or assigned agent (if not already disputed or completed).
+- `resolveDispute` accepts any resolution string but only two canonical strings trigger on-chain actions:
+  - `agent win` → `_completeJob`
+  - `employer win` → employer refund + job closed
+
+## Reputation mechanics
+- **Agent reputation**: derived from payout and completion time via `calculateReputationPoints`, then stored through `enforceReputationGrowth` (diminishing returns with a cap).
+- **Validator reputation**: derived from agent reputation via `calculateValidatorReputationPoints` and updated for all validators who voted.
+- **Premium access**: `canAccessPremiumFeature` gates on `premiumReputationThreshold`.
 
 ## Eligibility and identity checks
 Agents and validators must either:
 - be explicitly allowlisted (`additionalAgents` or `additionalValidators`), or
 - pass `_verifyOwnership`, which checks Merkle proofs or ENS ownership through NameWrapper and Resolver fallback paths.
 
-If the ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for observability and continues evaluation.
+If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for observability and continues evaluation.
 
 ## NFT issuance and marketplace
 - **Minting**: completion mints a job NFT to the employer, with `tokenURI = baseIpfsUrl + '/' + job.ipfsHash`.
 - **Listings**: NFT owners can list tokens without escrow; listings live in the `listings` mapping.
 - **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT.
 
-## Architecture overview
+## Events
+High-signal events to index:
+- **Lifecycle**: `JobCreated`, `JobApplied`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `DisputeResolved`, `JobCompleted`, `JobCancelled`.
+- **Reputation**: `ReputationUpdated` (agents and validators).
+- **NFT marketplace**: `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`.
+- **Access signals**: `OwnershipVerified`, `RecoveryInitiated`.
 
-```mermaid
-flowchart LR
-    Employer -->|ERC-20 escrow| AGIJobManager
-    Agent -->|apply and complete| AGIJobManager
-    Validator -->|approve and disapprove| AGIJobManager
-    Moderator -->|resolve disputes| AGIJobManager
-    AGIJobManager -->|mint job NFT| JobNFT[ERC-721 Job NFT]
-    AGIJobManager <-->|ENS + NameWrapper + Resolver| ENS[ENS contracts]
-    AGIJobManager <-->|Merkle allowlists| Merkle[Validator and Agent roots]
-```
+See [`Interface.md`](Interface.md) for the complete ABI-derived list.
+
+## Error handling
+Custom errors and their intent:
+- `NotModerator`: caller is not a moderator.
+- `NotAuthorized`: caller lacks required role/ownership for the action.
+- `Blacklisted`: caller is explicitly blacklisted.
+- `InvalidParameters`: zero values, out-of-range percentages, or invalid constructor updates.
+- `InvalidState`: invalid lifecycle transition (e.g., reapply, double complete, dispute after completion).
+- `JobNotFound`: non-existent job ID.
+- `TransferFailed`: ERC‑20 `transfer`/`transferFrom` returned false.
+
+## Invariants and constraints
+- Job IDs must exist (`JobNotFound`) before use.
+- Jobs cannot be reassigned after `assignedAgent` is set.
+- Completed jobs cannot be re-completed or re-disputed.
+- Validator approvals and disapprovals are mutually exclusive per validator per job.
+- `maxJobPayout` and `jobDurationLimit` cap job creation inputs.
 
 ## References
 - **Interface reference (ABI-derived)**: [`Interface.md`](Interface.md)

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -5,13 +5,13 @@ This guide documents the deployment and verification workflow defined in `truffl
 ## Prerequisites
 - Node.js and npm (CI uses Node 20).
 - Truffle (installed via `npm install`).
-- RPC access for Sepolia or Mainnet.
+- RPC access for Sepolia or Mainnet (or a local Ganache instance).
 
 ## Environment variables
 
 | Variable | Purpose | Notes |
 | --- | --- | --- |
-| `PRIVATE_KEYS` | Deployer keys | Comma-separated, no spaces. |
+| `PRIVATE_KEYS` | Deployer keys | Comma-separated, no spaces. Required for Sepolia/Mainnet deployments. |
 | `SEPOLIA_RPC_URL` | Sepolia RPC URL | Optional if using Alchemy or Infura. |
 | `MAINNET_RPC_URL` | Mainnet RPC URL | Optional if using Alchemy or Infura. |
 | `ALCHEMY_KEY` | Alchemy key for Sepolia | Used if `SEPOLIA_RPC_URL` is empty. |
@@ -23,10 +23,16 @@ This guide documents the deployment and verification workflow defined in `truffl
 | `SEPOLIA_CONFIRMATIONS` / `MAINNET_CONFIRMATIONS` | Confirmations to wait | Defaults to 2. |
 | `SEPOLIA_TIMEOUT_BLOCKS` / `MAINNET_TIMEOUT_BLOCKS` | Timeout blocks | Defaults to 500. |
 | `RPC_POLLING_INTERVAL_MS` | Provider polling interval | Defaults to 8000 ms. |
-| `SOLC_VERSION` / `SOLC_RUNS` / `SOLC_VIA_IR` / `SOLC_EVM_VERSION` | Compiler settings | Must match deployed bytecode for verification. |
+| `SOLC_VERSION` / `SOLC_RUNS` / `SOLC_VIA_IR` / `SOLC_EVM_VERSION` | Compiler settings | Default `SOLC_VERSION` is 0.8.33; keep these consistent for verification. |
 | `GANACHE_MNEMONIC` | Local test mnemonic | Defaults to Ganache standard mnemonic if unset. |
 
 A template lives in [`.env.example`](../.env.example).
+
+## Networks configured
+- **test**: in-process Ganache provider for `truffle test`.
+- **development**: local RPC at `127.0.0.1:8545` (Ganache).
+- **sepolia**: remote deployment via RPC (HDWalletProvider).
+- **mainnet**: remote deployment via RPC (HDWalletProvider).
 
 ## Migration script notes
 
@@ -70,5 +76,5 @@ npx truffle run verify AGIJobManager --network sepolia
 ## Troubleshooting
 - **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.
 - **Missing private keys**: ensure `PRIVATE_KEYS` is set and comma-separated.
-- **Verification failures**: confirm your compiler version and optimizer settings match the deployed bytecode.
+- **Verification failures**: confirm compiler version, optimizer runs, and `viaIR` settings match the deployed bytecode.
 - **Nonce conflicts**: avoid running multiple deployment processes with the same keys.

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -1,26 +1,32 @@
-# ERC-8004 integration (off-chain)
+# ERC‑8004 integration (off-chain)
 
-This repository keeps AGIJobManager’s escrow and settlement logic fully on-chain and free of any external ERC-8004 dependency. Instead, it provides documentation and off-chain tooling to **bridge AGIJobManager events into ERC-8004 identity + reputation workflows**.
+AGIJobManager keeps escrow and settlement logic fully on-chain and avoids external dependencies in critical flows. ERC‑8004 integration is intentionally **off-chain** in this repository.
 
-## What is ERC-8004?
-ERC-8004 defines an agent identity registry plus a standardized reputation signal format. It enables agents, validators, and external observers to publish reputation artifacts (e.g., success rates, dispute rates, or revenue proxies) in a consistent schema that other systems can consume. For the canonical spec, see the EIP and ERC-8004 best-practices guidance. The contracts repo is linked below. (Assumption: the “best practices” guidance lives in the ERC-8004 spec document.)
+## What is ERC‑8004?
+ERC‑8004 standardizes how agent identity, reputation, and validation signals are published so other systems can index and consume them consistently. See the canonical spec and references:
 
 - EIP: https://eips.ethereum.org/EIPS/eip-8004
-- Best practices (spec doc): https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md
+- ERC document: https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md
 - Reference contracts: https://github.com/erc-8004/erc-8004-contracts
 
-## Why the contract is NOT hardwired to ERC-8004
-AGIJobManager intentionally avoids external contract calls in critical escrow paths. Coupling job completion, dispute resolution, or payouts to an external ERC-8004 registry would introduce **liveness and dependency risks** that could block escrow settlement or allow a third-party registry outage to halt payouts. Therefore, ERC-8004 integration is **strictly off-chain** in this repo.
+## Why AGIJobManager is not hardwired to ERC‑8004
+Coupling escrow settlement to an external registry would introduce **liveness and dependency risks** (e.g., if a registry or indexer is unavailable). AGIJobManager therefore remains a self-contained enforcement layer, while ERC‑8004 operates as a signaling layer.
+
+## Recommended integration pattern (signaling → enforcement)
+1. **Publish trust signals** via ERC‑8004 (identity, reputation, validation outcomes).
+2. **Index and rank** those signals off-chain.
+3. **Translate policy into allowlists** (Merkle roots at deployment, explicit allowlists/blacklists during operation).
+4. **Use AGIJobManager** as the on-chain escrow and settlement anchor.
 
 ## Agent/validator registration guidance
-Agents and validators should register in ERC-8004 using a **registration file** that includes a `services` array (not `endpoints`). A minimal example lives in:
+Agents and validators should register in ERC‑8004 using a registration file that includes a `services` array. A minimal example lives in:
 
 - `integrations/erc8004/examples/registration.json`
 
-Host the registration JSON via HTTPS or IPFS and reference it from the ERC-8004 identity token’s `tokenURI` (or the registry’s metadata field, depending on the specific registry contract you use). Keep URLs stable so watchers can resolve it reliably.
+Host the registration JSON via HTTPS or IPFS and reference it from the ERC‑8004 identity token’s metadata (exact field depends on the registry implementation you use).
 
-## Metrics from AGIJobManager → ERC-8004 signals
-AGIJobManager emits job lifecycle events that can be mapped to reputation metrics. The adapter in `integrations/erc8004/` aggregates these into per-agent metrics, then encodes them as ERC-8004 signals with `value` and `valueDecimals`. **Decimals and negative values are supported** for rate and feedback signals.
+## Metrics from AGIJobManager → ERC‑8004 signals
+AGIJobManager emits job lifecycle events that can be mapped to reputation metrics. The adapter in `integrations/erc8004/` aggregates these into per‑agent metrics, then encodes them as ERC‑8004 signals with `value` and `valueDecimals` (supporting decimals and negative values).
 
 Recommended tag1 examples:
 - `successRate`
@@ -31,13 +37,13 @@ Recommended tag1 examples:
 - `revenues`
 - `ownerVerified`
 
-Concrete encoding examples:
+Encoding examples:
 - successRate 99.80% → `value=9980`, `valueDecimals=2`
 - downvote −1 → `value=-1`, `valueDecimals=0`
 - revenues $556,000 → `value=556000`, `valueDecimals=0`
 
 ## Trusted client set guidance
-For AGIJobManager feedback, a strong eligibility set for “trusted clients” is: **addresses that actually created paid jobs** (derived from `JobCreated` events). This reduces sybil feedback and mirrors real economic participation in the system.
+For AGIJobManager feedback, a strong eligibility set for “trusted clients” is: addresses that actually created paid jobs (derived from `JobCreated` events). This reduces sybil feedback and mirrors real economic participation.
 
 ## Off-chain adapter
 See the adapter README and spec for how events map into metrics and how to export JSON artifacts:

--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -11,10 +11,10 @@ Events to watch:
 - `OwnershipVerified` indicates a successful ownership check.
 - `RecoveryInitiated` indicates an ENS or NameWrapper failure path.
 
-## ERC‑8004 off-chain adapter
+## ERC‑8004 signaling (off-chain)
 AGIJobManager keeps escrow settlement fully on-chain and does **not** depend on any ERC‑8004 contract. The repository provides an off-chain adapter that maps job events into ERC‑8004 reputation signals.
 
-- Adapter documentation: [`docs/ERC8004.md`](ERC8004.md)
+- Integration pattern: [`docs/ERC8004.md`](ERC8004.md)
 - Adapter implementation: [`integrations/erc8004/`](../integrations/erc8004/)
 
 ## Indexing guidance

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation index
 
-Welcome to the AGIJobManager documentation set. Each document is scoped and cross-referenced so integrators, operators, auditors, and contributors can navigate quickly.
+This documentation set targets engineers, integrators, operators, and auditors. Each document has a focused scope with cross-references for faster navigation.
 
 ## Core documentation
 - **Contract specification**: [`AGIJobManager.md`](AGIJobManager.md)
@@ -8,9 +8,9 @@ Welcome to the AGIJobManager documentation set. Each document is scoped and cros
 - **Deployment guide (Truffle)**: [`Deployment.md`](Deployment.md)
 - **Security model and limitations**: [`Security.md`](Security.md)
 
-## Integrations and ecosystem
+## Trust layer & integrations
+- **ERC‑8004 integration (signaling → enforcement)**: [`ERC8004.md`](ERC8004.md)
 - **Integrations overview**: [`Integrations.md`](Integrations.md)
-- **ERC‑8004 off-chain adapter**: [`ERC8004.md`](ERC8004.md)
 
 ## Operations and validation
 - **Regression tests summary**: [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md)

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -2,9 +2,17 @@
 
 This document summarizes security considerations specific to the current `AGIJobManager` contract. It should be read alongside the test suite and interface reference.
 
-## Trust model
-- **Owner powers**: pause or unpause job flows, update token address, thresholds, allowlists and blacklists, add AGI types, update metadata fields, and withdraw ERC‑20 escrow.
+## Threat model overview
+
+**Assets at risk**
+- Escrowed ERC‑20 funds held by the contract.
+- Job NFTs minted on completion.
+- Reputation mappings used for premium access gating.
+
+**Primary trust assumptions**
+- **Owner powers**: can pause flows, update token address, thresholds, allowlists/blacklists, metadata fields, add AGI types, and withdraw ERC‑20 escrow.
 - **Moderator powers**: resolve disputes with arbitrary strings. Only the canonical strings `agent win` and `employer win` trigger on-chain payout or refund.
+- **Validator set**: validators are allowlisted or ENS/Merkle-gated; the contract does not enforce decentralization.
 
 ## Hardened improvements (vs. historical v0)
 The regression suite documents the following safer behaviors in the current contract:
@@ -30,6 +38,7 @@ Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, `pur
 - **ERC‑20 compatibility**: tokens must return a boolean for `transfer` and `transferFrom`.
 - **Agent payout can be zero**: if no AGI type applies, the agent payout percentage is zero and residual funds remain in the contract.
 - **Validator payout sharing**: all validators who voted share equally; there is no weighting or slashing.
+- **Owner-controlled parameters**: thresholds and limits can be changed post-deployment by the owner.
 
 ## Disclosure
 Report security issues privately via [`SECURITY.md`](../SECURITY.md).


### PR DESCRIPTION
### Motivation
- Provide an institutional-grade documentation surface that explains the repository as the on‑chain enforcement layer in a "signaling → enforcement" trust stack while avoiding any claims beyond the code in this repo.
- Clarify roles, lifecycle, integration pattern with ERC‑8004 (off‑chain), deployment steps (Truffle), and security/trust assumptions for integrators, operators, and auditors.
- Keep code changes limited to docs and metadata and explicitly avoid any edits to `contracts/AGIJobManager.sol` as required.

### Description
- Rewrote the repository `README.md` to include an "At a glance" section, the "MONTREAL.AI × ERC‑8004: From signaling → enforcement" framing, two Mermaid diagrams (job lifecycle and full‑stack trust layer), a roles & permissions table, quickstart, and Truffle deployment/verification notes; preserved only provable badges (License, Solidity, Truffle, CI) tied to existing files/workflow.
- Expanded and refreshed the `docs/` set to better match the contract and operational expectations by updating: `docs/README.md`, `docs/AGIJobManager.md` (contract spec, lifecycle, payouts, events, invariants), `docs/Deployment.md` (env vars, networks, migrations), `docs/Security.md` (threat model, reentrancy posture, limitations), `docs/ERC8004.md` (off‑chain integration pattern), and `docs/Integrations.md` (access control and adapter links).
- Kept all changes strictly documentation-only; no changes were made to `contracts/AGIJobManager.sol` or any contract source as required.
- Minor wording adjustments to emphasize the intended off‑chain ERC‑8004 integration pattern (publish → index → generate allowlists → enforce with AGIJobManager), and documented the hardcoded constructor values in `migrations/2_deploy_contracts.js` as a required manual edit before production deployments.

### Testing
- Installed dependencies with `npm install`; installation completed with warnings about deprecated packages and a reported audit result of vulnerabilities (informational only, see `npm audit`).
- Compiled the contracts with `npm run build` (runs `truffle compile`) and observed successful compilation: solc used `0.8.33` and artifacts were written to `build/contracts/`.
- Regenerated interface docs with `npm run docs:interface` which wrote `docs/Interface.md` from `build/contracts/AGIJobManager.json`.
- Ran the test suite with `npm test` (runs `truffle test --network test` and a node test runner) and all automated tests passed (`6 passing`); the regression tests referenced in the repo succeeded.

Files changed/added (high level)
- Modified: `README.md`
- Modified: `docs/README.md`, `docs/AGIJobManager.md`, `docs/Deployment.md`, `docs/Security.md`, `docs/ERC8004.md`, `docs/Integrations.md`

Commands executed (results)
- `npm install` — succeeded with warnings; `npm audit` reported vulnerabilities (see output for details).
- `npm run build` (`truffle compile`) — succeeded, artifacts written; `solc: 0.8.33`.
- `npm run docs:interface` — wrote `docs/Interface.md`.
- `npm test` — succeeded; test suite passed (`6 passing`).

CI / badges
- CI workflow detected at `.github/workflows/ci.yml` and the README includes a CI badge that references the real workflow file.
- License, Solidity, and Truffle badges in the README are provably correct given `LICENSE`, the contract pragma, and `package.json`/`truffle-config.js` usage of Truffle.

Known gaps / next steps
- `migrations/2_deploy_contracts.js` hardcodes constructor parameters and must be edited before any production deployment; this is documented in README and `docs/Deployment.md`.
- The repository intentionally implements ERC‑8004 only as an off‑chain integration pattern and does not add on‑chain ERC‑8004 contracts (documented prominently).
- `npm install` reported dependency deprecation warnings and security advisories; consider dependency upgrades in a separate, targeted follow-up.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a2adf79f4833388e7e5d35ec35bb6)