### PR TITLE
docs: add Etherscan screenshot placeholders and clarify Truffle testing flow

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing Guide
 
-This repository uses Truffle with an in‑process Ganache provider (see `truffle-config.js`). The default test run spins up a local chain automatically.
+This repository uses Truffle with an in‑process Ganache provider (see `truffle-config.js`). Use the `test` network to run against the in‑process chain, or run Ganache locally for the `development` network.
 
 ## Install dependencies
 ```bash
@@ -12,15 +12,20 @@ npm install
 npx truffle compile
 ```
 
-## Run all tests
+## Run all tests (in‑process provider)
 ```bash
-npx truffle test
+npx truffle test --network test
 ```
 
 ## Run against a local Ganache instance
 ```bash
 npx ganache -p 8545
 npx truffle test --network development
+```
+
+## Run all tests (development default)
+```bash
+npx truffle test
 ```
 
 ## ENS / NameWrapper mocks

--- a/docs/TEST_STATUS.md
+++ b/docs/TEST_STATUS.md
@@ -1,0 +1,20 @@
+# Test Status
+
+## Failing command
+- `npx truffle test`
+
+## Error output
+```
+> Something went wrong while attempting to connect to the network at http://127.0.0.1:8545. Check your network configuration.
+CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545.
+Truffle v5.11.5 (core: 5.11.5)
+Node v20.19.6
+```
+
+## Root cause
+`truffle test` defaults to the `development` network (localhost:8545). No Ganache node was running at that address in this environment.
+
+## Smallest fix required
+Either:
+1. Run a local node: `npx ganache -p 8545`, then re-run `npx truffle test`, **or**
+2. Use the in-process provider: `npx truffle test --network test`.

--- a/docs/roles/AGENT.md
+++ b/docs/roles/AGENT.md
@@ -9,6 +9,7 @@ You must satisfy **one** of these:
 3. **additionalAgents** allowlist (owner‑managed).
 
 ## Step‑by‑step (non‑technical)
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `applyForJob` inputs filled in.
 ### 1) Confirm your identity method
 - If using ENS/NameWrapper: ensure the contract’s root node and your subdomain are correct.
 - If using a Merkle allowlist: get your proof from the operator.

--- a/docs/roles/EMPLOYER.md
+++ b/docs/roles/EMPLOYER.md
@@ -8,6 +8,7 @@ This guide is for job posters (employers). It shows how to safely create and man
 - Confidence that the AGI token address is correct.
 
 ## Step‑by‑step (non‑technical)
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `createJob` inputs filled in.
 ### 1) Approve escrow amount
 Use your wallet or Etherscan to approve **only the exact payout amount**.
 

--- a/docs/roles/MODERATOR.md
+++ b/docs/roles/MODERATOR.md
@@ -10,6 +10,7 @@ The contract only triggers actions for **exactly** these strings:
 Any other string will **only** emit a `DisputeResolved` event and close the dispute without payouts.
 
 ## Step‑by‑step (non‑technical)
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `resolveDispute` inputs filled in.
 1. Confirm the job is disputed (look for the `JobDisputed` event).
 2. Call `resolveDispute(jobId, resolution)` with the exact string above.
 3. Verify the `DisputeResolved` event.

--- a/docs/roles/NFT_MARKETPLACE.md
+++ b/docs/roles/NFT_MARKETPLACE.md
@@ -3,6 +3,7 @@
 AGIJobManager mints an NFT receipt to the employer when a job completes. This NFT can be listed and sold using the built‑in marketplace.
 
 ## Step‑by‑step (non‑technical)
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `listNFT` inputs filled in.
 ### 1) List an NFT
 Call `listNFT(tokenId, price)` from the wallet that owns the NFT.
 - `price` is in AGI token wei.

--- a/docs/roles/OWNER_OPERATOR.md
+++ b/docs/roles/OWNER_OPERATOR.md
@@ -10,6 +10,7 @@ This guide covers administrative operations and safety controls.
 - Withdraw escrowed AGI funds when appropriate.
 
 ## Administrative actions
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `pause`/`unpause` actions.
 ### Pause / unpause
 - `pause()` stops most user actions.
 - `unpause()` restores normal operations.

--- a/docs/roles/VALIDATOR.md
+++ b/docs/roles/VALIDATOR.md
@@ -9,6 +9,7 @@ You must satisfy **one** of these:
 3. **additionalValidators** allowlist (owner‑managed).
 
 ## Step‑by‑step (non‑technical)
+> **Screenshot placeholder:** Etherscan “Write Contract” tab showing `validateJob` inputs filled in.
 ### 1) Validate a job
 Call `validateJob(jobId, subdomain, proof)`.
 


### PR DESCRIPTION
### Motivation
- Make role guides more friendly for non‑technical users by showing exactly where to call contract methods via Etherscan UI. 
- Clarify how to run the Truffle test suite reliably (in‑process provider vs local Ganache) and capture the default-network failure so contributors are not confused.

### Description
- Added Etherscan "Screenshot placeholder" lines to the non‑technical guides for Employer, Agent, Validator, Moderator, Owner/Operator, and NFT Marketplace to show where to use the Etherscan Write UI. (`docs/roles/EMPLOYER.md`, `docs/roles/AGENT.md`, `docs/roles/VALIDATOR.md`, `docs/roles/MODERATOR.md`, `docs/roles/OWNER_OPERATOR.md`, `docs/roles/NFT_MARKETPLACE.md`).
- Updated `docs/TESTING.md` to recommend `--network test` (in‑process Ganache provider) and to document running a local Ganache instance for the `development` network. (`docs/TESTING.md`).
- Added `docs/TEST_STATUS.md` documenting the observed `npx truffle test` failure when no local Ganache is running and the minimal remediation (run Ganache or use `--network test`). (`docs/TEST_STATUS.md`).

### Testing
- Ran `npm install` which completed successfully (audit warnings reported but not blocking). 
- Ran `npx truffle compile` which completed successfully and produced build artifacts. 
- Ran `npx truffle test` (default) which failed with a connection error to `http://127.0.0.1:8545` because no Ganache node was running; this failure is documented in `docs/TEST_STATUS.md`. 
- Ran `npx truffle test --network test` (in‑process Ganache provider) which succeeded: the test run completed with `60 passing` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697aad5ecb0c83339f7705274d36dac1)