### PR TITLE
Add comprehensive AGIJobManager test suite and testing docs

### DIFF
--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -1,38 +1,42 @@
-# Testing
+# Testing AGIJobManager
 
-This repository uses Truffle with a local Ganache chain for testing. The default `truffle test` command runs against an in-process Ganache provider defined in `truffle-config.js`, so no environment variables are required for local unit tests.
+This repository uses Truffle + Ganache for local testing. The suite includes mock contracts for ENS/NameWrapper/Resolver, ERC-20 transfer failures, and AGIType ERC-721s so we can validate the safety fixes without touching production code.
 
-## Quickstart
+## Local setup
+
+Install dependencies:
 
 ```bash
 npm install
-npx truffle compile
-npx truffle test
 ```
 
-## Running against a local development chain (Ganache)
-
-If you prefer a persistent local chain, start Ganache and run Truffle against the `development` network:
+Start Ganache in a separate terminal (development network):
 
 ```bash
-npx ganache -p 8545
-npx truffle test --network development
+npx ganache -p 8545 --wallet.mnemonic "test test test test test test test test test test test junk"
 ```
 
-## Test-only mocks
+Compile and run tests against the local `development` network:
 
-The test suite includes minimal mock contracts under `contracts/test/`:
+```bash
+truffle compile
+truffle test --network development
+```
 
-- **MockERC20** / **FailTransferToken** / **FailingERC20**: ERC‑20 mocks to simulate successful transfers and `transfer`/`transferFrom` failures.
-- **MockERC721**: ERC‑721 mock used for AGIType payout boosts.
-- **MockENS**, **MockResolver**, **MockNameWrapper**: deterministic ENS/NameWrapper mocks for access gating tests.
+## Mocks used in tests
 
-## Suite layout
+The test suite uses the following test-only contracts under `contracts/test/`:
 
-- **`test/AGIJobManager.full.test.js`**: comprehensive unit/integration coverage for lifecycle, dispute resolution, vote rules, ERC‑20 transfer checks, and NFT marketplace behavior.
-- **`test/regressions.better-only.js`**: regression coverage for the better‑only hardening fixes.
+- `MockERC20`: basic ERC-20 for escrow and payouts.
+- `FailingERC20` / `FailTransferToken`: ERC-20s that return `false` for `transfer` / `transferFrom`.
+- `MockENS`, `MockResolver`, `MockNameWrapper`: ENS gating mocks.
+- `MockERC721`: AGIType NFT for payout boosts.
 
-## Extending tests
+## Extending the tests
 
-- Add new scenarios under `test/` and reuse the helper utilities in `test/AGIJobManager.full.test.js`.
-- Keep mocks deterministic and minimal, and avoid modifying `contracts/AGIJobManager.sol`.
+Most tests share helper utilities in `test/helpers/`:
+
+- `ens.js` for constructing namehash/root/subnode values and setting mock ownership.
+- `errors.js` for asserting custom error selectors.
+
+Add new scenarios by reusing these helpers and creating focused test cases for new behaviors. Keep job IDs and test data deterministic to ensure consistent results across runs.

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -1,0 +1,630 @@
+const { expectEvent, expectRevert, BN, time } = require("@openzeppelin/test-helpers");
+const { MerkleTree } = require("merkletreejs");
+const keccak256 = require("keccak256");
+
+const { expectCustomError } = require("./helpers/errors");
+const { rootNode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const FailingERC20 = artifacts.require("FailingERC20");
+const MockENS = artifacts.require("MockENS");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const toWei = (value) => web3.utils.toWei(value.toString());
+
+const leafFor = (address) =>
+  Buffer.from(web3.utils.soliditySha3({ type: "address", value: address }).slice(2), "hex");
+
+const buildTree = (addresses) => {
+  const leaves = addresses.map(leafFor);
+  const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
+  return {
+    tree,
+    root: tree.getHexRoot(),
+    proofFor: (address) => tree.getHexProof(leafFor(address)),
+  };
+};
+
+contract("AGIJobManager comprehensive suite", (accounts) => {
+  const [
+    owner,
+    employer,
+    agent,
+    validatorOne,
+    validatorTwo,
+    validatorThree,
+    validatorFour,
+    buyer,
+    moderator,
+    outsider,
+  ] = accounts;
+
+  const baseIpfsUrl = "ipfs://base";
+  const jobIpfs = "QmJobHash";
+  const updatedIpfs = "QmJobHashUpdated";
+  const jobDetails = "Do the thing";
+  const payout = new BN(toWei("1000"));
+  const duration = new BN("5000");
+
+  let token;
+  let manager;
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let agiTypeNft;
+  let agentTree;
+  let validatorTree;
+  let clubRoot;
+  let agentRoot;
+
+  const approveToken = async (holder, amount = payout) => {
+    await token.approve(manager.address, amount, { from: holder });
+  };
+
+  const createJob = async (from = employer, jobPayout = payout, jobDuration = duration, hash = jobIpfs) => {
+    await approveToken(from, jobPayout);
+    return manager.createJob(hash, jobPayout, jobDuration, jobDetails, { from });
+  };
+
+  const assignAgentWithProof = async (jobId, selectedAgent = agent) =>
+    manager.applyForJob(jobId, "agent", agentTree.proofFor(selectedAgent), { from: selectedAgent });
+
+  const validateWithProof = async (jobId, validator) =>
+    manager.validateJob(jobId, "validator", validatorTree.proofFor(validator), { from: validator });
+
+  beforeEach(async () => {
+    token = await MockERC20.new();
+    ens = await MockENS.new();
+    resolver = await MockResolver.new();
+    nameWrapper = await MockNameWrapper.new();
+    agiTypeNft = await MockERC721.new();
+
+    agentTree = buildTree([agent, validatorFour]);
+    validatorTree = buildTree([validatorOne, validatorTwo, validatorThree]);
+    clubRoot = rootNode("club");
+    agentRoot = rootNode("agent");
+
+    manager = await AGIJobManager.new(
+      token.address,
+      baseIpfsUrl,
+      ens.address,
+      nameWrapper.address,
+      clubRoot,
+      agentRoot,
+      validatorTree.root,
+      agentTree.root
+    );
+
+    await token.mint(employer, payout.muln(5));
+    await token.mint(agent, payout);
+    await token.mint(buyer, payout);
+    await token.mint(owner, payout);
+
+    await manager.addModerator(moderator, { from: owner });
+  });
+
+  describe("deployment & initialization", () => {
+    it("deploys with expected constructor configuration", async () => {
+      const agiTokenAddress = await manager.agiToken();
+      assert.equal(agiTokenAddress, token.address);
+      assert.equal(await manager.requiredValidatorApprovals(), "3");
+      assert.equal(await manager.requiredValidatorDisapprovals(), "3");
+      assert.equal(await manager.validationRewardPercentage(), "8");
+      assert.equal(await manager.maxJobPayout(), toWei("4888"));
+      assert.equal(await manager.jobDurationLimit(), "10000000");
+      assert.equal(await manager.owner(), owner);
+      assert.equal(await manager.name(), "AGIJobs");
+      assert.equal(await manager.symbol(), "Job");
+    });
+
+    it("pauses and unpauses owner-only", async () => {
+      await expectRevert(manager.pause({ from: outsider }), "Ownable: caller is not the owner");
+      await manager.pause({ from: owner });
+      await expectRevert(
+        manager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer }),
+        "Pausable: paused"
+      );
+      await manager.unpause({ from: owner });
+      await approveToken(employer);
+      await manager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer });
+    });
+  });
+
+  describe("job lifecycle (happy path)", () => {
+    it("escrows payout, assigns agent, completes with validator approvals and payouts", async () => {
+      await manager.addAGIType(agiTypeNft.address, 80, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      const creation = await createJob();
+      expectEvent(creation, "JobCreated", {
+        jobId: new BN(0),
+        ipfsHash: jobIpfs,
+        payout,
+        duration,
+        details: jobDetails,
+      });
+      const contractBalance = await token.balanceOf(manager.address);
+      assert.equal(contractBalance.toString(), payout.toString());
+
+      const applyReceipt = await assignAgentWithProof(0);
+      expectEvent(applyReceipt, "JobApplied", { jobId: new BN(0), agent });
+      const job = await manager.jobs(0);
+      assert.equal(job.assignedAgent, agent);
+      assert.isTrue(new BN(job.assignedAt).gt(new BN(0)));
+
+      const completion = await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
+      expectEvent(completion, "JobCompletionRequested", { jobId: new BN(0), agent });
+      const status = await manager.getJobStatus(0);
+      assert.equal(status[1], true);
+      assert.equal(status[2], updatedIpfs);
+
+      const validatorOneBalanceBefore = await token.balanceOf(validatorOne);
+      const validatorTwoBalanceBefore = await token.balanceOf(validatorTwo);
+      const validatorThreeBalanceBefore = await token.balanceOf(validatorThree);
+      const agentBalanceBefore = await token.balanceOf(agent);
+
+      await validateWithProof(0, validatorOne);
+      await validateWithProof(0, validatorTwo);
+      const completionReceipt = await validateWithProof(0, validatorThree);
+      expectEvent(completionReceipt, "JobCompleted", { jobId: new BN(0), agent });
+
+      const finalJob = await manager.jobs(0);
+      assert.equal(finalJob.completed, true);
+
+      const validatorPayoutTotal = payout.muln(8).divn(100);
+      const validatorPayoutEach = validatorPayoutTotal.divn(3);
+      const agentPayout = payout.muln(92).divn(100);
+
+      const agentBalanceAfter = await token.balanceOf(agent);
+      const validatorOneBalanceAfter = await token.balanceOf(validatorOne);
+      const validatorTwoBalanceAfter = await token.balanceOf(validatorTwo);
+      const validatorThreeBalanceAfter = await token.balanceOf(validatorThree);
+
+      assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), agentPayout.toString());
+      assert.equal(
+        validatorOneBalanceAfter.sub(validatorOneBalanceBefore).toString(),
+        validatorPayoutEach.toString()
+      );
+      assert.equal(
+        validatorTwoBalanceAfter.sub(validatorTwoBalanceBefore).toString(),
+        validatorPayoutEach.toString()
+      );
+      assert.equal(
+        validatorThreeBalanceAfter.sub(validatorThreeBalanceBefore).toString(),
+        validatorPayoutEach.toString()
+      );
+
+      const tokenId = await manager.nextTokenId();
+      const mintedTokenId = tokenId.subn(1);
+      assert.equal(await manager.ownerOf(mintedTokenId), employer);
+      assert.equal(await manager.tokenURI(mintedTokenId), `${baseIpfsUrl}/${updatedIpfs}`);
+      const agentReputation = await manager.reputation(agent);
+      assert.isTrue(agentReputation.gt(new BN(0)));
+      const validatorReputation = await manager.reputation(validatorOne);
+      assert.isTrue(validatorReputation.gt(new BN(0)));
+    });
+
+    it("allows requestJobCompletion only by assigned agent within duration", async () => {
+      await createJob();
+      await assignAgentWithProof(0);
+      await expectCustomError(
+        manager.requestJobCompletion.call(0, updatedIpfs, { from: employer }),
+        "NotAuthorized"
+      );
+
+      await time.increase(duration.addn(1));
+      await expectCustomError(
+        manager.requestJobCompletion.call(0, updatedIpfs, { from: agent }),
+        "InvalidState"
+      );
+    });
+  });
+
+  describe("hardening protections", () => {
+    it("reverts for phantom job ids", async () => {
+      await expectCustomError(manager.applyForJob.call(123, "agent", [], { from: agent }), "JobNotFound");
+      await expectCustomError(
+        manager.validateJob.call(123, "validator", [], { from: validatorOne }),
+        "JobNotFound"
+      );
+      await expectCustomError(
+        manager.disapproveJob.call(123, "validator", [], { from: validatorOne }),
+        "JobNotFound"
+      );
+      await expectCustomError(manager.disputeJob.call(123, { from: employer }), "JobNotFound");
+      await expectCustomError(manager.cancelJob.call(123, { from: employer }), "JobNotFound");
+      await expectCustomError(manager.delistJob.call(123, { from: owner }), "JobNotFound");
+    });
+
+    it("prevents double completion and late validations", async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.validateJob(0, "validator", [], { from: validatorOne });
+
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+      await expectCustomError(
+        manager.disapproveJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+      await expectCustomError(manager.disputeJob.call(0, { from: employer }), "InvalidState");
+    });
+
+    it("marks employer-win disputes as completed to block future payouts", async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.setRequiredValidatorApprovals(1, { from: owner });
+
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.disputeJob(0, { from: employer });
+
+      const employerBalanceBefore = await token.balanceOf(employer);
+      await manager.resolveDispute(0, "employer win", { from: moderator });
+      const employerBalanceAfter = await token.balanceOf(employer);
+
+      assert.equal(employerBalanceAfter.sub(employerBalanceBefore).toString(), payout.toString());
+
+      const job = await manager.jobs(0);
+      assert.equal(job.completed, true);
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+      await expectCustomError(
+        manager.resolveDispute.call(0, "agent win", { from: moderator }),
+        "InvalidState"
+      );
+    });
+
+    it("completes without validators (no division by zero)", async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 100, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.disputeJob(0, { from: agent });
+
+      const agentBalanceBefore = await token.balanceOf(agent);
+      await manager.resolveDispute(0, "agent win", { from: moderator });
+      const agentBalanceAfter = await token.balanceOf(agent);
+
+      assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), payout.toString());
+      const job = await manager.jobs(0);
+      assert.equal(job.completed, true);
+    });
+  });
+
+  describe("vote rules & blacklists", () => {
+    beforeEach(async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+    });
+
+    it("blocks double voting and mixed approve/disapprove", async () => {
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.validateJob(0, "validator", [], { from: validatorOne });
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+      await expectCustomError(
+        manager.disapproveJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+
+      await manager.addAdditionalValidator(validatorTwo, { from: owner });
+      await manager.disapproveJob(0, "validator", [], { from: validatorTwo });
+      await expectCustomError(
+        manager.disapproveJob.call(0, "validator", [], { from: validatorTwo }),
+        "InvalidState"
+      );
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorTwo }),
+        "InvalidState"
+      );
+    });
+
+    it("requires assignment and non-completion for votes", async () => {
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await manager.validateJob(0, "validator", [], { from: validatorOne });
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+
+      await createJob(employer, payout, duration, "QmNewJob");
+      await expectCustomError(
+        manager.validateJob.call(1, "validator", [], { from: validatorOne }),
+        "InvalidState"
+      );
+    });
+
+    it("blocks blacklisted agents and validators", async () => {
+      await manager.blacklistAgent(agent, true, { from: owner });
+      await createJob(employer, payout, duration, "QmBlocked");
+      await expectCustomError(
+        manager.applyForJob.call(1, "agent", [], { from: agent }),
+        "Blacklisted"
+      );
+
+      await manager.blacklistValidator(validatorOne, true, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await expectCustomError(
+        manager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        "Blacklisted"
+      );
+    });
+  });
+
+  describe("dispute resolution behavior", () => {
+    beforeEach(async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+    });
+
+    it("allows only employer or agent to dispute", async () => {
+      await expectCustomError(manager.disputeJob.call(0, { from: outsider }), "NotAuthorized");
+      await manager.disputeJob(0, { from: agent });
+      await expectCustomError(manager.disputeJob.call(0, { from: agent }), "InvalidState");
+    });
+
+    it("marks job disputed once disapproval threshold reached", async () => {
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.addAdditionalValidator(validatorTwo, { from: owner });
+      await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+
+      await manager.disapproveJob(0, "validator", [], { from: validatorOne });
+      const receipt = await manager.disapproveJob(0, "validator", [], { from: validatorTwo });
+      expectEvent(receipt, "JobDisputed", { jobId: new BN(0), disputant: validatorTwo });
+      const job = await manager.jobs(0);
+      assert.equal(job.disputed, true);
+    });
+
+    it("resolves disputes with agent win, employer win, and neutral outcomes", async () => {
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 100, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await manager.disputeJob(0, { from: employer });
+      await expectCustomError(
+        manager.resolveDispute.call(0, "agent win", { from: outsider }),
+        "NotModerator"
+      );
+
+      const agentBalanceBefore = await token.balanceOf(agent);
+      const resolutionReceipt = await manager.resolveDispute(0, "agent win", { from: moderator });
+      expectEvent(resolutionReceipt, "DisputeResolved", { jobId: new BN(0), resolver: moderator });
+      const agentBalanceAfter = await token.balanceOf(agent);
+      assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), payout.toString());
+
+      const newJobId = await manager.nextJobId();
+      await createJob();
+      await manager.applyForJob(newJobId, "agent", [], { from: agent });
+      await manager.disputeJob(newJobId, { from: employer });
+      const neutralReceipt = await manager.resolveDispute(newJobId, "needs more info", { from: moderator });
+      expectEvent(neutralReceipt, "DisputeResolved", { jobId: newJobId, resolver: moderator });
+      const neutralJob = await manager.jobs(newJobId);
+      assert.equal(neutralJob.completed, false);
+      assert.equal(neutralJob.disputed, false);
+    });
+  });
+
+  describe("checked ERC20 transfers", () => {
+    it("reverts createJob if transferFrom fails", async () => {
+      const failingToken = await FailingERC20.new();
+      await failingToken.mint(employer, payout);
+      await failingToken.setFailTransferFroms(true);
+
+      const altManager = await AGIJobManager.new(
+        failingToken.address,
+        baseIpfsUrl,
+        ens.address,
+        nameWrapper.address,
+        clubRoot,
+        agentRoot,
+        validatorTree.root,
+        agentTree.root
+      );
+
+      await failingToken.approve(altManager.address, payout, { from: employer });
+      await expectCustomError(
+        altManager.createJob.call(jobIpfs, payout, duration, jobDetails, { from: employer }),
+        "TransferFailed"
+      );
+    });
+
+    it("reverts payouts when transfer returns false", async () => {
+      const failingToken = await FailingERC20.new();
+      await failingToken.mint(employer, payout);
+      await failingToken.mint(owner, payout);
+
+      const altManager = await AGIJobManager.new(
+        failingToken.address,
+        baseIpfsUrl,
+        ens.address,
+        nameWrapper.address,
+        clubRoot,
+        agentRoot,
+        validatorTree.root,
+        agentTree.root
+      );
+      await altManager.addAdditionalAgent(agent, { from: owner });
+      await altManager.addAGIType(agiTypeNft.address, 100, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await failingToken.approve(altManager.address, payout, { from: employer });
+      await altManager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer });
+      await altManager.applyForJob(0, "agent", [], { from: agent });
+
+      await failingToken.setFailTransfers(true);
+      await altManager.addModerator(moderator, { from: owner });
+      await altManager.disputeJob(0, { from: agent });
+      await expectCustomError(
+        altManager.resolveDispute.call(0, "agent win", { from: moderator }),
+        "TransferFailed"
+      );
+    });
+
+    it("reverts NFT purchases when transferFrom fails", async () => {
+      const failingToken = await FailingERC20.new();
+      await failingToken.mint(employer, payout);
+      await failingToken.mint(buyer, payout);
+
+      const altManager = await AGIJobManager.new(
+        failingToken.address,
+        baseIpfsUrl,
+        ens.address,
+        nameWrapper.address,
+        clubRoot,
+        agentRoot,
+        validatorTree.root,
+        agentTree.root
+      );
+      await altManager.addAdditionalAgent(agent, { from: owner });
+      await altManager.addAGIType(agiTypeNft.address, 92, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await failingToken.approve(altManager.address, payout, { from: employer });
+      await altManager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer });
+      await altManager.applyForJob(0, "agent", [], { from: agent });
+      await altManager.addAdditionalValidator(validatorOne, { from: owner });
+      await altManager.setRequiredValidatorApprovals(1, { from: owner });
+      await altManager.validateJob(0, "validator", [], { from: validatorOne });
+
+      const tokenId = (await altManager.nextTokenId()).subn(1);
+      await altManager.listNFT(tokenId, payout, { from: employer });
+      await failingToken.setFailTransferFroms(true);
+      await failingToken.approve(altManager.address, payout, { from: buyer });
+
+      await expectCustomError(altManager.purchaseNFT.call(tokenId, { from: buyer }), "TransferFailed");
+    });
+  });
+
+  describe("admin & configuration", () => {
+    it("restricts owner-only controls and updates config", async () => {
+      await expectRevert(manager.setBaseIpfsUrl("ipfs://new", { from: outsider }), "Ownable: caller is not the owner");
+      await expectRevert(
+        manager.updateAGITokenAddress(token.address, { from: outsider }),
+        "Ownable: caller is not the owner"
+      );
+      await expectRevert(manager.setMaxJobPayout(payout, { from: outsider }), "Ownable: caller is not the owner");
+      await expectRevert(manager.setJobDurationLimit(1, { from: outsider }), "Ownable: caller is not the owner");
+      await expectRevert(manager.addModerator(outsider, { from: outsider }), "Ownable: caller is not the owner");
+      await expectRevert(manager.blacklistAgent(agent, true, { from: outsider }), "Ownable: caller is not the owner");
+      await expectRevert(manager.addAdditionalAgent(agent, { from: outsider }), "Ownable: caller is not the owner");
+
+      await manager.setBaseIpfsUrl("ipfs://new", { from: owner });
+      await manager.updateAGITokenAddress(token.address, { from: owner });
+      await manager.setMaxJobPayout(payout.muln(10), { from: owner });
+      await manager.setJobDurationLimit(9000, { from: owner });
+      await manager.addModerator(validatorFour, { from: owner });
+      await manager.removeModerator(validatorFour, { from: owner });
+      await manager.blacklistAgent(agent, true, { from: owner });
+      await manager.blacklistAgent(agent, false, { from: owner });
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.removeAdditionalAgent(agent, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.removeAdditionalValidator(validatorOne, { from: owner });
+
+      assert.equal(await manager.maxJobPayout(), payout.muln(10).toString());
+      assert.equal(await manager.jobDurationLimit(), "9000");
+    });
+
+    it("withdraws AGI with bounds checks", async () => {
+      await token.mint(manager.address, payout);
+      await expectCustomError(manager.withdrawAGI.call(0, { from: owner }), "InvalidParameters");
+      await expectCustomError(manager.withdrawAGI.call(payout.muln(2), { from: owner }), "InvalidParameters");
+
+      const ownerBalanceBefore = await token.balanceOf(owner);
+      await manager.withdrawAGI(payout, { from: owner });
+      const ownerBalanceAfter = await token.balanceOf(owner);
+      assert.equal(ownerBalanceAfter.sub(ownerBalanceBefore).toString(), payout.toString());
+    });
+  });
+
+  describe("NFT marketplace", () => {
+    beforeEach(async () => {
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
+      await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
+      await agiTypeNft.mint(agent);
+
+      await createJob();
+      await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.validateJob(0, "validator", [], { from: validatorOne });
+    });
+
+    it("lists, purchases, and delists NFTs with proper access control", async () => {
+      const tokenId = (await manager.nextTokenId()).subn(1);
+      await expectCustomError(manager.listNFT.call(tokenId, 0, { from: employer }), "InvalidParameters");
+      await expectCustomError(manager.listNFT.call(tokenId, payout, { from: outsider }), "NotAuthorized");
+
+      const listReceipt = await manager.listNFT(tokenId, payout, { from: employer });
+      expectEvent(listReceipt, "NFTListed", { tokenId, seller: employer, price: payout });
+
+      await token.approve(manager.address, payout, { from: buyer });
+      const purchaseReceipt = await manager.purchaseNFT(tokenId, { from: buyer });
+      expectEvent(purchaseReceipt, "NFTPurchased", { tokenId, buyer, price: payout });
+
+      assert.equal(await manager.ownerOf(tokenId), buyer);
+      await expectCustomError(manager.delistNFT.call(tokenId, { from: employer }), "NotAuthorized");
+    });
+
+    it("allows seller to delist active listing", async () => {
+      const tokenId = (await manager.nextTokenId()).subn(1);
+      await manager.listNFT(tokenId, payout, { from: employer });
+      const delistReceipt = await manager.delistNFT(tokenId, { from: employer });
+      expectEvent(delistReceipt, "NFTDelisted", { tokenId });
+    });
+  });
+
+  describe("ownership gating (ENS & Merkle)", () => {
+    it("accepts valid Merkle proofs and rejects invalid ones", async () => {
+      await createJob();
+      await assignAgentWithProof(0, agent);
+
+      await createJob(employer, payout, duration, "QmSecond");
+      await expectCustomError(
+        manager.applyForJob.call(1, "agent", [], { from: agent }),
+        "NotAuthorized"
+      );
+
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.applyForJob(1, "agent", [], { from: agent });
+    });
+
+    it("accepts NameWrapper ownership and resolver address matches", async () => {
+      await createJob();
+      const subdomain = "agent";
+      await setNameWrapperOwnership(nameWrapper, agentRoot, subdomain, agent);
+      await manager.applyForJob(0, subdomain, [], { from: agent });
+
+      await createJob(employer, payout, duration, "QmResolver");
+      await setResolverOwnership(ens, resolver, clubRoot, "validator", validatorOne);
+      await manager.applyForJob(1, "agent", agentTree.proofFor(agent), { from: agent });
+      await manager.validateJob(1, "validator", [], { from: validatorOne });
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide an exhaustive Truffle test suite that proves `contracts/AGIJobManager.sol` behaves as intended and verifies the “better-only” hardening fixes (takeover protection, double-complete prevention, div-by-zero prevention, vote rules, dispute resolution, and checked token transfers). 
- Keep production contract unchanged and use minimal test-only mocks to exercise ENS/Merkle, ERC‑20 failure modes, and AGIType NFT boosts.

### Description
- Add a new comprehensive test file `test/AGIJobManager.comprehensive.test.js` that covers deployment defaults, the full job lifecycle (create/apply/request/validate/_complete), payouts & reputation, NFT minting/listing/purchase flows, vote/dispute rules, admin access controls, ENS/NameWrapper/Resolver and Merkle gating, and checked ERC‑20 transfer failure cases. 
- Add `docs/Testing.md` with exact local instructions for installing deps, starting Ganache, compiling, and running the tests; document the test-only mocks used. 
- Tests reuse existing minimal mocks under `contracts/test/` (`MockERC20`, `FailingERC20`, `FailTransferToken`, `MockENS`, `MockResolver`, `MockNameWrapper`, `MockERC721`) and helper utilities in `test/helpers/` (`ens.js`, `errors.js`). 
- All changes are test-only; `contracts/AGIJobManager.sol` was not modified.

### Testing
- Commands executed: `npm install` (dependencies installed; npm audit warnings only), `npx truffle compile` (compiled with configured solc), started Ganache with `npx ganache -p 8545 --wallet.mnemonic "test test test test test test test test test test test junk"`, and ran `npx truffle test --network development` (Truffle picks `development`/Ganache settings from `truffle-config.js`).
- Result: test run completed successfully with all added checks; the test suite reported `88 passing` and no remaining failing tests in this run. 
- Coverage highlights: the suite explicitly asserts takeover/phantom-jobId guards, prevents double-complete and late validations, demonstrates safe completion with zero validators (no division by zero), enforces vote rules and blacklists, validates dispute resolution outcomes (agent win / employer win / neutral), and verifies that operations revert when ERC‑20 `transfer`/`transferFrom` return `false`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ad2bc250883338cd812f21da4a7b6)