### PR TITLE
Clarify dispute resolution behavior and update interface regen command

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
+*Note:* `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested).
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/docs/README.md
+++ b/docs/README.md
@@ -40,5 +40,5 @@ The interface reference is generated from the compiled ABI. After running a comp
 
 ```bash
 npm run build
-node scripts/generate-interface-doc.js
+npm run docs:interface
 ```


### PR DESCRIPTION
### Motivation
- Remove ambiguity in the job lifecycle documentation about how `resolveDispute` behaves for non‑canonical resolution strings and make the interface regeneration instruction match the repo's npm scripts to avoid documentation drift.

### Description
- Add a README note that `resolveDispute` with a non‑canonical resolution clears the `disputed` flag and returns the job to its previous in‑progress state (Assigned or CompletionRequested). 
- Update `docs/README.md` to recommend `npm run docs:interface` (the existing npm script) for regenerating the ABI‑derived `Interface.md`.

### Testing
- Executed `npm install`, `npm run build` (Truffle compile) and `npm test`; compilation succeeded and the test suite passed locally with `89 passing` automated tests, and the repository contains a CI workflow at `.github/workflows/ci.yml` that will run the same checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b70a3597c833388fc10d9e936b4d2)