### PR TITLE
Docs: institutional documentation overhaul — ERC‑8004 framing & operational guides

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,23 @@
+# Code of Conduct
+
+We are committed to providing a friendly, safe, and welcoming environment for all contributors.
+
+## Our standards
+Examples of behavior that contributes to a positive environment include:
+- Being respectful and considerate in speech and actions.
+- Giving and receiving constructive feedback.
+- Focusing on what is best for the community.
+
+Examples of unacceptable behavior include:
+- Harassment or discrimination in any form.
+- Trolling, insulting comments, or personal attacks.
+- Publishing others' private information without permission.
+
+## Enforcement
+Project maintainers may take appropriate corrective action in response to any behavior that violates this Code of Conduct.
+
+## Scope
+This Code of Conduct applies within project spaces and in public spaces when an individual is representing the project or community.
+
+## Reporting
+To report an incident, please open a GitHub issue requesting a private channel or follow [`SECURITY.md`](SECURITY.md) for sensitive issues.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,31 @@
+# Contributing to AGIJobManager
+
+Thanks for your interest in contributing. This repository is security-sensitive and contract changes must be reviewed with extra rigor.
+
+## Ground rules
+- Be respectful and professional.
+- Keep changes minimal and well-scoped.
+- Do not add or modify `contracts/AGIJobManager.sol` unless explicitly requested and reviewed.
+
+## Development workflow
+1. **Install dependencies**
+   ```bash
+   npm install
+   ```
+2. **Compile**
+   ```bash
+   npm run build
+   ```
+3. **Test**
+   ```bash
+   npm test
+   ```
+
+## Documentation changes
+Documentation improvements are welcome. Please:
+- Keep claims factual and verifiable.
+- Avoid adding claims about deployments or audits without evidence.
+- Update references in `docs/` when editing core docs.
+
+## Security issues
+Please do **not** report vulnerabilities in public issues. Follow the guidance in [`SECURITY.md`](SECURITY.md).

--- a/README.md
+++ b/README.md
@@ -1,58 +1,42 @@
 # AGIJobManager
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Solidity](https://img.shields.io/badge/solidity-%5E0.8.17-363636.svg)](contracts/AGIJobManager.sol)
+[![Solidity](https://img.shields.io/badge/solidity-0.8.33-363636.svg)](contracts/AGIJobManager.sol)
 [![Truffle](https://img.shields.io/badge/truffle-5.x-3fe0c5.svg)](https://trufflesuite.com/)
 [![CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml)
 
-**AGIJobManager** is an on-chain job escrow and settlement contract for agent–employer workflows with validator review, dispute resolution, reputation updates, job NFT issuance, and a simple NFT listing/purchase flow.
+**AGIJobManager** is MONTREAL.AI’s on-chain enforcement layer for agent–employer workflows: validator-gated job escrow, payouts, dispute resolution, and reputation tracking, with ENS/Merkle role gating and an ERC‑721 job NFT marketplace. It is the *enforcement* half of a “Full‑Stack Trust Layer for AI Agents.”
 
-> **Warning**: This is an experimental research system. Treat deployments as high-risk until you have completed independent security review and operational readiness checks.
+> **Status / Caution**: Experimental research software. Treat deployments as high-risk until you have performed independent security review, validated parameters, and ensured operational readiness.
 
-## Quick links
-- **Contract source**: [`contracts/AGIJobManager.sol`](contracts/AGIJobManager.sol)
-- **How to deploy**: [Deployment](#deployment-truffle)
-- **How to test**: [Testing](#testing)
-- **Security**: [Security considerations](#security-considerations)
-- **Historical v0 deployment (mainnet)**: https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477
-- **Docs index**: [`docs/README.md`](docs/README.md)
-
-## What it is / What it isn’t
+## At a glance
 
 **What it is**
-- **Job escrow + workflow engine**: employers escrow ERC-20 payouts; agents apply and are assigned; validators approve/disapprove; moderators resolve disputes. The contract enforces payouts/refunds and updates reputation on completion.
-- **Reputation tracking**: on-chain reputation points for agents and validators based on job outcomes.
-- **Job NFT issuance + marketplace**: successful completion mints an ERC-721 “job NFT” to the employer; those job NFTs can be listed and purchased in a simple, contract-native listing flow.
-- **Eligibility gating**: agent/validator eligibility is determined by explicit allowlists plus Merkle proofs and ENS/NameWrapper/Resolver ownership checks.
+- **Job escrow & settlement engine**: employer-funded jobs, agent assignment, validator approvals/disapprovals, moderator dispute resolution, payouts/refunds. 
+- **Reputation mapping**: on-chain reputation updates for agents and validators derived from job outcomes. 
+- **Job NFT issuance + listings**: mints an ERC‑721 “job NFT” on completion and supports a minimal listing/purchase flow for those NFTs.
+- **Trust gating**: role eligibility enforced via explicit allowlists, Merkle proofs, and ENS/NameWrapper/Resolver ownership checks.
 
-**What it isn’t**
-- **Not a full identity registry**: identity is gated by ENS and Merkle allowlists only; no global identity or reputation registry is included.
-- **Not a generalized NFT marketplace**: listings are limited to job NFTs minted by this contract.
-- **Not a decentralized court**: moderators have authority to resolve disputes and the owner has significant administrative power.
+**What it is NOT**
+- **Not an on-chain ERC‑8004 implementation**: ERC‑8004 is consumed off-chain; this repo does not integrate it on-chain.
+- **Not a generalized identity or reputation registry**: only contract-local reputation mappings and ENS/Merkle gating are provided.
+- **Not a generalized NFT marketplace**: listings are only for job NFTs minted by this contract.
+- **Not a decentralized court**: moderators and the owner have significant authority.
 
-## Key concepts
+## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
-### Roles
-- **Owner**: pauses/unpauses, updates parameters and metadata, manages allowlists/blacklists, adds moderators and AGI types, withdraws escrowed ERC-20.
-- **Moderator**: resolves disputes via `resolveDispute` (only canonical resolutions trigger payouts/refunds).
-- **Employer**: creates and funds jobs, can cancel before assignment, can dispute jobs, receives job NFTs.
-- **Agent**: applies for jobs, requests completion, earns payouts and reputation.
-- **Validator**: approves/disapproves jobs, earns payout share and reputation for participation.
+**ERC‑8004** standardizes *trust signals* (identity, reputation, validation outcomes) for off-chain publication and indexing. **AGIJobManager** enforces *settlement* (escrow, payouts, dispute resolution, reputation updates) on-chain.
 
-### Assets & value flows
-- **ERC-20 token (configured at deployment; called `agiToken` in code)**: escrowed on job creation and used for payouts, validator rewards, and NFT purchases.
-- **Job NFTs (ERC-721)**: minted to the employer on successful completion, with token URI derived from the job’s IPFS hash.
-- **AGIType NFTs**: external ERC-721 collections mapped to payout percentages; the highest owned percentage determines agent payout.
-- **Listings marketplace**: sellers list job NFTs without escrow; purchases transfer ERC-20 from buyer to seller and transfer the NFT.
+**Recommended integration pattern (no contract changes required)**
+1. **Publish trust signals** using ERC‑8004 (identity, reputation, validation outcomes).
+2. **Index/rank/watch off-chain** with a trust policy specific to your domain.
+3. **Translate policy into allowlists** (Merkle roots at deployment, explicit allowlists/blacklists during operation).
+4. **Use AGIJobManager** as the enforcement/settlement anchor.
 
-### Authorization sources
-- **Merkle allowlists** for agents and validators.
-- **ENS / NameWrapper / Resolver** ownership checks as a fallback path.
-- **Explicit allowlists / blacklists** controlled by the owner.
+**Implemented here**: validator-gated escrow, dispute resolution, reputation mapping, ENS/Merkle role gating, and job NFT issuance. 
+**Not implemented here**: any on-chain ERC‑8004 registry or trust-signal processing.
 
-If a Merkle proof fails, the contract tries NameWrapper ownership and then ENS resolver lookup; failures emit `RecoveryInitiated` to aid off-chain monitoring.
-
-## Architecture & illustrations
+## Architecture + illustrations
 
 ### Job lifecycle (state machine)
 ```mermaid
@@ -69,88 +53,65 @@ stateDiagram-v2
     Assigned --> Disputed: disputeJob (manual)
     CompletionRequested --> Disputed: disputeJob (manual)
 
-    Disputed --> Resolved: resolveDispute
-    Resolved --> Completed: agent win / employer win
-    Resolved --> Assigned: other resolution
+    Disputed --> Completed: resolveDispute("agent win")
+    Disputed --> Completed: resolveDispute("employer win")
+    Disputed --> Assigned: resolveDispute(other)
 
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
 
-**State fields that change during the lifecycle**
-- `assignedAgent`, `assignedAt`
-- `completionRequested`
-- `validatorApprovals`, `validatorDisapprovals`, per-validator approval/disapproval mappings
-- `disputed`, `completed`
-
-### Enforcement + identity architecture (on-chain / off-chain)
+### Full‑stack trust layer (signaling → enforcement)
 ```mermaid
 flowchart LR
-    subgraph Off-chain signals
+    subgraph Off-chain signaling
         A[Agents, Validators, Observers] --> B[ERC-8004 signals]
-        B --> C[Indexers and rankers]
-        C --> D[Policy decisions<br/>allowlists and trust tiers]
+        B --> C[Indexers / Rankers]
+        C --> D[Policy decisions<br/>allowlists, trust tiers]
     end
 
-    D -->|Merkle roots and allowlists| E[AGIJobManager contract]
+    D -->|Merkle roots & allowlists| E[AGIJobManager contract]
     E <-->|ENS + NameWrapper + Resolver| F[ENS contracts]
     E --> G[Escrow, payouts,<br/>reputation, job NFTs]
 ```
 
-## Contract interface summary (high level)
+## Roles & permissions
 
-| Function | Typical caller | Purpose | Key preconditions | Major side effects |
-| --- | --- | --- | --- | --- |
-| `createJob` | Employer | Create a job and escrow payout | `payout > 0`, `duration > 0`, within limits | Transfers ERC-20 into escrow, stores job | 
-| `applyForJob` | Agent | Assign agent to a job | Job exists and unassigned; agent allowlisted or passes ownership check | Sets `assignedAgent`, `assignedAt` |
-| `requestJobCompletion` | Assigned agent | Request completion and update IPFS hash | Agent assigned; still within job duration | Sets `completionRequested`, updates `ipfsHash` |
-| `validateJob` | Validator | Approve job completion | Validator allowlisted/verified; not already voted | Records approval; completes job on threshold |
-| `disapproveJob` | Validator | Disapprove job completion | Validator allowlisted/verified; not already voted | Records disapproval; marks `disputed` on threshold |
-| `disputeJob` | Employer or agent | Open dispute manually | Job not completed; caller is employer or assigned agent | Sets `disputed = true` |
-| `resolveDispute` | Moderator | Resolve dispute | Job is disputed | For `agent win` completes job; for `employer win` refunds and finalizes; clears `disputed` |
-| `cancelJob` | Employer | Cancel before assignment | Caller is employer; job unassigned and not completed | Refunds escrow; deletes job |
-| `delistJob` | Owner | Cancel before assignment | Job unassigned and not completed | Refunds escrow; deletes job |
-| `listNFT` / `purchaseNFT` / `delistNFT` | NFT owner / buyer | List and trade job NFTs | Listing active for purchase; owner-only for list/delist | Transfers ERC-20 and NFT on purchase |
-| `addAGIType` | Owner | Register payout boost NFTs | `nftAddress` non-zero; percentage in (0,100] | Updates AGIType table |
-| `getJobStatus` | Anyone | Lightweight job polling | Job exists | Returns `completed`, `completionRequested`, and `ipfsHash` |
-| `canAccessPremiumFeature` | Anyone | Check premium gating | None | Returns true if reputation ≥ threshold |
-| `withdrawAGI` | Owner | Withdraw ERC-20 from contract | `amount > 0` and `amount <= balance` | Transfers ERC-20 to owner |
-| `contributeToRewardPool` | Any | Add ERC-20 to contract | `amount > 0` | Transfers ERC-20 into contract |
+| Role | Capabilities | Trust considerations |
+| --- | --- | --- |
+| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw escrowed ERC‑20. | Highly privileged. Compromise or misuse can override operational safety. |
+| **Moderator** | Resolve disputes via `resolveDispute`. | Central dispute authority; outcomes depend on moderator integrity. |
+| **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
+| **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
+| **Validator** | Approve/disapprove jobs, earn payout share and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
 
-### Events to index
-High-signal events for indexers and analytics:
-- **Lifecycle**: `JobCreated`, `JobApplied`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `DisputeResolved`, `JobCompleted`, `JobCancelled`.
-- **NFT marketplace**: `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`.
-- **Reputation**: `ReputationUpdated`.
-- **Access signals**: `OwnershipVerified`, `RecoveryInitiated`.
-
-## Installation (local development)
+## Quickstart
 
 ```bash
 npm install
 ```
 
-## Compilation
-
 ```bash
 npm run build
 ```
-
-## Testing
 
 ```bash
 npm test
 ```
 
-`npm test` runs the in-process Ganache tests defined in `truffle-config.js` and a standalone node regression runner.
+Local dev chain (Ganache):
+```bash
+npx ganache -p 8545
+npx truffle migrate --network development
+```
 
-## Environment configuration
+## Deployment & verification (Truffle)
 
-`truffle-config.js` uses dotenv. See [`.env.example`](.env.example) for a safe template.
+`truffle-config.js` is the source of truth for networks and env vars. A full guide lives in [`docs/Deployment.md`](docs/Deployment.md).
 
-**Required for Sepolia/Mainnet deployments**
-- `PRIVATE_KEYS`: comma-separated private keys (no spaces).
-- One of:
+**Required (Sepolia / Mainnet)**
+- `PRIVATE_KEYS`: comma-separated private keys.
+- RPC configuration, one of:
   - `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`, or
   - `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN`, or
   - `INFURA_KEY`.
@@ -158,88 +119,41 @@ npm test
 **Verification**
 - `ETHERSCAN_API_KEY` for `truffle-plugin-verify`.
 
-**Optional overrides**
-- Gas and confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
-- Provider tuning: `RPC_POLLING_INTERVAL_MS`.
+**Optional tuning**
+- Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
+- Provider polling: `RPC_POLLING_INTERVAL_MS`.
 - Compiler settings: `SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`.
 - Local chain: `GANACHE_MNEMONIC`.
 
-## Deployment (Truffle)
-
-> **Important**: `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token, ENS, NameWrapper, root nodes, Merkle roots). Update them before real deployments.
-
-### Local development chain (Ganache)
-
-```bash
-npx ganache -p 8545
-npx truffle migrate --network development
-```
-
-### Sepolia
-
-```bash
-npx truffle migrate --network sepolia
-```
-
-### Mainnet
-
-```bash
-npx truffle migrate --network mainnet
-```
-
-> Mainnet deployments are high-risk. Verify gas limits, addresses, and constructor parameters, and double-check key custody and funding.
-
-### Verification (Etherscan)
-
-```bash
-npx truffle run verify AGIJobManager --network sepolia
-```
-
-## Troubleshooting
-- **Missing RPC URL**: set `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL` or provide `ALCHEMY_KEY(_MAIN)` / `INFURA_KEY`.
-- **Missing private keys**: `PRIVATE_KEYS` must be set (comma-separated).
-- **Verification failures**: ensure compiler settings match deployment (`SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`).
-- **Nonce conflicts**: avoid simultaneous deployments from the same key.
-- **Out of gas**: increase `SEPOLIA_GAS` / `MAINNET_GAS` and verify `gasPrice` settings.
+> **Deployment caution**: `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token, ENS, NameWrapper, root nodes, Merkle roots). Update them before any production deployment.
 
 ## Security considerations
 
-**Trust model**
-- **Owner powers**: can pause flows, adjust thresholds/limits, update token address and metadata fields, manage allowlists/blacklists, add AGI types, and withdraw escrowed ERC-20.
-- **Moderator powers**: can resolve disputes; only `agent win` and `employer win` trigger payouts/refunds.
+- **Centralization risk**: the owner can change critical parameters and withdraw escrowed ERC‑20; moderators can resolve disputes.
+- **Eligibility gating**: Merkle roots and ENS dependencies are immutable post-deploy; misconfiguration requires redeployment.
+- **Token compatibility**: ERC‑20 must return `true` for `transfer`/`transferFrom`.
+- **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
 
-**Hardening vs historical v0**
-- Phantom job IDs blocked.
-- Pre-apply assignment takeover blocked.
-- Double-complete flows blocked (employer-win dispute now finalizes the job).
-- Division-by-zero avoided when no validators participated.
-- Single-vote enforcement (no approve + disapprove from same validator).
-- ERC-20 transfer/transferFrom return values are enforced.
+See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known limitations.
 
-**Responsible disclosure**
-See [`SECURITY.md`](SECURITY.md).
+## Documentation
 
-## Project structure
+Start here:
+- [`docs/README.md`](docs/README.md)
+- [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
+- [`docs/Deployment.md`](docs/Deployment.md)
+- [`docs/ERC8004.md`](docs/ERC8004.md)
 
-```
-contracts/      # Solidity contracts (AGIJobManager.sol)
-migrations/     # Truffle deployment scripts
-scripts/        # Utilities (ABI/interface generation)
-integrations/   # Off-chain adapters
-test/           # Truffle tests + regression runner
-docs/           # Extended documentation
-```
+## Ecosystem links
 
-Compilation artifacts and ABIs are written to `build/contracts/`.
+- **Historical v0 contract (mainnet)**: https://etherscan.io/address/0x0178b6bad606aaf908f72135b8ec32fc1d5ba477
+- **OpenSea search (contract address)**: https://opensea.io/assets?search[query]=0x0178b6bad606aaf908f72135b8ec32fc1d5ba477
+- **ERC‑8004 spec**: https://eips.ethereum.org/EIPS/eip-8004
+- **ERC‑8004 repo**: https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md
+- **ERC‑8004 reference contracts**: https://github.com/erc-8004/erc-8004-contracts
+- **ERC‑8004 deck (PDF)**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/presentation/MONTREALAI_x_ERC8004_v0.pdf
+- **Related repos**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
 
-## Versioning & compatibility
+## License
 
-- **Solidity version**: the contract uses `pragma solidity ^0.8.17`, while `truffle-config.js` defaults to `0.8.33` for compilation. Adjust `SOLC_VERSION` if you need a different compiler within the compatible range.
-- **Optimizer**: enabled with `SOLC_RUNS` (default 200). Keep optimizer settings stable for reproducible bytecode and Etherscan verification.
-- **EVM version**: defaults to `london` (`SOLC_EVM_VERSION`).
-
-## Contributing & license
-
-- Security policy: [`SECURITY.md`](SECURITY.md)
-- License: [MIT](LICENSE)
-- Contributing guide: none currently; please open an issue or PR with context.
+MIT. See [LICENSE](LICENSE).

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -19,7 +19,7 @@ This document describes the on-chain behavior of `AGIJobManager` as implemented 
 - [References](#references)
 
 ## Overview
-AGIJobManager coordinates employer-funded jobs, agent assignment, validator review, dispute resolution, reputation updates, and job NFT issuance. It escrows ERC‑20 payouts and mints an ERC‑721 to the employer when a job completes successfully.
+AGIJobManager coordinates employer-funded jobs, agent assignment, validator review, dispute resolution, reputation updates, and job NFT issuance. It escrows ERC‑20 payouts and mints an ERC‑721 to the employer when a job completes successfully. This specification describes the *on-chain enforcement layer* only; ERC‑8004 trust signals are consumed off‑chain and are not part of the on-chain interface.
 
 ## Roles and permissions
 | Role | Capabilities |

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -48,6 +48,7 @@ The deployment script in `migrations/2_deploy_contracts.js` hardcodes constructo
    ```
 2. Deploy:
    ```bash
+   npm run build
    npx truffle migrate --network development
    ```
 
@@ -56,6 +57,7 @@ The deployment script in `migrations/2_deploy_contracts.js` hardcodes constructo
 1. Set environment variables (`PRIVATE_KEYS` plus RPC configuration).
 2. Deploy:
    ```bash
+   npm run build
    npx truffle migrate --network sepolia
    ```
 
@@ -64,6 +66,7 @@ The deployment script in `migrations/2_deploy_contracts.js` hardcodes constructo
 1. Set environment variables (`PRIVATE_KEYS` plus RPC configuration).
 2. Deploy:
    ```bash
+   npm run build
    npx truffle migrate --network mainnet
    ```
 
@@ -73,6 +76,10 @@ When `ETHERSCAN_API_KEY` is set:
 
 ```bash
 npx truffle run verify AGIJobManager --network sepolia
+```
+
+```bash
+npx truffle run verify AGIJobManager --network mainnet
 ```
 
 ### Verification tips

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -12,6 +12,10 @@ ERC‑8004 standardizes how agent identity, reputation, and validation signals a
 ## Why AGIJobManager is not hardwired to ERC‑8004
 Coupling escrow settlement to an external registry would introduce **liveness and dependency risks** (e.g., if a registry or indexer is unavailable). AGIJobManager therefore remains a self-contained enforcement layer, while ERC‑8004 operates as a signaling layer.
 
+### What is implemented here vs. off‑chain
+- **Implemented in this repo**: escrow/settlement, validator gating, dispute resolution, and reputation updates inside `AGIJobManager`.
+- **Off‑chain only**: publishing, indexing, and ranking ERC‑8004 trust signals.
+
 ## Recommended integration pattern (no contract changes required)
 1. **Publish trust signals** via ERC‑8004 (identity, reputation, validation outcomes).
 2. **Index and rank** those signals off‑chain.

--- a/docs/README.md
+++ b/docs/README.md
@@ -13,6 +13,10 @@ This documentation set targets engineers, integrators, operators, and auditors. 
 - **Troubleshooting**: [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
 - **Security best practices**: [`SECURITY_BEST_PRACTICES.md`](SECURITY_BEST_PRACTICES.md)
 
+## Trust layer & integrations
+- **Full‑stack trust layer (ERC‑8004 → enforcement)**: [`ERC8004.md`](ERC8004.md)
+- **Integrations overview**: [`Integrations.md`](Integrations.md)
+
 ## Role guides
 - **Employer**: [`roles/EMPLOYER.md`](roles/EMPLOYER.md)
 - **Agent**: [`roles/AGENT.md`](roles/AGENT.md)
@@ -20,10 +24,6 @@ This documentation set targets engineers, integrators, operators, and auditors. 
 - **Moderator**: [`roles/MODERATOR.md`](roles/MODERATOR.md)
 - **Owner/Operator**: [`roles/OWNER_OPERATOR.md`](roles/OWNER_OPERATOR.md)
 - **NFT Marketplace**: [`roles/NFT_MARKETPLACE.md`](roles/NFT_MARKETPLACE.md)
-
-## Trust layer & integrations
-- **ERC‑8004 integration (signaling → enforcement)**: [`ERC8004.md`](ERC8004.md)
-- **Integrations overview**: [`Integrations.md`](Integrations.md)
 
 ## Operations and validation
 - **Regression tests summary**: [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md)

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -40,5 +40,9 @@ Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, `pur
 - **Validator payout sharing**: all validators who voted share equally; there is no weighting or slashing.
 - **Owner-controlled parameters**: thresholds and limits can be changed post-deployment by the owner.
 
+## Operational monitoring
+- Index and alert on `JobDisputed`, `DisputeResolved`, `JobCompleted`, and `ReputationUpdated` events.
+- Track `OwnershipVerified` and `RecoveryInitiated` to monitor ENS/Merkle ownership checks and fallbacks.
+
 ## Disclosure
 Report security issues privately via [`SECURITY.md`](../SECURITY.md).


### PR DESCRIPTION
### Motivation
- Lift repository documentation to an institutional standard that clearly positions AGIJobManager as the on‑chain enforcement layer in a “Full‑Stack Trust Layer for AI Agents” (signaling via ERC‑8004 → enforcement on‑chain). 
- Provide crisp, accurate operational guidance (Truffle deploy/verify, env vars, monitoring) and clarify what this repo implements vs. recommended off‑chain integrations. 
- Improve auditability and contributor hygiene with a small set of governance docs (CONTRIBUTING, CODE_OF_CONDUCT) while preserving a strict no‑changes rule for `contracts/AGIJobManager.sol`.

### Description
- Rewrote the root `README.md` for institutional framing, added explicit “At a glance”, “MONTREAL.AI × ERC‑8004: From signaling → enforcement”, architecture diagrams (Mermaid), roles & permissions, quickstart, and deployment/verification guidance; adjusted the Solidity badge to match the repo compiler setting and included the CI badge referencing `.github/workflows/ci.yml`.
- Updated and clarified core docs in `docs/` (notably `docs/AGIJobManager.md`, `docs/Deployment.md`, `docs/Security.md`, `docs/ERC8004.md`, `docs/README.md`) to document the on‑chain contract spec, deployment environment variables, recommended ERC‑8004 integration pattern (off‑chain), and operational monitoring points.
- Added lightweight community files `CONTRIBUTING.md` and `CODE_OF_CONDUCT.md` to guide contributions and reporting; generated the ABI/Interface doc via `scripts/generate-interface-doc.js` and ensured docs reference the generated `docs/Interface.md`.
- Kept changes documentation‑only and explicit about constraints: `contracts/AGIJobManager.sol` was not modified and the README/doc text explicitly warns to update hardcoded constructor params in `migrations/2_deploy_contracts.js` before production deployment.

### Testing
- `npm install` completed (dependencies installed; repository shows audit warnings but installation succeeded).
- `npx truffle compile` completed successfully and produced artifacts using `solc 0.8.33` (artifacts written to `build/contracts`).
- `node scripts/generate-interface-doc.js` ran and wrote `docs/Interface.md`.
- `npm test` ran the Truffle test suite and regression runner producing `60 passing` tests; all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ab13148648333b9baf8667c63d5fb)