### PR TITLE
Add ERC‑8004 adapter: docs, deterministic exporter, schemas, examples, and smoke test

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -30,3 +30,12 @@ ETHERSCAN_API_KEY=
 
 # Local test chain
 GANACHE_MNEMONIC=
+
+# ERC-8004 adapter (off-chain tooling)
+AGIJOBMANAGER_ADDRESS=
+FROM_BLOCK=
+TO_BLOCK=
+OUT_DIR=integrations/erc8004/out
+INCLUDE_VALIDATORS=false
+EVENT_BATCH_SIZE=2000
+METRICS_JSON=integrations/erc8004/out/erc8004_metrics.json

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ Start here:
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)
+- **ERC‑8004 integration (control plane ↔ execution plane)**: [`docs/erc8004/README.md`](docs/erc8004/README.md)
 - **AGI.Eth Namespace (alpha)**:
   - User guide: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md)
   - Quickstart: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md)

--- a/docs/ERC8004.md
+++ b/docs/ERC8004.md
@@ -1,6 +1,6 @@
 # ERC‑8004 integration (signaling → enforcement)
 
-AGIJobManager keeps escrow and settlement logic fully on‑chain and avoids external dependencies in critical flows. ERC‑8004 integration is intentionally **off‑chain** in this repository.
+AGIJobManager keeps escrow and settlement logic fully on‑chain and avoids external dependencies in critical flows. ERC‑8004 integration is intentionally **off‑chain** in this repository. For the detailed mapping spec and threat model, see [`docs/erc8004/README.md`](erc8004/README.md).
 
 ## What is ERC‑8004?
 ERC‑8004 standardizes how agent identity, reputation, and validation signals are published so other systems can index and consume them consistently.

--- a/docs/Integrations.md
+++ b/docs/Integrations.md
@@ -16,6 +16,7 @@ Events to watch:
 AGIJobManager keeps escrow settlement fully on‑chain and does **not** depend on any ERC‑8004 contract. The repository provides an off‑chain adapter that maps job events into ERC‑8004 reputation signals.
 
 - Integration pattern: [`docs/ERC8004.md`](ERC8004.md)
+- Mapping spec & threat model: [`docs/erc8004/README.md`](erc8004/README.md)
 - Adapter implementation: [`integrations/erc8004/`](../integrations/erc8004/)
 
 ## Indexing guidance

--- a/docs/README.md
+++ b/docs/README.md
@@ -16,6 +16,7 @@ This documentation set targets engineers, integrators, operators, and auditors. 
 
 ## Trust layer & integrations
 - **Full‑stack trust layer (ERC‑8004 → enforcement)**: [`ERC8004.md`](ERC8004.md)
+- **ERC‑8004 integration (control plane ↔ execution plane)**: [`erc8004/README.md`](erc8004/README.md)
 - **Integrations overview**: [`Integrations.md`](Integrations.md)
 
 ## Role guides

--- a/docs/erc8004/AGIJobManager_to_ERC8004.md
+++ b/docs/erc8004/AGIJobManager_to_ERC8004.md
@@ -1,0 +1,96 @@
+# AGIJobManager → ERC-8004 mapping spec (human-friendly)
+
+This document defines how AGIJobManager execution outcomes map to ERC-8004 identity, reputation, and validation signals **without touching on-chain contract logic**. It implements the control-plane ↔ execution-plane separation required by the trust-layer architecture.
+
+## 1) Identity mapping (AGI.Eth → ERC-8004 registration)
+
+### AGI.Eth namespace grammar
+AGI.Eth names follow:
+```
+<entity>.(<env>.)<role>.agi.eth
+```
+Where `role ∈ {club, agent, node}` and `env` is optional (e.g., `alpha`). Examples:
+- `alpha.agent.agi.eth`
+- `alpha.club.agi.eth`
+- `node.agi.eth`
+
+### ERC-8004 registration “services”
+Per EIP-8004 and the best-practices Registration guide, agent registration files include a top-level `services` array. Each entry is a flexible **endpoint descriptor** with a `name`, `endpoint`, and optional `version`.
+
+**Recommended representation** (AGI.Eth identity):
+| AGI.Eth role | Example name | ERC-8004 service entry (`services[]`) | Notes |
+| --- | --- | --- | --- |
+| `agent` | `alpha.agent.agi.eth` | `{ "name": "ENS", "endpoint": "alpha.agent.agi.eth", "version": "v1" }` | Primary agent identity for AGIJobManager. |
+| `club` | `alpha.club.agi.eth` | `{ "name": "ENS", "endpoint": "alpha.club.agi.eth", "version": "v1" }` | Validator identity (club = validator). |
+| `node` | `alpha.node.agi.eth` | `{ "name": "ENS", "endpoint": "alpha.node.agi.eth", "version": "v1" }` | Node identity for infrastructure / routing. |
+
+**Additional recommended services**:
+- `agentWallet` (payments): `{ "name": "agentWallet", "endpoint": "eip155:1:0x..." }`
+- `MCP` and/or `A2A` endpoints for agent communication
+
+> The adapter itself only reads on-chain events. Identity registration is supplied by the agent/validator using ERC-8004 registration registries.
+
+## 2) Reputation export rules (execution → signals)
+
+### Core aggregates (per agent)
+The adapter aggregates the following from AGIJobManager events:
+- `jobsAssigned` — number of `JobApplied` events (assignment on apply)
+- `jobsCompletionRequested` — number of `JobCompletionRequested` events
+- `jobsCompleted` — number of `JobCompleted` events
+- `jobsDisputed` — number of `JobDisputed` events
+- `agentWins` / `employerWins` / `unknownResolutions` — derived from `DisputeResolved` resolution strings
+- `revenuesProxy` — sum of `job.payout` for completed jobs (proxy only)
+
+### Rate definitions
+Rates are exported in ERC-8004’s fixed-point format (`value`, `valueDecimals`):
+- `successRate` = `jobsCompleted / jobsAssigned * 100`
+- `disputeRate` = `jobsDisputed / jobsAssigned * 100`
+
+Example encoding (aligned to EIP-8004):
+- successRate 99.80% → `value=9980`, `valueDecimals=2`
+- downvote −1 → `value=-1`, `valueDecimals=0`
+- revenues $556,000 → `value=556000`, `valueDecimals=0`
+
+### Tag conventions (best-practices-aligned)
+Recommended `tag1` values when publishing feedback:
+- `successRate`
+- `uptime`
+- `responseTime`
+- `blocktimeFreshness`
+- `revenues`
+- `ownerVerified`
+
+## 3) Validation export rules (validator outcomes → validation signals)
+
+ERC-8004 includes a validation registry (requests + responses). We map AGIJobManager validator outcomes **off-chain** to validation-like artifacts:
+- `JobValidated` → validation response with `response=100` (passed)
+- `JobDisapproved` → validation response with `response=0` (failed)
+- `DisputeResolved` → optional validation tag (e.g., `jobDisputeResolution`) tied to the same request hash
+
+**Request hash suggestion** (off-chain only):
+```
+requestHash = keccak256(chainId, contractAddress, jobId, eventTxHash)
+```
+This keeps validation artifacts anchored to a specific on-chain job outcome without coupling settlement to external calls.
+
+## 4) Trusted rater set guidance (sybil resistance)
+A recommended policy for trusted raters is:
+- **Eligible raters are addresses that created paid jobs** (`JobCreated` with `payout > 0`).
+
+This is a **policy choice**, not a protocol guarantee. Indexers/rankers should document and enforce their own trusted rater sets.
+
+## 5) Evidence model (auditable anchors)
+Every exported signal must be traceable to on-chain anchors. The adapter outputs:
+- `txHash`, `logIndex`, `blockNumber`, `contractAddress`, `chainId`
+
+Heavy data (full job details, external proofs, or explanation text) stays **off-chain** and can be referenced by hash if needed.
+
+## 6) Separation rationale (control plane vs execution plane)
+- **ERC-8004**: publish minimal, verifiable trust signals.
+- **AGIJobManager**: escrow, settlement, validation, and dispute enforcement.
+- **Invariant**: no payout without validated proof; no settlement without validation.
+
+This mapping preserves liveness by preventing any ERC-8004 dependency from gating escrow finalization.
+
+## Version alignment
+Aligned to EIP-8004 and the ERC-8004 best-practices Registration/Reputation guides as of **2026-01-29**.

--- a/docs/erc8004/README.md
+++ b/docs/erc8004/README.md
@@ -1,0 +1,30 @@
+# ERC-8004 integration (control plane ↔ execution plane)
+
+This repository treats **ERC-8004** as the *trust-signaling control plane* (Identity • Reputation • Validation), and **AGIJobManager** as the *execution + settlement plane* (AuthZ gate • escrow • quorum validation • disputes • reputation accounting). The integration is intentionally **off-chain** and **non-blocking**: no payout or finalization path depends on external ERC-8004 calls.
+
+## Canonical framing (internal sources)
+The architectural intent in this repo aligns with the internal decks:
+- **MONTREAL.AI × ERC-8004 Full-Stack Trust Layer** (`presentations/MONTREALAI_x_ERC8004_v0.pdf`)
+- **AGI.Eth Namespace + AGI Jobs v0 institutional brief** (`presentations/AGI_Eth_Institutional_v0.pdf`)
+
+These sources emphasize **signaling vs enforcement** and the invariant mindset: **no payout without validated proof; no settlement without validation**.
+
+## External references (verified)
+Aligned to the latest public sources as of **2026-01-29**:
+- **EIP-8004 spec** (registration uses a `services` array with `name`/`endpoint`/`version`, feedback uses `value` + `valueDecimals`, optional `tag1`/`tag2`, `endpoint`, `feedbackURI`, `feedbackHash`): https://eips.ethereum.org/EIPS/eip-8004
+- **ERC-8004 best practices** (Registration + Reputation guides):
+  - https://github.com/erc-8004/best-practices/blob/main/Registration.md
+  - https://github.com/erc-8004/best-practices/blob/main/Reputation.md
+- **Ethereum Foundation intro**: https://ai.ethereum.foundation/blog/intro-erc-8004
+
+## Quick links
+- **Mapping spec**: [`AGIJobManager_to_ERC8004.md`](AGIJobManager_to_ERC8004.md)
+- **Threat model**: [`ThreatModel.md`](ThreatModel.md)
+- **Adapter spec & examples**: [`integrations/erc8004/`](../../integrations/erc8004)
+
+## Why the separation matters
+- **ERC-8004 is signaling**: publish minimal, verifiable trust signals for indexing, ranking, and policy formation.
+- **AGIJobManager is enforcement**: settle escrow, apply dispute outcomes, and account for reputation without external dependencies.
+- **No liveness dependency**: AGIJobManager does not wait for ERC-8004 registries, indexers, or feedback submissions.
+
+The adapter translates **execution outcomes** into portable ERC-8004-friendly signals without coupling settlement to external calls.

--- a/docs/erc8004/ThreatModel.md
+++ b/docs/erc8004/ThreatModel.md
@@ -1,0 +1,46 @@
+# ERC-8004 integration threat model (AGIJobManager)
+
+This threat model focuses on the **off-chain adapter** and the **signaling vs enforcement** separation. AGIJobManager remains the enforcement plane; ERC-8004 is a signaling plane.
+
+## What we gain
+- **Portable trust signals** for identity, reputation, and validation that can be indexed by any ERC-8004-aware service.
+- **Composability** across catalogs, rankers, insurers, and auditors without modifying the core escrow contract.
+- **Auditability**: every exported signal includes on-chain anchors (txHash, logIndex, blockNumber, contractAddress, chainId).
+
+## What we do NOT trust
+- **Off-chain computation** is not authoritative for settlement.
+- **External indexers/registries** are not liveness dependencies for payouts or dispute resolution.
+- **Self-reported metadata** (registration fields) is informational and must be weighted or verified by observers.
+
+## Core safety principle
+**No payout without validated proof; no settlement without validation.**
+
+The adapter reads events after settlement is finalized; it never influences on-chain control flow.
+
+## Attack surfaces & mitigations
+### 1) Sybil feedback
+- **Risk**: attackers can post feedback from many addresses.
+- **Mitigation**: establish a trusted rater set (e.g., addresses that created paid jobs) and filter/weight accordingly.
+- **Note**: this is a policy choice, not a protocol guarantee.
+
+### 2) Data availability / indexer downtime
+- **Risk**: ERC-8004 indexer is down or delayed.
+- **Mitigation**: no on-chain dependency; settlement is independent. Off-chain exports can be regenerated later.
+
+### 3) Off-chain data tampering
+- **Risk**: metrics file altered.
+- **Mitigation**: anchor evidence to on-chain logs (txHash/logIndex), optionally publish a content hash (e.g., IPFS CID or keccak256) in ERC-8004 feedback.
+
+### 4) Metric ambiguity
+- **Risk**: different observers compute metrics differently.
+- **Mitigation**: adapter spec explicitly defines rates, thresholds, and event mappings. Any alternative policy must document its deviations.
+
+## Residual risks
+- **Economic manipulation**: agents could complete low-value jobs to boost counts.
+- **Bias**: trusted rater selection can be too strict or too permissive.
+- **Context gaps**: on-chain events can’t encode the full job context; heavy data remains off-chain.
+
+## Why off-chain export is safe
+- The adapter only **reads** on-chain data and exports it.
+- It never triggers on-chain calls during job completion or dispute resolution.
+- Signals are **verifiable** and **replayable** by independent observers.

--- a/integrations/erc8004/README.md
+++ b/integrations/erc8004/README.md
@@ -26,16 +26,16 @@ truffle exec scripts/erc8004/export_metrics.js --network sepolia
 ```
 
 ## Output
-The export script writes a JSON file containing per-agent metrics, computed rates, and metadata. See `adapter_spec.md` for field definitions.
+The export script writes a JSON file containing per-agent metrics, computed rates, evidence anchors, and metadata. See `adapter_spec.md` for field definitions and `schemas/metrics.schema.json` for a JSON Schema snapshot.
 
-## Next step: feedback intent generation
+## Next step: feedback action plan (dry-run)
 ```bash
 METRICS_JSON=integrations/erc8004/out/erc8004_metrics.json \
 OUT_DIR=integrations/erc8004/out \
-node scripts/erc8004/generate_feedback_calldata.js
+node scripts/erc8004/generate_feedback_actions.js
 ```
 
-This generates a dry-run list of intended ERC-8004 feedback signals (no transactions are sent). For on-chain submission, use the official ERC-8004 tooling (e.g., Agent0 SDK) and the JSON output as input.
+This generates a dry-run list of intended ERC-8004 feedback signals (no transactions are sent). For on-chain submission, use the official ERC-8004 tooling (for example, the SDKs linked from the best-practices repo) and the JSON output as input.
 
 ## Example registration file
 See `integrations/erc8004/examples/registration.json` for a sample ERC-8004 registration JSON with a `services` array.

--- a/integrations/erc8004/adapter_spec.md
+++ b/integrations/erc8004/adapter_spec.md
@@ -1,12 +1,14 @@
 # Adapter spec: AGIJobManager → ERC-8004 metrics
 
-This adapter reads AGIJobManager events over a block range and aggregates **per-agent** reputation metrics, with optional **per-validator** aggregates.
+This adapter reads AGIJobManager events over a block range and aggregates **per-agent** reputation metrics, with optional **per-validator** aggregates. It is intentionally **off-chain** and only emits JSON artifacts.
 
 ## Event → metric mapping
 - `JobCreated(jobId, ...)`
-  - Employer addresses are recorded for the “trusted client set.”
+  - Employer addresses are recorded for the “trusted client set” (addresses that created paid jobs).
 - `JobApplied(jobId, agent)`
   - Increments `jobsApplied` and `jobsAssigned` for the agent (AGIJobManager assigns on apply).
+- `JobCompletionRequested(jobId, agent)`
+  - Increments `jobsCompletionRequested` for the agent.
 - `JobCompleted(jobId, agent, ...)`
   - Increments `jobsCompleted` for the agent.
   - Adds `job.payout` (proxy for revenue) to `revenuesProxy`.
@@ -15,9 +17,12 @@ This adapter reads AGIJobManager events over a block range and aggregates **per-
 - `DisputeResolved(jobId, resolution)`
   - Increments `agentWins`, `employerWins`, or `unknownResolutions` for the assigned agent depending on the resolution string.
 - `JobValidated(jobId, validator)` (optional)
-  - Increments `jobsValidated` for the validator.
+  - Increments `approvals` for the validator.
 - `JobDisapproved(jobId, validator)` (optional)
-  - Increments `jobsDisapproved` for the validator.
+  - Increments `disapprovals` for the validator.
+- `ReputationUpdated(user, newReputation)` (optional)
+  - If `user` is a known validator in-range, increments `reputationUpdates` and updates `latestReputation`.
+  - `reputationGain` sums **positive deltas** between consecutive updates observed in-range (best-effort proxy only).
 
 ## Computed rates
 Rates are expressed as percentages with `valueDecimals=2` (basis points of percent):
@@ -26,27 +31,49 @@ Rates are expressed as percentages with `valueDecimals=2` (basis points of perce
 
 If `jobsAssigned` is 0, rates are omitted.
 
+## Evidence anchors
+Every metric bundle includes `evidence.anchors[]` with:
+- `txHash`, `logIndex`, `blockNumber`
+- `event`, `jobId`
+- `contractAddress`, `chainId`
+
+Heavy data stays off-chain; anchors are sufficient to re-derive metrics.
+
 ## Output schema (intermediate JSON)
 ```json
 {
-  "version": "0.1",
+  "version": "0.2",
   "metadata": {
     "chainId": 11155111,
     "network": "sepolia",
+    "contractAddress": "0x...",
     "fromBlock": 0,
     "toBlock": 123456,
     "generatedAt": "2024-05-01T00:00:00.000Z",
-    "sourceContract": "0x...",
-    "adapterVersion": "0.1.0"
+    "toolVersion": "agijobmanager-erc8004-adapter@0.1.0"
   },
   "trustedClientSet": {
     "criteria": "addresses that created paid jobs in range",
-    "addresses": ["0x..."]
+    "addresses": ["0x..."],
+    "evidence": {
+      "anchors": [
+        {
+          "txHash": "0x...",
+          "logIndex": 3,
+          "blockNumber": 12345,
+          "event": "JobCreated",
+          "jobId": "1",
+          "chainId": 11155111,
+          "contractAddress": "0x..."
+        }
+      ]
+    }
   },
   "agents": {
-    "0xAgent": {
+    "0xagent": {
       "jobsApplied": 2,
       "jobsAssigned": 2,
+      "jobsCompletionRequested": 1,
       "jobsCompleted": 1,
       "jobsDisputed": 0,
       "employerWins": 0,
@@ -56,13 +83,19 @@ If `jobsAssigned` is 0, rates are omitted.
       "rates": {
         "successRate": {"value": 5000, "valueDecimals": 2},
         "disputeRate": {"value": 0, "valueDecimals": 2}
-      }
+      },
+      "evidence": {"anchors": []}
     }
   },
   "validators": {
-    "0xValidator": {
-      "jobsValidated": 3,
-      "jobsDisapproved": 1
+    "0xvalidator": {
+      "approvals": 3,
+      "disapprovals": 1,
+      "disputesTriggered": 0,
+      "reputationUpdates": 1,
+      "reputationGain": "5",
+      "latestReputation": "42",
+      "evidence": {"anchors": []}
     }
   }
 }
@@ -71,3 +104,4 @@ If `jobsAssigned` is 0, rates are omitted.
 ## Notes
 - `revenuesProxy` is the sum of job `payout` values for completed jobs. This is a **proxy** for actual transfers.
 - Resolution strings are treated case-insensitively and mapped to `agent win` / `employer win`.
+- `reputationGain` is best-effort and only covers updates within the specified block range.

--- a/integrations/erc8004/examples/feedback_actions.sample.json
+++ b/integrations/erc8004/examples/feedback_actions.sample.json
@@ -1,0 +1,75 @@
+{
+  "source": {
+    "chainId": 1337,
+    "network": "development",
+    "contractAddress": "0x0000000000000000000000000000000000000001",
+    "fromBlock": 0,
+    "toBlock": 42,
+    "generatedAt": "2026-01-29T00:00:00.000Z",
+    "toolVersion": "agijobmanager-erc8004-adapter@0.1.0"
+  },
+  "generatedAt": "2026-01-29T00:00:10.000Z",
+  "actions": [
+    {
+      "subject": {
+        "address": "0x00000000000000000000000000000000000000bb",
+        "ens": null
+      },
+      "tag1": "disputeRate",
+      "value": 5000,
+      "valueDecimals": 2,
+      "evidence": {
+        "anchors": [],
+        "feedbackURI": null,
+        "feedbackHash": null
+      },
+      "notes": {
+        "tagNote": null,
+        "jobsAssigned": 2,
+        "jobsCompleted": 1,
+        "jobsDisputed": 1
+      }
+    },
+    {
+      "subject": {
+        "address": "0x00000000000000000000000000000000000000bb",
+        "ens": null
+      },
+      "tag1": "revenues",
+      "value": "1000000000000000000",
+      "valueDecimals": 0,
+      "evidence": {
+        "anchors": [],
+        "feedbackURI": null,
+        "feedbackHash": null
+      },
+      "notes": {
+        "tagNote": "Proxy: sum of job payout values for completed jobs (raw token units).",
+        "jobsAssigned": 2,
+        "jobsCompleted": 1,
+        "jobsDisputed": 1
+      }
+    },
+    {
+      "subject": {
+        "address": "0x00000000000000000000000000000000000000bb",
+        "ens": null
+      },
+      "tag1": "successRate",
+      "value": 5000,
+      "valueDecimals": 2,
+      "evidence": {
+        "anchors": [],
+        "feedbackURI": null,
+        "feedbackHash": null
+      },
+      "notes": {
+        "tagNote": null,
+        "jobsAssigned": 2,
+        "jobsCompleted": 1,
+        "jobsDisputed": 1
+      }
+    }
+  ],
+  "notes": "Dry-run output only. Use official ERC-8004 tooling for on-chain submission."
+}

--- a/integrations/erc8004/examples/output.sample.json
+++ b/integrations/erc8004/examples/output.sample.json
@@ -1,0 +1,72 @@
+{
+  "version": "0.2",
+  "metadata": {
+    "chainId": 1337,
+    "network": "development",
+    "contractAddress": "0x0000000000000000000000000000000000000001",
+    "fromBlock": 0,
+    "toBlock": 42,
+    "generatedAt": "2026-01-29T00:00:00.000Z",
+    "toolVersion": "agijobmanager-erc8004-adapter@0.1.0"
+  },
+  "trustedClientSet": {
+    "criteria": "addresses that created paid jobs in range",
+    "addresses": ["0x00000000000000000000000000000000000000aa"],
+    "evidence": {
+      "anchors": [
+        {
+          "txHash": "0xabc",
+          "logIndex": 1,
+          "blockNumber": 10,
+          "event": "JobCreated",
+          "jobId": "1",
+          "chainId": 1337,
+          "contractAddress": "0x0000000000000000000000000000000000000001"
+        }
+      ]
+    }
+  },
+  "agents": {
+    "0x00000000000000000000000000000000000000bb": {
+      "jobsApplied": 2,
+      "jobsAssigned": 2,
+      "jobsCompletionRequested": 1,
+      "jobsCompleted": 1,
+      "jobsDisputed": 1,
+      "employerWins": 1,
+      "agentWins": 0,
+      "unknownResolutions": 0,
+      "revenuesProxy": "1000000000000000000",
+      "rates": {
+        "successRate": {"value": 5000, "valueDecimals": 2},
+        "disputeRate": {"value": 5000, "valueDecimals": 2}
+      },
+      "evidence": {
+        "anchors": [
+          {
+            "txHash": "0xdef",
+            "logIndex": 2,
+            "blockNumber": 12,
+            "event": "JobCompleted",
+            "jobId": "1",
+            "chainId": 1337,
+            "contractAddress": "0x0000000000000000000000000000000000000001"
+          }
+        ]
+      }
+    }
+  },
+  "validators": {
+    "0x00000000000000000000000000000000000000cc": {
+      "approvals": 1,
+      "disapprovals": 1,
+      "disputesTriggered": 1,
+      "reputationUpdates": 1,
+      "reputationGain": "5",
+      "latestReputation": "42",
+      "evidence": {
+        "anchors": []
+      }
+    }
+  }
+}

--- a/integrations/erc8004/examples/registration.json
+++ b/integrations/erc8004/examples/registration.json
@@ -1,22 +1,29 @@
 {
+  "type": "https://eips.ethereum.org/EIPS/eip-8004#registration-v1",
   "name": "Example AGI Agent",
-  "description": "Example ERC-8004 registration metadata for an AGIJobManager agent.",
+  "description": "Example ERC-8004 registration metadata for an AGIJobManager agent (AGI.Eth alpha namespace).",
+  "image": "https://example.com/agent.png",
   "services": [
     {
-      "type": "a2a",
-      "url": "https://example.com/a2a.json"
+      "name": "A2A",
+      "endpoint": "https://example.com/.well-known/agent-card.json",
+      "version": "0.3.0",
+      "a2aSkills": ["task_execution/job_validation"]
     },
     {
-      "type": "mcp",
-      "url": "https://example.com/mcp"
+      "name": "MCP",
+      "endpoint": "https://example.com/mcp",
+      "version": "2025-06-18",
+      "mcpTools": ["job_summary", "job_execution"]
     },
     {
-      "type": "ens",
-      "value": "example-agent.eth"
+      "name": "ENS",
+      "endpoint": "alpha.agent.agi.eth",
+      "version": "v1"
     },
     {
-      "type": "email",
-      "value": "ops@example.com"
+      "name": "agentWallet",
+      "endpoint": "eip155:1:0x1111111111111111111111111111111111111111"
     }
   ]
 }

--- a/integrations/erc8004/schemas/metrics.schema.json
+++ b/integrations/erc8004/schemas/metrics.schema.json
@@ -1,0 +1,139 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "AGIJobManager ERC-8004 Metrics Export",
+  "type": "object",
+  "required": ["version", "metadata", "trustedClientSet", "agents"],
+  "properties": {
+    "version": {"type": "string"},
+    "metadata": {
+      "type": "object",
+      "required": ["chainId", "network", "contractAddress", "fromBlock", "toBlock", "generatedAt", "toolVersion"],
+      "properties": {
+        "chainId": {"type": "integer"},
+        "network": {"type": "string"},
+        "contractAddress": {"type": "string"},
+        "fromBlock": {"type": "integer"},
+        "toBlock": {"type": "integer"},
+        "generatedAt": {"type": "string"},
+        "toolVersion": {"type": "string"}
+      },
+      "additionalProperties": false
+    },
+    "trustedClientSet": {
+      "type": "object",
+      "required": ["criteria", "addresses", "evidence"],
+      "properties": {
+        "criteria": {"type": "string"},
+        "addresses": {"type": "array", "items": {"type": "string"}},
+        "evidence": {
+          "type": "object",
+          "required": ["anchors"],
+          "properties": {
+            "anchors": {"type": "array", "items": {"$ref": "#/definitions/anchor"}}
+          }
+        }
+      }
+    },
+    "agents": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/agentMetrics"}
+    },
+    "validators": {
+      "type": "object",
+      "additionalProperties": {"$ref": "#/definitions/validatorMetrics"}
+    }
+  },
+  "definitions": {
+    "anchor": {
+      "type": "object",
+      "required": ["txHash", "logIndex", "blockNumber", "event", "chainId", "contractAddress"],
+      "properties": {
+        "txHash": {"type": "string"},
+        "logIndex": {"type": "integer"},
+        "blockNumber": {"type": "integer"},
+        "event": {"type": "string"},
+        "jobId": {"type": ["string", "null"]},
+        "chainId": {"type": "integer"},
+        "contractAddress": {"type": "string"}
+      }
+    },
+    "rate": {
+      "type": "object",
+      "required": ["value", "valueDecimals"],
+      "properties": {
+        "value": {"type": "integer"},
+        "valueDecimals": {"type": "integer"}
+      }
+    },
+    "agentMetrics": {
+      "type": "object",
+      "required": [
+        "jobsApplied",
+        "jobsAssigned",
+        "jobsCompletionRequested",
+        "jobsCompleted",
+        "jobsDisputed",
+        "employerWins",
+        "agentWins",
+        "unknownResolutions",
+        "revenuesProxy",
+        "rates",
+        "evidence"
+      ],
+      "properties": {
+        "jobsApplied": {"type": "integer"},
+        "jobsAssigned": {"type": "integer"},
+        "jobsCompletionRequested": {"type": "integer"},
+        "jobsCompleted": {"type": "integer"},
+        "jobsDisputed": {"type": "integer"},
+        "employerWins": {"type": "integer"},
+        "agentWins": {"type": "integer"},
+        "unknownResolutions": {"type": "integer"},
+        "revenuesProxy": {"type": "string"},
+        "rates": {
+          "type": "object",
+          "properties": {
+            "successRate": {"$ref": "#/definitions/rate"},
+            "disputeRate": {"$ref": "#/definitions/rate"}
+          },
+          "additionalProperties": false
+        },
+        "evidence": {
+          "type": "object",
+          "required": ["anchors"],
+          "properties": {
+            "anchors": {"type": "array", "items": {"$ref": "#/definitions/anchor"}}
+          }
+        }
+      }
+    },
+    "validatorMetrics": {
+      "type": "object",
+      "required": [
+        "approvals",
+        "disapprovals",
+        "disputesTriggered",
+        "reputationUpdates",
+        "reputationGain",
+        "latestReputation",
+        "evidence"
+      ],
+      "properties": {
+        "approvals": {"type": "integer"},
+        "disapprovals": {"type": "integer"},
+        "disputesTriggered": {"type": "integer"},
+        "reputationUpdates": {"type": "integer"},
+        "reputationGain": {"type": "string"},
+        "latestReputation": {"type": ["string", "null"]},
+        "evidence": {
+          "type": "object",
+          "required": ["anchors"],
+          "properties": {
+            "anchors": {"type": "array", "items": {"$ref": "#/definitions/anchor"}}
+          }
+        }
+      }
+    }
+  },
+  "additionalProperties": false
+}

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -1,0 +1,114 @@
+const assert = require('assert');
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockResolver = artifacts.require('MockResolver');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+
+const { runExportMetrics } = require('../scripts/erc8004/export_metrics');
+
+const ZERO_ROOT = '0x' + '00'.repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract('ERC-8004 adapter export (smoke test)', (accounts) => {
+  const [owner, employer, agent, validator, moderator] = accounts;
+  let token;
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let manager;
+
+  const payout = toBN(toWei('10'));
+
+  async function createJob() {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob('ipfs-job', payout, 3600, 'details', { from: employer });
+    return tx.logs[0].args.jobId.toNumber();
+  }
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    resolver = await MockResolver.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      'ipfs://base',
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+  });
+
+  it('exports deterministic metrics and expected aggregates', async () => {
+    const jobId1 = await createJob();
+    await manager.applyForJob(jobId1, 'agent', EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId1, 'ipfs-complete', { from: agent });
+    await manager.validateJob(jobId1, 'club', EMPTY_PROOF, { from: validator });
+
+    const jobId2 = await createJob();
+    await manager.applyForJob(jobId2, 'agent', EMPTY_PROOF, { from: agent });
+    await manager.disapproveJob(jobId2, 'club', EMPTY_PROOF, { from: validator });
+    await manager.resolveDispute(jobId2, 'employer win', { from: moderator });
+
+    const toBlock = await web3.eth.getBlockNumber();
+    const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'erc8004-'));
+
+    const first = await runExportMetrics({
+      address: manager.address,
+      fromBlock: 0,
+      toBlock,
+      outDir,
+      includeValidators: true,
+      generatedAt: '2026-01-29T00:00:00.000Z',
+      toolVersion: 'test-runner',
+      network: 'test',
+    });
+
+    const second = await runExportMetrics({
+      address: manager.address,
+      fromBlock: 0,
+      toBlock,
+      outDir,
+      includeValidators: true,
+      generatedAt: '2026-01-29T00:00:00.000Z',
+      toolVersion: 'test-runner',
+      network: 'test',
+    });
+
+    const metrics = JSON.parse(fs.readFileSync(first.outPath, 'utf8'));
+    assert.deepStrictEqual(first.output, second.output, 'output should be deterministic');
+
+    const agentKey = agent.toLowerCase();
+    assert.ok(metrics.agents[agentKey], 'agent metrics should exist');
+    assert.strictEqual(metrics.agents[agentKey].jobsAssigned, 2);
+    assert.strictEqual(metrics.agents[agentKey].jobsCompletionRequested, 1);
+    assert.strictEqual(metrics.agents[agentKey].jobsCompleted, 1);
+    assert.strictEqual(metrics.agents[agentKey].jobsDisputed, 1);
+    assert.strictEqual(metrics.agents[agentKey].employerWins, 1);
+    assert.strictEqual(metrics.agents[agentKey].agentWins, 0);
+    assert.strictEqual(metrics.agents[agentKey].unknownResolutions, 0);
+
+    const validatorKey = validator.toLowerCase();
+    assert.ok(metrics.validators[validatorKey], 'validator metrics should exist');
+    assert.strictEqual(metrics.validators[validatorKey].approvals, 1);
+    assert.strictEqual(metrics.validators[validatorKey].disapprovals, 1);
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide an off‑chain ERC‑8004 integration that cleanly translates AGIJobManager execution outcomes into portable trust signals while preserving the contract-only enforcement model and avoiding any liveness dependency on external registries.
- Make exported signals deterministic, auditable, and BigNumber-safe so indexers/watchers can reproducibly derive reputation and validation inputs for ERC‑8004 feeds.
- Document the mapping, threat model, and AGI.Eth naming conventions so integrators and watchers share a single reference implementation and policy recommendation.

### Description
- Add documentation under `docs/erc8004/` including `README.md`, `AGIJobManager_to_ERC8004.md` (mapping spec), and `ThreatModel.md` (threats, mitigations, and policy guidance), and wire these into top-level docs and README links; alignment noted to EIP‑8004 and best‑practices as of 2026-01-29.
- Implement a deterministic, paginated exporter `scripts/erc8004/export_metrics.js` that reads AGIJobManager events, computes per-agent and optional per-validator aggregates, encodes rates as `value`/`valueDecimals`, anchors evidence to on‑chain `txHash/logIndex/blockNumber/contractAddress/chainId`, is BigNumber-safe for payouts, and supports configurable block ranges and batch sizes.
- Add `scripts/erc8004/generate_feedback_actions.js` to produce a dry-run, deterministic feedback action plan (sorted signals, evidence anchors) from exporter output and rename/refactor the previous generation script accordingly.
- Ship adapter artifacts under `integrations/erc8004/`: `README.md`, `adapter_spec.md`, `schemas/metrics.schema.json`, and examples (`registration.json`, `output.sample.json`, `feedback_actions.sample.json`).
- Add `.env.example` entries for adapter usage, update repo docs to link the new guidance, and ensure `integrations/erc8004/out/` is ignored by default in `.gitignore`.
- Add a deterministic smoke test `test/erc8004.adapter.test.js` that deploys AGIJobManager on the test network, runs a small job lifecycle (assign, request completion, validate/disapprove, resolve), invokes `runExportMetrics` programmatically twice, and asserts identical outputs and expected aggregates.
- Do not modify `contracts/AGIJobManager.sol` or add any new public/external contract functions or events; all integration work is strictly off‑chain and optional.

### Testing
- `npm install` completed successfully (packages installed; audit warnings noted but unrelated to functionality).
- `npx truffle compile` completed successfully with contracts compiled using `solc 0.8.33`.
- `npx truffle test --network test` was run and the full suite passed; the test run produced `89 passing` including the new `ERC-8004 adapter export (smoke test)` which asserts determinism and expected metrics.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ada057bc083338f7496af4e2787fe)