### PR TITLE
docs: institutionalize README and docs set

### DIFF
--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -5,20 +5,21 @@ This document describes the on-chain behavior of `AGIJobManager` as implemented 
 ## Contents
 - [Overview](#overview)
 - [Roles and permissions](#roles-and-permissions)
+- [Core data structures](#core-data-structures)
 - [Lifecycle state machine](#lifecycle-state-machine)
-- [State variables and flags](#state-variables-and-flags)
 - [Escrow and payout mechanics](#escrow-and-payout-mechanics)
 - [Validation and dispute flow](#validation-and-dispute-flow)
 - [Reputation mechanics](#reputation-mechanics)
 - [Eligibility and identity checks](#eligibility-and-identity-checks)
 - [NFT issuance and marketplace](#nft-issuance-and-marketplace)
+- [Reward pool contributions](#reward-pool-contributions)
 - [Events](#events)
 - [Error handling](#error-handling)
 - [Invariants and constraints](#invariants-and-constraints)
 - [References](#references)
 
 ## Overview
-AGIJobManager coordinates employer-funded jobs, agent assignment, validator review, dispute resolution, reputation updates, and job NFT issuance. The contract holds ERC‑20 escrow for job payouts and mints an ERC‑721 to the employer when a job completes.
+AGIJobManager coordinates employer-funded jobs, agent assignment, validator review, dispute resolution, reputation updates, and job NFT issuance. It escrows ERC‑20 payouts and mints an ERC‑721 to the employer when a job completes successfully.
 
 ## Roles and permissions
 | Role | Capabilities |
@@ -31,6 +32,26 @@ AGIJobManager coordinates employer-funded jobs, agent assignment, validator revi
 
 Refer to the ABI-derived access map in [`Interface.md`](Interface.md).
 
+## Core data structures
+
+### Job
+Each job is a struct containing:
+- `id`, `employer`, `ipfsHash`, `payout`, `duration`, `assignedAgent`, `assignedAt`, `details`.
+- State flags: `completed`, `completionRequested`, `disputed`.
+- Validation: `validatorApprovals`, `validatorDisapprovals`, per-validator `approvals` and `disapprovals`, plus the `validators` list.
+
+Job entries are created in `createJob` and stored in `jobs(jobId)`.
+
+### AGI types
+`AGIType` entries map ERC‑721 collections to a payout percentage used for agent rewards. The agent’s **highest** applicable percentage is used to compute payouts.
+
+### Listings
+`Listing` entries represent non-escrowed job NFT listings (tokenId, seller, price, isActive). The NFT remains in the seller’s wallet until purchase.
+
+### Read-only helpers
+- `getJobStatus(jobId)` returns `(completed, completionRequested, ipfsHash)` for lightweight polling.
+- `jobs(jobId)` returns the fixed fields of the `Job` struct (it omits the internal validator list and per-validator mappings).
+
 ## Lifecycle state machine
 
 ```mermaid
@@ -39,50 +60,38 @@ stateDiagram-v2
     Created --> Assigned: applyForJob
     Assigned --> CompletionRequested: requestJobCompletion
 
-    Assigned --> Validated: validateJob (threshold)
-    CompletionRequested --> Validated: validateJob (threshold)
-    Validated --> Completed: _completeJob
+    Assigned --> Finalized: validateJob (threshold)
+    CompletionRequested --> Finalized: validateJob (threshold)
 
     Assigned --> Disputed: disputeJob
     CompletionRequested --> Disputed: disputeJob
     Assigned --> Disputed: disapproveJob (threshold)
     CompletionRequested --> Disputed: disapproveJob (threshold)
 
-    Disputed --> Completed: resolveDispute('agent win')
-    Disputed --> Resolved: resolveDispute('employer win')
-    Disputed --> Resolved: resolveDispute(other)
+    Disputed --> Finalized: resolveDispute("agent win")
+    Disputed --> Finalized: resolveDispute("employer win")
+    Disputed --> Assigned: resolveDispute(other)
 
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
 
-## State variables and flags
-Job state is encoded in the following fields:
-- `assignedAgent` and `assignedAt` indicate assignment.
-- `completionRequested` flips to true when the agent submits a completion request.
-- `validatorApprovals` and `validatorDisapprovals` track votes.
-- `disputed` and `completed` represent terminal or contested outcomes.
-
-These flags are observable via the public `jobs(jobId)` getter and lifecycle events.
-
-### Read-only helpers
-- `getJobStatus(jobId)` returns `(completed, completionRequested, ipfsHash)` for lightweight polling.
-- `jobs(jobId)` returns the fixed fields of the `Job` struct (it omits the internal validator list and approval mappings).
+**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDispute(other)` clears the dispute while preserving the in‑progress flags (for example, `completionRequested` remains set if it was set before the dispute).
 
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.
 - **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is the highest AGI type percentage owned by the agent (may be zero).
-- **Validator payout**: if validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
+- **Validator payout**: when validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
 - **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner.
-- **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with employer win refunds and closes the job.
+- **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with `employer win` refunds and finalizes the job.
 
 ## Validation and dispute flow
-- `validateJob` increments approval count, records validator participation, and auto-completes when approvals reach the required threshold.
-- `disapproveJob` increments disapproval count, records validator participation, and flips `disputed` when disapprovals reach the required threshold.
+- `validateJob` increments approval count, records validator participation, and auto‑completes when approvals reach the required threshold.
+- `disapproveJob` increments disapproval count, records participation, and flips `disputed` when disapprovals reach the required threshold.
 - `disputeJob` can be called by employer or assigned agent (if not already disputed or completed).
-- `resolveDispute` accepts any resolution string but only two canonical strings trigger on-chain actions:
+- `resolveDispute` accepts any resolution string, but only two canonical strings trigger on-chain actions:
   - `agent win` → `_completeJob`
-  - `employer win` → employer refund + job closed
+  - `employer win` → employer refund + `completed = true`
 
 ## Reputation mechanics
 - **Agent reputation**: derived from payout and completion time via `calculateReputationPoints`, then stored through `enforceReputationGrowth` (diminishing returns with a cap).
@@ -101,12 +110,16 @@ If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for obs
 - **Listings**: NFT owners can list tokens without escrow; listings live in the `listings` mapping.
 - **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT.
 
+## Reward pool contributions
+`contributeToRewardPool` allows any address to transfer ERC‑20 into the contract. These funds increase the contract’s balance and are withdrawable by the owner via `withdrawAGI`.
+
 ## Events
 High-signal events to index:
 - **Lifecycle**: `JobCreated`, `JobApplied`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `DisputeResolved`, `JobCompleted`, `JobCancelled`.
 - **Reputation**: `ReputationUpdated` (agents and validators).
 - **NFT marketplace**: `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`.
-- **Access signals**: `OwnershipVerified`, `RecoveryInitiated`.
+- **Access signals**: `OwnershipVerified`, `RecoveryInitiated`. (`RootNodeUpdated` and `MerkleRootUpdated` are defined but not emitted by current functions.)
+- **Other**: `AGITypeUpdated`, `RewardPoolContribution`.
 
 See [`Interface.md`](Interface.md) for the complete ABI-derived list.
 
@@ -126,6 +139,7 @@ Custom errors and their intent:
 - Completed jobs cannot be re-completed or re-disputed.
 - Validator approvals and disapprovals are mutually exclusive per validator per job.
 - `maxJobPayout` and `jobDurationLimit` cap job creation inputs.
+- Root nodes and Merkle roots are immutable after deployment (no setters).
 
 ## References
 - **Interface reference (ABI-derived)**: [`Interface.md`](Interface.md)

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -9,6 +9,8 @@ This guide documents the deployment and verification workflow defined in `truffl
 
 ## Environment variables
 
+The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS` is required for Sepolia/Mainnet deployments.
+
 | Variable | Purpose | Notes |
 | --- | --- | --- |
 | `PRIVATE_KEYS` | Deployer keys | Comma-separated, no spaces. Required for Sepolia/Mainnet deployments. |
@@ -36,7 +38,7 @@ A template lives in [`.env.example`](../.env.example).
 
 ## Migration script notes
 
-The deployment script in `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token address, ENS addresses, root nodes, Merkle roots). **Edit these values** before deploying to any production network.
+The deployment script in `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token address, ENS registry, NameWrapper address, root nodes, Merkle roots). **Edit these values** before deploying to any production network.
 
 ## Local deployment (Ganache)
 
@@ -72,6 +74,11 @@ When `ETHERSCAN_API_KEY` is set:
 ```bash
 npx truffle run verify AGIJobManager --network sepolia
 ```
+
+### Verification tips
+- Keep the compiler settings (`SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`) identical to the original deployment.
+- Ensure your migration constructor parameters match the deployed contract.
+- If the Etherscan plugin fails, re-run with `--debug` to capture full output.
 
 ## Troubleshooting
 - **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -1,9 +1,9 @@
-# ERC‑8004 integration (off-chain)
+# ERC‑8004 integration (signaling → enforcement)
 
-AGIJobManager keeps escrow and settlement logic fully on-chain and avoids external dependencies in critical flows. ERC‑8004 integration is intentionally **off-chain** in this repository.
+AGIJobManager keeps escrow and settlement logic fully on‑chain and avoids external dependencies in critical flows. ERC‑8004 integration is intentionally **off‑chain** in this repository.
 
 ## What is ERC‑8004?
-ERC‑8004 standardizes how agent identity, reputation, and validation signals are published so other systems can index and consume them consistently. See the canonical spec and references:
+ERC‑8004 standardizes how agent identity, reputation, and validation signals are published so other systems can index and consume them consistently.
 
 - EIP: https://eips.ethereum.org/EIPS/eip-8004
 - ERC document: https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md
@@ -12,11 +12,18 @@ ERC‑8004 standardizes how agent identity, reputation, and validation signals a
 ## Why AGIJobManager is not hardwired to ERC‑8004
 Coupling escrow settlement to an external registry would introduce **liveness and dependency risks** (e.g., if a registry or indexer is unavailable). AGIJobManager therefore remains a self-contained enforcement layer, while ERC‑8004 operates as a signaling layer.
 
-## Recommended integration pattern (signaling → enforcement)
+## Recommended integration pattern (no contract changes required)
 1. **Publish trust signals** via ERC‑8004 (identity, reputation, validation outcomes).
-2. **Index and rank** those signals off-chain.
+2. **Index and rank** those signals off‑chain.
 3. **Translate policy into allowlists** (Merkle roots at deployment, explicit allowlists/blacklists during operation).
-4. **Use AGIJobManager** as the on-chain escrow and settlement anchor.
+4. **Use AGIJobManager** as the on‑chain escrow and settlement anchor.
+
+## How to combine ERC‑8004 and AGIJobManager in practice
+A practical workflow without contract changes:
+- Publish ERC‑8004 identity and reputation updates for agents and validators.
+- Run an indexer/ranker that produces a trusted set based on those signals.
+- Encode the trusted set into the Merkle roots used at deployment, or add addresses to `additionalAgents` / `additionalValidators`.
+- Use AGIJobManager to enforce payouts, refunds, and reputation updates.
 
 ## Agent/validator registration guidance
 Agents and validators should register in ERC‑8004 using a registration file that includes a `services` array. A minimal example lives in:
@@ -25,7 +32,7 @@ Agents and validators should register in ERC‑8004 using a registration file th
 
 Host the registration JSON via HTTPS or IPFS and reference it from the ERC‑8004 identity token’s metadata (exact field depends on the registry implementation you use).
 
-## Metrics from AGIJobManager → ERC‑8004 signals
+## Mapping AGIJobManager events to ERC‑8004 signals
 AGIJobManager emits job lifecycle events that can be mapped to reputation metrics. The adapter in `integrations/erc8004/` aggregates these into per‑agent metrics, then encodes them as ERC‑8004 signals with `value` and `valueDecimals` (supporting decimals and negative values).
 
 Recommended tag1 examples:
@@ -45,7 +52,7 @@ Encoding examples:
 ## Trusted client set guidance
 For AGIJobManager feedback, a strong eligibility set for “trusted clients” is: addresses that actually created paid jobs (derived from `JobCreated` events). This reduces sybil feedback and mirrors real economic participation.
 
-## Off-chain adapter
+## Off‑chain adapter
 See the adapter README and spec for how events map into metrics and how to export JSON artifacts:
 
 - `integrations/erc8004/README.md`

--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -1,21 +1,22 @@
 # Integrations overview
 
-This document summarizes integration points for AGIJobManager, including allowlist checks and off-chain reputation tooling.
+This document summarizes integration points for AGIJobManager, including role gating and off‑chain reputation tooling.
 
 ## Access control integrations
-- **Merkle allowlists**: agents and validators can be authorized by Merkle proofs over their address.
+- **Merkle allowlists**: agents and validators can be authorized by Merkle proofs over their address (`agentMerkleRoot`, `validatorMerkleRoot`).
 - **ENS ownership checks**: `_verifyOwnership` attempts NameWrapper and resolver lookups for a subdomain under the configured root node.
 - **Explicit allowlists**: the owner can add or remove `additionalAgents` and `additionalValidators` to bypass Merkle or ENS checks.
+- **Explicit blacklists**: the owner can blacklist agents or validators to block participation.
 
 Events to watch:
 - `OwnershipVerified` indicates a successful ownership check.
 - `RecoveryInitiated` indicates an ENS or NameWrapper failure path.
 
-## ERC‑8004 signaling (off-chain)
-AGIJobManager keeps escrow settlement fully on-chain and does **not** depend on any ERC‑8004 contract. The repository provides an off-chain adapter that maps job events into ERC‑8004 reputation signals.
+## ERC‑8004 signaling (off‑chain)
+AGIJobManager keeps escrow settlement fully on‑chain and does **not** depend on any ERC‑8004 contract. The repository provides an off‑chain adapter that maps job events into ERC‑8004 reputation signals.
 
 - Integration pattern: [`docs/ERC8004.md`](ERC8004.md)
 - Adapter implementation: [`integrations/erc8004/`](../integrations/erc8004/)
 
 ## Indexing guidance
-Indexers should prioritize job lifecycle events and NFT issuance events (see `docs/Interface.md` for the canonical list). Most job events are not indexed; downstream systems should scan by block range and store their own derived indices.
+Indexers should prioritize job lifecycle events and NFT issuance events (see [`docs/Interface.md`](Interface.md) for the canonical list). Most job events are not indexed; downstream systems should scan by block range and store their own derived indices.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,6 +1,6 @@
 # Documentation index
 
-This documentation set targets engineers, integrators, operators, and auditors. Each document has a focused scope with cross-references for faster navigation.
+This documentation set targets engineers, integrators, operators, and auditors. Each document has a focused scope with cross-references for faster navigation and auditability.
 
 ## Core documentation
 - **Contract specification**: [`AGIJobManager.md`](AGIJobManager.md)
@@ -21,5 +21,6 @@ This documentation set targets engineers, integrators, operators, and auditors. 
 The interface reference is generated from the compiled ABI. After running a compile, regenerate it with:
 
 ```bash
+npm run build
 node scripts/generate-interface-doc.js
 ```

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -12,7 +12,7 @@ This document summarizes security considerations specific to the current `AGIJob
 **Primary trust assumptions**
 - **Owner powers**: can pause flows, update token address, thresholds, allowlists/blacklists, metadata fields, add AGI types, and withdraw ERC‑20 escrow.
 - **Moderator powers**: resolve disputes with arbitrary strings. Only the canonical strings `agent win` and `employer win` trigger on-chain payout or refund.
-- **Validator set**: validators are allowlisted or ENS/Merkle-gated; the contract does not enforce decentralization.
+- **Validator set**: validators are allowlisted or ENS/Merkle‑gated; the contract does not enforce decentralization.
 
 ## Hardened improvements (vs. historical v0)
 The regression suite documents the following safer behaviors in the current contract:


### PR DESCRIPTION
### Motivation
- Provide an institutional-grade, accurate, and auditable documentation surface for AGIJobManager that clearly communicates intent, architecture, and operational guidance. 
- Clarify the project framing as a "Full‑Stack Trust Layer for AI Agents" that pairs off‑chain ERC‑8004 signaling with on‑chain enforcement without implying unimplemented on‑chain features. 
- Surface actionable deployment, verification, and security guidance so integrators and operators can safely compile, test, and deploy the contract.

### Description
- Overhauled the root `README.md` with full‑stack trust layer framing, mermaid diagrams for job lifecycle and trust flow, explicit "What it is / is not" sections, role/permission mapping, quickstart, and deployment guidance. 
- Updated and tightened the `docs/` set: `docs/README.md`, `docs/AGIJobManager.md`, `docs/Deployment.md`, `docs/Security.md`, `docs/ERC8004.md`, and `docs/Integrations.md` to reflect the actual contract behavior and recommended off‑chain integration patterns. 
- Regenerated the interface reference via `node scripts/generate-interface-doc.js` and left all contract sources untouched per constraint (no edits to `contracts/AGIJobManager.sol`). 
- Kept only provable badges (license badge from `LICENSE`, Solidity link to the contract file, Truffle badge because Truffle is in `package.json`, and CI badge pointing to `.github/workflows/ci.yml`) and added clarifying notes about immutable roots and the migration script hardcoded constructor parameters.

### Testing
- Installed dependencies with `npm install` (completed with dependency warnings and `85 vulnerabilities` reported by `npm`; these are third‑party package warnings and not changes to the contract). 
- Compiled with `npm run build` which invokes `truffle compile` and successfully compiled artifacts using `solc 0.8.33` (contract `pragma ^0.8.17` remains unchanged and compatible). 
- Ran the test suite with `npm test` which executed `truffle test --network test` and the local JS test runner; all regression tests passed (6 passing) and an ABI smoke test succeeded. 
- Regenerated docs interface with `npm run docs:interface` which wrote `docs/Interface.md`; CI workflow was discovered at `.github/workflows/ci.yml` and the CI badge in `README.md` references that workflow.

Files changed/added (high level): `README.md`, `docs/README.md`, `docs/AGIJobManager.md`, `docs/Deployment.md`, `docs/Security.md`, `docs/ERC8004.md`, `docs/Integrations.md`, plus regenerated `docs/Interface.md`.

Known gaps / next steps: update `migrations/2_deploy_contracts.js` constructor parameters before any production deployment; evaluate `npm audit` findings and remediate third‑party dependency vulnerabilities as a repo maintenance task; consider adding automated interface regeneration to CI if desired.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697a311ce6988333aa3aa6f7d4260dbc)