### PR TITLE
Add AGI.Eth alpha namespace docs and deterministic local ENS gating tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Start here:
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)
+- **AGI.Eth Namespace (alpha)**: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md)
 
 ## Ecosystem links
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ This documentation set targets engineers, integrators, operators, and auditors. 
 - **Testing guide**: [`TESTING.md`](TESTING.md)
 - **Troubleshooting**: [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
 - **Security best practices**: [`SECURITY_BEST_PRACTICES.md`](SECURITY_BEST_PRACTICES.md)
+- **AGI.Eth Namespace (alpha)**: [`namespace/AGI_ETH_NAMESPACE_ALPHA.md`](namespace/AGI_ETH_NAMESPACE_ALPHA.md)
 
 ## Trust layer & integrations
 - **Full‑stack trust layer (ERC‑8004 → enforcement)**: [`ERC8004.md`](ERC8004.md)

--- a/docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md
+++ b/docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md
@@ -1,0 +1,237 @@
+# AGI.Eth Namespace (env = alpha) — User Guide
+
+This guide is **non‑technical** and written for institutions and end users who want to use the **AGI.Eth Namespace (alpha environment)** with the existing `AGIJobManager` smart contract. It explains naming, roles, the exact inputs the contract expects, and practical step‑by‑step flows for common roles.
+
+> **Scope**: This guide explains how to use the **alpha** namespace (e.g., `helper.alpha.agent.agi.eth`) with **AGIJobManager** deployments that are configured with alpha root nodes at deploy time.
+
+---
+
+## 1) Quick orientation (plain English)
+
+The AGI.Eth Namespace is a human‑readable identity system for agents, validators, and nodes. For the **alpha** environment, names include the `alpha` layer in the middle of the name. Example:
+
+- **Agent**: `helper.alpha.agent.agi.eth`
+- **Validator**: `alice.alpha.club.agi.eth`
+- **Node (ecosystem convention)**: `gpu01.alpha.node.agi.eth`
+
+When AGIJobManager checks your identity, it **does not** use the full ENS name. Instead, it expects **only the left‑most label** as input:
+
+- `helper.alpha.agent.agi.eth` → `subdomain = "helper"`
+- `alice.alpha.club.agi.eth` → `subdomain = "alice"`
+
+The contract then combines your **subdomain label** with the **configured root node** (e.g., `alpha.agent.agi.eth` or `alpha.club.agi.eth`) to verify ownership.
+
+---
+
+## 2) Naming scheme (institutional standard)
+
+The namespace grammar follows one rule:
+
+```
+<entity>.(<env>.)<role>.agi.eth
+```
+
+- **entity** = the unique name for the person/system (e.g., `alice`, `helper`, `gpu01`)
+- **env** = optional environment layer (e.g., `alpha`, `x`, etc.)
+- **role** = `agent`, `club` (validator), or `node`
+
+### Role examples (alpha vs non‑alpha)
+
+| Role | Non‑alpha | Alpha (env = alpha) | What the user passes to `subdomain` |
+| --- | --- | --- | --- |
+| Validator (club) | `alice.club.agi.eth` | `alice.alpha.club.agi.eth` | `"alice"` |
+| Agent | `helper.agent.agi.eth` | `helper.alpha.agent.agi.eth` | `"helper"` |
+| Node (convention) | `gpu01.node.agi.eth` | `gpu01.alpha.node.agi.eth` | `"gpu01"` |
+
+> **Important:** The contract does **not** accept the full ENS name as `subdomain`. Use only the left‑most label.
+
+---
+
+## 3) What AGIJobManager checks (in order)
+
+When you call `applyForJob` (agent) or `validateJob` / `disapproveJob` (validator), the contract checks **one** of the following identity methods, in this order:
+
+1. **Merkle allowlist**: your wallet address is in the allowlist proof.
+2. **NameWrapper ownership**: you own the subdomain under the configured root node.
+3. **ENS resolver address**: the resolver for the subdomain points to your wallet.
+
+If **any** of the above succeeds, you pass. If **all** fail, the transaction reverts.
+
+> **Owner‑managed bypass:** the contract owner can add you to `additionalAgents` or `additionalValidators`, which bypasses all identity checks.
+
+> **Blacklist:** the owner can also blacklist agents or validators, which always blocks access.
+
+---
+
+## 4) Step‑by‑step “click‑by‑click” guides by role
+
+These steps assume you are using a block explorer like Etherscan and have the contract address.
+
+### A) Employer — create and fund a job
+
+1. **Acquire tokens** (AGI or the configured ERC‑20).
+2. **Approve allowance** for the AGIJobManager contract.
+   - Go to the ERC‑20 contract → **Write Contract** → `approve(spender, amount)`
+   - Use a **small, exact amount** (avoid unlimited approvals).
+3. **Create a job**
+   - Call `createJob(ipfsHash, payout, duration, details)`
+   - `ipfsHash`: just the hash/CID (no `ipfs://` prefix)
+   - `payout`: token amount in **wei** (18 decimals)
+   - `duration`: seconds
+4. **Track your jobId** from the `JobCreated` event.
+
+**What happens on-chain**
+- Tokens move into escrow when the job is created.
+- An NFT is minted to you only after the job is completed and validated.
+
+---
+
+### B) Agent — apply and request completion
+
+1. **Confirm your identity method** (one of):
+   - You own `helper.alpha.agent.agi.eth` in NameWrapper, **or**
+   - The ENS resolver for your subdomain points to your wallet, **or**
+   - You are in the Merkle allowlist, **or**
+   - The owner added you to `additionalAgents`.
+2. **Apply for the job**
+   - Call `applyForJob(jobId, subdomain, proof)`
+   - `subdomain`: the left‑most label only (e.g., `"helper"`)
+   - `proof`: Merkle proof array if allowlisted; otherwise `[]`
+3. **Request completion**
+   - Call `requestJobCompletion(jobId, ipfsHash)`
+   - Use a final IPFS hash that represents your deliverable.
+
+**What happens on‑chain**
+- `JobApplied` assigns you to the job.
+- `JobCompletionRequested` updates the job’s IPFS hash.
+- You are paid when validators approve (or when a moderator resolves dispute as “agent win”).
+
+---
+
+### C) Validator — approve or disapprove
+
+1. **Confirm your identity method** (one of):
+   - You own `alice.alpha.club.agi.eth` in NameWrapper, **or**
+   - The ENS resolver for your subdomain points to your wallet, **or**
+   - You are in the Merkle allowlist, **or**
+   - The owner added you to `additionalValidators`.
+2. **Approve the job**
+   - Call `validateJob(jobId, subdomain, proof)`
+3. **Disapprove if needed**
+   - Call `disapproveJob(jobId, subdomain, proof)`
+
+**Vote rules (strict)**
+- A validator **cannot vote twice**.
+- A validator **cannot both approve and disapprove** the same job.
+
+---
+
+### D) Moderator — resolve disputes
+
+1. Call `resolveDispute(jobId, resolution)`.
+2. Use one of the **exact** canonical strings:
+   - `"agent win"` → triggers completion and payment to agent
+   - `"employer win"` → refunds escrow to employer and finalizes job
+3. Any **other string** still emits `DisputeResolved` but **does not** move funds.
+
+---
+
+### E) Owner / Operator — safety‑critical controls
+
+The owner can:
+- Pause/unpause the contract.
+- Add/remove `additionalAgents` / `additionalValidators`.
+- Manage blacklists.
+- Adjust economic parameters (payout caps, validator thresholds, reward percentages).
+- Withdraw escrowed ERC‑20.
+
+Use a hardware wallet or multisig for the owner key.
+
+---
+
+## 5) Safety checklist (non‑technical)
+
+Before doing anything on-chain:
+
+- ✅ Confirm the **contract address** from a trusted source.
+- ✅ Confirm the **token address** (ERC‑20 used for payout).
+- ✅ Verify your ENS ownership in the ENS app.
+- ✅ Use **small test amounts** first.
+- ✅ Approve **only the amount you need**.
+- ✅ Revoke approvals after completion (set allowance to 0).
+- ✅ Ensure you’re on the right network (mainnet vs testnet vs local).
+
+---
+
+## 6) Practical troubleshooting
+
+If a call fails with `NotAuthorized`, check:
+
+- Are you passing only the left‑most label in `subdomain`?
+- Does the contract deployment use **alpha** root nodes?
+- Do you own the **alpha** ENS name or set the resolver correctly?
+- Are you on the allowlist, or has the owner added you to `additionalAgents/Validators`?
+
+---
+
+## 7) Visual flows (Mermaid)
+
+### Identity verification flow
+```mermaid
+sequenceDiagram
+  participant User
+  participant Contract
+  participant NameWrapper
+  participant ENS
+  participant Resolver
+
+  User->>Contract: applyForJob / validateJob (subdomain, proof)
+  Contract->>Contract: Verify Merkle proof
+  Contract->>NameWrapper: ownerOf(namehash(subnode))
+  Contract->>ENS: resolver(subnode)
+  Contract->>Resolver: addr(subnode)
+  Contract-->>User: OwnershipVerified OR NotAuthorized
+```
+
+### Happy‑path job lifecycle
+```mermaid
+sequenceDiagram
+  participant Employer
+  participant Agent
+  participant Validator
+  participant Contract
+
+  Employer->>Contract: createJob(...)
+  Agent->>Contract: applyForJob(jobId, subdomain, proof)
+  Agent->>Contract: requestJobCompletion(jobId, ipfsHash)
+  Validator->>Contract: validateJob(jobId, subdomain, proof)
+  Contract-->>Agent: payout
+  Contract-->>Employer: NFT receipt
+```
+
+### Dispute lifecycle
+```mermaid
+sequenceDiagram
+  participant Employer
+  participant Agent
+  participant Validator
+  participant Moderator
+  participant Contract
+
+  Employer->>Contract: createJob(...)
+  Agent->>Contract: applyForJob(...)
+  Validator->>Contract: disapproveJob(...)
+  Contract-->>Contract: job.disputed = true
+  Moderator->>Contract: resolveDispute("agent win" | "employer win" | other)
+  Contract-->>Agent: payout (only on "agent win")
+  Contract-->>Employer: refund (only on "employer win")
+```
+
+---
+
+## 8) Next steps
+
+- **Quickstart checklist**: [`AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md`](AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md)
+- **Technical appendix**: [`ENS_IDENTITY_GATING.md`](ENS_IDENTITY_GATING.md)
+- **FAQ / troubleshooting**: [`FAQ.md`](FAQ.md)
+- **Testing coverage (local mocks)**: [`TESTING.md`](TESTING.md)

--- a/docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md
+++ b/docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md
@@ -1,0 +1,58 @@
+# AGI.Eth Namespace (alpha) — Quickstart
+
+Use this checklist if you already know your role and just need the **correct inputs**.
+
+## 1) Know your role
+
+| Role | ENS name pattern | Example | `subdomain` input |
+| --- | --- | --- | --- |
+| Validator | `<entity>.alpha.club.agi.eth` | `alice.alpha.club.agi.eth` | `"alice"` |
+| Agent | `<entity>.alpha.agent.agi.eth` | `helper.alpha.agent.agi.eth` | `"helper"` |
+| Node (convention) | `<entity>.alpha.node.agi.eth` | `gpu01.alpha.node.agi.eth` | `"gpu01"` |
+
+**Important:** `subdomain` is the left‑most label only. Do **not** pass the full ENS name.
+
+---
+
+## 2) Identity method (pick one)
+
+- **ENS / NameWrapper ownership**, or
+- **ENS resolver address** points to your wallet, or
+- **Merkle allowlist** proof, or
+- **Owner allowlist** via `additionalAgents` / `additionalValidators`.
+
+---
+
+## 3) Common calls (Etherscan “Write Contract”)
+
+### Employer
+1. `approve(AGIJobManager, amount)` on the ERC‑20 token.
+2. `createJob(ipfsHash, payout, duration, details)`.
+
+### Agent
+1. `applyForJob(jobId, "helper", proof)`.
+2. `requestJobCompletion(jobId, ipfsHash)`.
+
+### Validator
+1. `validateJob(jobId, "alice", proof)`.
+2. Or `disapproveJob(jobId, "alice", proof)`.
+
+### Moderator
+- `resolveDispute(jobId, "agent win" | "employer win" | other)`.
+
+---
+
+## 4) Safety checklist
+
+- ✅ Verify contract and token addresses.
+- ✅ Use small amounts first.
+- ✅ Avoid unlimited approvals; revoke afterward.
+- ✅ Confirm you are on the right network.
+
+---
+
+## 5) Need more detail?
+
+- Full guide: [`AGI_ETH_NAMESPACE_ALPHA.md`](AGI_ETH_NAMESPACE_ALPHA.md)
+- Technical appendix: [`ENS_IDENTITY_GATING.md`](ENS_IDENTITY_GATING.md)
+- FAQ / troubleshooting: [`FAQ.md`](FAQ.md)

--- a/docs/namespace/ENS_IDENTITY_GATING.md
+++ b/docs/namespace/ENS_IDENTITY_GATING.md
@@ -1,0 +1,103 @@
+# ENS Identity Gating — Technical Appendix (AGI.Eth alpha)
+
+This appendix explains the **exact identity checks** used by `AGIJobManager` and how to derive the on‑chain node hashes for the **alpha** namespace.
+
+---
+
+## 1) Contract checks (exact order)
+
+For agent and validator calls (`applyForJob`, `validateJob`, `disapproveJob`), `_verifyOwnership` runs these checks **in order**:
+
+1. **Merkle allowlist**
+   - Leaf = `keccak256(abi.encodePacked(claimant))` (the wallet address).
+   - Proof is verified against `agentMerkleRoot` or `validatorMerkleRoot`.
+2. **NameWrapper ownership**
+   - Node = `subnode(rootNode, labelHash(subdomain))`.
+   - `ownerOf(uint256(node))` must equal the claimant.
+3. **ENS resolver address**
+   - `resolver(node)` must return a non‑zero resolver address.
+   - `resolver.addr(node)` must equal the claimant.
+
+If all checks fail, the call reverts `NotAuthorized`.
+
+---
+
+## 2) How root nodes are set (alpha environment)
+
+The **alpha** namespace uses these root nodes at deployment time:
+
+- `clubRootNode = namehash("alpha.club.agi.eth")`
+- `agentRootNode = namehash("alpha.agent.agi.eth")`
+
+These root nodes are **immutable after deployment**, so a mismatch requires redeployment.
+
+---
+
+## 3) Subnode derivation (same as contract)
+
+The contract derives subnodes using:
+
+```
+subnode = keccak256(abi.encodePacked(rootNode, keccak256(label)))
+```
+
+Where `label` is the **left‑most** label only (e.g., `"helper"`).
+
+### JS helper (web3.js compatible)
+
+```js
+const { soliditySha3, keccak256 } = web3.utils;
+
+function namehash(name) {
+  let node = "0x" + "00".repeat(32);
+  if (!name) return node;
+  const labels = name.toLowerCase().split(".").filter(Boolean);
+  for (let i = labels.length - 1; i >= 0; i -= 1) {
+    node = soliditySha3(
+      { type: "bytes32", value: node },
+      { type: "bytes32", value: keccak256(labels[i]) }
+    );
+  }
+  return node;
+}
+
+function subnode(rootNode, subdomain) {
+  return soliditySha3(
+    { type: "bytes32", value: rootNode },
+    { type: "bytes32", value: keccak256(subdomain) }
+  );
+}
+```
+
+### Example (alpha agent)
+
+- Full ENS name: `helper.alpha.agent.agi.eth`
+- `rootNode`: `namehash("alpha.agent.agi.eth")`
+- `subdomain`: `"helper"`
+- `subnode`: `keccak256(rootNode, keccak256("helper"))`
+
+---
+
+## 4) What to pass to the contract
+
+- `subdomain`: **left‑most label only** (e.g., `"helper"`, `"alice"`).
+- `proof`: Merkle proof array for allowlisted addresses, otherwise `[]`.
+
+Passing the full ENS name (e.g., `"helper.alpha.agent.agi.eth"`) will **not** work.
+
+---
+
+## 5) Operational signals
+
+The contract emits two useful events for monitoring identity verification:
+
+- `OwnershipVerified(claimant, subdomain)` → identity check succeeded.
+- `RecoveryInitiated(reason)` → ENS / NameWrapper failure path (useful for diagnostics).
+
+---
+
+## 6) Known limits of local tests
+
+Local tests use deterministic mocks of ENS, Resolver, and NameWrapper to simulate mainnet behavior. This proves the **verification logic** in isolation, but it does **not** assert real mainnet ownership or resolver data.
+
+See: [`TESTING.md`](TESTING.md)

--- a/docs/namespace/FAQ.md
+++ b/docs/namespace/FAQ.md
@@ -1,0 +1,32 @@
+# AGI.Eth Namespace (alpha) — FAQ
+
+## Q1) Do I pass the full ENS name to the contract?
+**No.** You pass **only the left‑most label**. Example:
+- `helper.alpha.agent.agi.eth` → `subdomain = "helper"`
+
+## Q2) Why does `NotAuthorized` happen even though I own the name?
+Common causes:
+- You are using the **wrong environment** (non‑alpha vs alpha).
+- The deployment is configured with **alpha** root nodes, but you own a **non‑alpha** name.
+- The ENS resolver is not set to your wallet address.
+- You are not on the allowlist and were not added to `additionalAgents/Validators`.
+
+## Q3) Can I use `helper.agent.agi.eth` with an alpha deployment?
+**No.** If the contract was deployed with `alpha.agent.agi.eth` and `alpha.club.agi.eth` root nodes, only the **alpha** names (e.g., `helper.alpha.agent.agi.eth`) will pass the ownership checks.
+
+## Q4) Can the root nodes or Merkle roots be changed after deployment?
+**No.** They are immutable in this contract. If they are wrong, the contract must be redeployed.
+
+## Q5) What if the ENS/NameWrapper contracts are down or revert?
+The contract emits `RecoveryInitiated` events for these failure paths and continues evaluation. In practice, this means you should **monitor those events** to spot ENS issues.
+
+## Q6) Which identity method is safest?
+Use the method that matches your operational policy. For institutions:
+- **ENS/NameWrapper ownership** is preferred for public accountability.
+- **Merkle allowlists** are useful for private or temporary access.
+- **additionalAgents/Validators** are a strong operational override but should be tightly controlled.
+
+## Q7) What if I don’t have a Merkle proof?
+You can still pass if:
+- You own the proper alpha ENS name, or
+- The owner has allowlisted your address in `additionalAgents/Validators`.

--- a/docs/namespace/TESTING.md
+++ b/docs/namespace/TESTING.md
@@ -1,0 +1,41 @@
+# Namespace Identity Tests — Local Coverage
+
+This document explains the **local Truffle tests** added to prove AGI.Eth namespace gating for the **alpha** environment using deterministic mocks.
+
+## What the tests cover
+
+The new test suite focuses on the alpha namespace and identity‑gating logic using mock ENS contracts:
+
+1. **Agent authorization via NameWrapper** under `alpha.agent.agi.eth`.
+2. **Validator authorization via ENS resolver** under `alpha.club.agi.eth`.
+3. **Unauthorized access rejection** when no allowlist or ownership exists.
+4. **Wrong root node rejection** (non‑alpha name with alpha deployment).
+5. **Owner allowlist bypass** using `additionalAgents` / `additionalValidators`.
+
+## How the tests simulate mainnet behavior
+
+Local tests use deterministic mocks:
+
+- `MockENS` stores a resolver per node.
+- `MockResolver` returns an address for `addr(node)`.
+- `MockNameWrapper` returns an owner for `ownerOf(node)`.
+
+The tests compute **alpha root nodes** using namehash and derive subnodes exactly as the contract does:
+
+```
+subnode = keccak256(rootNode, keccak256(label))
+```
+
+This makes the local chain behave like mainnet **for identity verification logic only**. It does not assert real ENS ownership.
+
+## How to run
+
+```bash
+npm install
+npx truffle compile
+npx truffle test
+```
+
+## Test file
+
+- `test/namespaceAlpha.test.js`

--- a/test/helpers/ens.js
+++ b/test/helpers/ens.js
@@ -1,5 +1,18 @@
 const { soliditySha3, keccak256, toBN } = web3.utils;
 
+function namehash(name) {
+  let node = "0x" + "00".repeat(32);
+  if (!name) return node;
+  const labels = name.toLowerCase().split(".").filter(Boolean);
+  for (let i = labels.length - 1; i >= 0; i -= 1) {
+    node = soliditySha3(
+      { type: "bytes32", value: node },
+      { type: "bytes32", value: keccak256(labels[i]) }
+    );
+  }
+  return node;
+}
+
 function rootNode(label) {
   return soliditySha3({ type: "string", value: label });
 }
@@ -23,6 +36,7 @@ async function setResolverOwnership(ens, resolver, root, subdomain, owner) {
 }
 
 module.exports = {
+  namehash,
   rootNode,
   subnode,
   setNameWrapperOwnership,

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -1,0 +1,119 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { namehash, subnode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
+const { expectRevert } = require("@openzeppelin/test-helpers");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager alpha namespace gating", (accounts) => {
+  const [owner, employer, agent, validator, outsider] = accounts;
+  let token;
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let manager;
+  let clubRoot;
+  let agentRoot;
+
+  const payout = toBN(toWei("10"));
+
+  async function createJob() {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+    return tx.logs[0].args.jobId.toNumber();
+  }
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    resolver = await MockResolver.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    clubRoot = namehash("alpha.club.agi.eth");
+    agentRoot = namehash("alpha.agent.agi.eth");
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      clubRoot,
+      agentRoot,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+  });
+
+  it("authorizes an agent via NameWrapper ownership under alpha.agent", async () => {
+    const jobId = await createJob();
+    await setNameWrapperOwnership(nameWrapper, agentRoot, "helper", agent);
+
+    const tx = await manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent });
+    const appliedEvent = tx.logs.find((log) => log.event === "JobApplied");
+    assert.ok(appliedEvent, "JobApplied should be emitted");
+
+    const job = await manager.jobs(jobId);
+    assert.equal(job.assignedAgent, agent, "agent should be assigned");
+  });
+
+  it("authorizes a validator via ENS resolver addr under alpha.club", async () => {
+    const jobId = await createJob();
+    await setNameWrapperOwnership(nameWrapper, agentRoot, "helper", agent);
+    await manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent });
+
+    await setResolverOwnership(ens, resolver, clubRoot, "alice", validator);
+
+    const tx = await manager.validateJob(jobId, "alice", EMPTY_PROOF, { from: validator });
+    const validatedEvent = tx.logs.find((log) => log.event === "JobValidated");
+    const completedEvent = tx.logs.find((log) => log.event === "JobCompleted");
+    assert.ok(validatedEvent, "JobValidated should be emitted");
+    assert.ok(completedEvent, "JobCompleted should be emitted when approvals threshold met");
+
+    const status = await manager.getJobStatus(jobId);
+    const completed = status.completed ?? status[0];
+    assert.equal(completed, true, "job should be completed");
+  });
+
+  it("rejects unauthorized agents with no allowlist or ENS ownership", async () => {
+    const jobId = await createJob();
+    await expectRevert.unspecified(
+      manager.applyForJob(jobId, "intruder", EMPTY_PROOF, { from: outsider })
+    );
+  });
+
+  it("rejects non-alpha ownership when alpha root nodes are configured", async () => {
+    const jobId = await createJob();
+    const nonAlphaAgentRoot = namehash("agent.agi.eth");
+    const nonAlphaNode = subnode(nonAlphaAgentRoot, "helper");
+    await nameWrapper.setOwner(toBN(nonAlphaNode), agent, { from: owner });
+
+    await expectRevert.unspecified(
+      manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent })
+    );
+  });
+
+  it("allows additionalAgents/additionalValidators bypass", async () => {
+    const jobId = await createJob();
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+
+    await manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent });
+    const tx = await manager.validateJob(jobId, "alice", EMPTY_PROOF, { from: validator });
+
+    const validatedEvent = tx.logs.find((log) => log.event === "JobValidated");
+    assert.ok(validatedEvent, "JobValidated should be emitted for allowlisted validator");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide clear, non‑technical institutional documentation for using the AGI.Eth `alpha` namespace with the existing `AGIJobManager` contract so end users understand naming, inputs, and safety practices.
- Prove identity‑gating behavior locally with minimal, deterministic Truffle tests that mock ENS/Resolver/NameWrapper so teams can validate alpha vs non‑alpha flows without mainnet forking.

### Description
- Added a dedicated docs set under `docs/namespace/`: `AGI_ETH_NAMESPACE_ALPHA.md`, `AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md`, `ENS_IDENTITY_GATING.md`, `FAQ.md`, and `TESTING.md`, and linked the primary guide from `README.md` and `docs/README.md`.
- Implemented a `namehash` helper and exported it from `test/helpers/ens.js` so tests derive root nodes and subnodes exactly as the contract does (`subnode = keccak256(rootNode, keccak256(label))`).
- Added a deterministic Truffle test `test/namespaceAlpha.test.js` that uses existing mock contracts (`MockENS`, `MockResolver`, `MockNameWrapper`, `MockERC20`) to exercise these scenarios: agent authorization via NameWrapper under `alpha.agent`, validator authorization via resolver under `alpha.club`, rejection of unauthorized/incorrect-root actors, and owner allowlist bypass via `additionalAgents`/`additionalValidators`.
- Minor test updates to use `@openzeppelin/test-helpers` patterns (`expectRevert`) and robust `getJobStatus` handling for assertions.

### Testing
- Ran `npx truffle compile` which completed successfully and produced artifacts.
- Ran the full suite via `npx truffle test --network test` (in‑process Ganache provider) and the test suite passed locally: `65 passing` including the new `AGIJobManager alpha namespace gating` tests.
- Note: running `npx truffle test` (default development network) can fail if a local node is not available at `127.0.0.1:8545`; use `--network test` or start Ganache for that workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697abe7749cc83339db08ca422759322)