### PR TITLE
docs(erc8004): clarify ERC‑8004 registry scope, evidence anchoring, and validation export guidance

### DIFF
--- a/docs/erc8004/AGIJobManager_to_ERC8004.md
+++ b/docs/erc8004/AGIJobManager_to_ERC8004.md
@@ -71,7 +71,7 @@ When publishing feedback, include `feedbackURI` + `feedbackHash` if you want to 
 
 ## 3) Validation export rules (validator outcomes → validation signals)
 
-ERC-8004 includes a validation registry (requests + responses). We map AGIJobManager validator outcomes **off-chain** to validation-like artifacts that can be submitted later:
+ERC-8004 includes a **validation registry** that records *requests* and *responses*. We map AGIJobManager validator outcomes **off-chain** to validation-like artifacts that can be submitted later without affecting settlement:
 - `JobValidated` → validation response with `response=100` (passed)
 - `JobDisapproved` → validation response with `response=0` (failed)
 - `DisputeResolved` → optional validation tag (e.g., `jobDisputeResolution`) tied to the same request hash
@@ -80,7 +80,7 @@ ERC-8004 includes a validation registry (requests + responses). We map AGIJobMan
 ```
 requestHash = keccak256(chainId, contractAddress, jobId, eventTxHash)
 ```
-This keeps validation artifacts anchored to a specific on-chain job outcome without coupling settlement to external calls.
+This keeps validation artifacts anchored to a specific on-chain job outcome, while preserving the no-liveness-dependency rule (AGIJobManager never waits on ERC-8004 registry calls).
 
 ## 4) Trusted rater set guidance (sybil resistance)
 A recommended policy for trusted raters is:
@@ -102,4 +102,4 @@ Heavy data (full job details, external proofs, or explanation text) stays **off-
 This mapping preserves liveness by preventing any ERC-8004 dependency from gating escrow finalization.
 
 ## Version alignment
-Aligned to EIP-8004 (ERCs repo + canonical mirror) and the ERC-8004 best-practices Registration/Reputation guides as of **2026-01-29**.
+Aligned to EIP-8004 (ERCs repo + canonical mirror) and the ERC-8004 best-practices Registration/Reputation guides as of **2026-01-29** (field names and fixed-point encoding verified against the official sources).

--- a/docs/erc8004/README.md
+++ b/docs/erc8004/README.md
@@ -9,8 +9,21 @@ The architectural intent in this repo aligns with the internal decks:
 
 These sources emphasize **signaling vs enforcement** and the invariant mindset: **no payout without validated proof; no settlement without validation**.
 
+## What ERC-8004 provides (and what it does not)
+**ERC-8004 is a set of registries** for *identity (registration)*, *reputation (feedback)*, and *validation* signals. The registries intentionally store **minimal, verifiable data** (addresses, tags, fixed-point values, and URIs) and **do not** store heavy data, settlement logic, or escrow outcomes. This makes it a **signaling layer** that complements AGIJobManager’s enforcement plane.
+
+**What it stores**
+- **Registration**: agent metadata + a `services[]` array of endpoints (e.g., MCP, A2A, ENS).
+- **Reputation**: compact trust signals (`value` + `valueDecimals`) with optional `tag1`/`tag2`, `endpoint`, and evidence URIs/hashes.
+- **Validation**: requests and responses that can be anchored to on-chain outcomes.
+
+**What it intentionally does not store**
+- Escrow balances, payout logic, or dispute outcomes.
+- Large evidence payloads (these stay off-chain and are referenced by hash/URI).
+- Any liveness requirement that would gate AGIJobManager settlement.
+
 ## External references (verified)
-Aligned to the latest public sources as of **2026-01-29** (field names confirmed against the ERCs repo):
+Aligned to the latest public sources as of **2026-01-29** (field names confirmed against the ERCs repo and best-practices docs):
 - **EIP-8004 spec** (registration uses a `services` array with `name`/`endpoint`/`version`; feedback uses `value` + `valueDecimals`, optional `tag1`/`tag2`, `endpoint`, `feedbackURI`, `feedbackHash`):
   - https://eips.ethereum.org/EIPS/eip-8004 (canonical mirror)
   - https://github.com/ethereum/ERCs/blob/master/ERCS/erc-8004.md (source of truth)
@@ -30,3 +43,4 @@ Aligned to the latest public sources as of **2026-01-29** (field names confirmed
 - **No liveness dependency**: AGIJobManager does not wait for ERC-8004 registries, indexers, or feedback submissions.
 
 The adapter translates **execution outcomes** into portable ERC-8004-friendly signals without coupling settlement to external calls.
+Signals should remain **minimal and auditable**: keep heavy data off-chain and anchor it by `txHash`, `logIndex`, `blockNumber`, `contractAddress`, and `chainId` references in exported artifacts.


### PR DESCRIPTION
### Motivation
- Make the off‑chain ERC‑8004→AGIJobManager translation explicit so integrators export minimal, auditable signals without introducing on‑chain liveness dependencies. 
- Clarify what ERC‑8004 registries store vs intentionally omit (no escrow, no heavy evidence) to reinforce the control‑plane vs execution‑plane separation. 
- Tighten guidance for validation artifacts and anchor construction so exported signals are reproducible and verifiable against on‑chain events. 

### Description
- Updated `docs/erc8004/README.md` to explain what ERC‑8004 stores and what it intentionally does not store, and added explicit evidence anchoring guidance (`txHash`, `logIndex`, `blockNumber`, `contractAddress`, `chainId`).
- Expanded `docs/erc8004/AGIJobManager_to_ERC8004.md` to strengthen validation export rules, show the suggested `requestHash` form, and explicitly state the no‑liveness‑dependency guarantee. 
- Documented version alignment: verified field names and fixed‑point encoding (`value` / `valueDecimals`, `tag1`/`tag2`, `services[]`) against the EIP‑8004 spec and the ERC‑8004 best‑practices repo as of 2026‑01‑29. 
- No Solidity or contract changes were made (the on‑chain `AGIJobManager.sol` was not modified and no new public/external functions or events were added). 

### Testing
- `npm install` completed successfully (dependencies installed; audit warnings reported but not blocking). 
- `npx truffle compile` completed successfully and wrote artifacts to `build/contracts`. 
- `npx truffle test` was executed (a local Ganache instance was started with `npx ganache -p 8545`) and the full test suite passed with `89 passing`, including the `ERC‑8004 adapter export (smoke test)` which asserts deterministic output. 
- The adapter smoke test ran `runExportMetrics` and wrote `erc8004_metrics.json` deterministically in the temp output directory (assertions in `test/erc8004.adapter.test.js` succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697b7a4e2da0833382ff636025eb7768)