### PR TITLE
Improve AGIJobManager web UI handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ Start here:
 ## Web UI
 
 - Static page: [`docs/agijobmanager.html`](docs/agijobmanager.html)
+- Usage guide: [`docs/agijobmanager_ui.md`](docs/agijobmanager_ui.md)
 - Local preview:
   ```bash
   python -m http.server docs

--- a/docs/agijobmanager.html
+++ b/docs/agijobmanager.html
@@ -661,6 +661,46 @@
       window.alert(message);
     }
 
+    function resetSnapshot() {
+      const snapshotFields = [
+        "contractName",
+        "contractSymbol",
+        "contractOwner",
+        "contractPaused",
+        "contractNextJob",
+        "contractNextToken",
+        "agiToken",
+        "agiTokenDecimals",
+        "agiTokenSymbol",
+        "requiredApprovals",
+        "requiredDisapprovals",
+        "validationReward",
+        "maxJobPayout",
+        "jobDurationLimit",
+        "premiumThreshold",
+        "agentRootNode",
+        "clubRootNode",
+        "agentMerkleRoot",
+        "validatorMerkleRoot",
+      ];
+      snapshotFields.forEach((field) => setText(field, "—"));
+    }
+
+    function resetRoleFlags() {
+      const roleFields = [
+        "isModerator",
+        "isAdditionalAgent",
+        "isAdditionalValidator",
+        "isBlacklistedAgent",
+        "isBlacklistedValidator",
+        "reputation",
+        "premiumAccess",
+        "agiBalance",
+        "agiAllowance",
+      ];
+      roleFields.forEach((field) => setText(field, "—"));
+    }
+
     function updateNetworkPill() {
       const pill = ids("networkPill");
       if (!state.chainId) {
@@ -719,6 +759,13 @@
       return parts;
     }
 
+    function maybeInitProvider() {
+      if (state.provider) return state.provider;
+      if (!window.ethereum) return null;
+      state.provider = new ethers.BrowserProvider(window.ethereum);
+      return state.provider;
+    }
+
     function getProvider() {
       if (!window.ethereum) {
         throw new Error("No wallet detected. Install a browser wallet like MetaMask.");
@@ -731,8 +778,15 @@
 
     function setContracts() {
       if (!state.contractAddress) {
+        if (state.contract) {
+          state.contract.removeAllListeners();
+        }
+        if (state.readContract) {
+          state.readContract.removeAllListeners();
+        }
         state.contract = null;
         state.readContract = null;
+        state.eventSubscribed = false;
         return;
       }
       if (!state.provider) return;
@@ -788,6 +842,7 @@
       setText("walletChain", "—");
       updateNetworkPill();
       setContracts();
+      resetRoleFlags();
     }
 
     async function ensureToken() {
@@ -1168,14 +1223,23 @@
           ids("contractAddress").value = parsed;
           state.contractAddress = parsed;
           localStorage.setItem(storageKey, parsed);
+          maybeInitProvider();
+          setContracts();
         } catch (error) {
           showAlert("Invalid contract address in query string.");
         }
       } else {
         const stored = localStorage.getItem(storageKey);
         if (stored) {
-          ids("contractAddress").value = stored;
-          state.contractAddress = stored;
+          try {
+            const parsed = ethers.getAddress(stored);
+            ids("contractAddress").value = parsed;
+            state.contractAddress = parsed;
+            maybeInitProvider();
+            setContracts();
+          } catch (error) {
+            localStorage.removeItem(storageKey);
+          }
         }
       }
     }
@@ -1187,9 +1251,13 @@
       }
       state.contractAddress = parseAddress(value, "Contract address");
       localStorage.setItem(storageKey, state.contractAddress);
-      getProvider();
-      setContracts();
-      await updateSnapshot();
+      const provider = maybeInitProvider();
+      if (provider) {
+        setContracts();
+        await updateSnapshot();
+      } else {
+        resetSnapshot();
+      }
     }
 
     async function handleSwitchMainnet() {
@@ -1206,19 +1274,39 @@
       if (!window.ethereum) return;
       window.ethereum.on("accountsChanged", () => {
         disconnectWallet();
-        connectWallet().catch((error) => showAlert(error.message));
+        connectWallet()
+          .then(async () => {
+            if (state.contractAddress) {
+              await updateSnapshot();
+              await updateRoleFlags();
+            }
+          })
+          .catch((error) => showAlert(error.message));
       });
       window.ethereum.on("chainChanged", () => {
+        state.provider = null;
         disconnectWallet();
-        connectWallet().catch((error) => showAlert(error.message));
+        connectWallet()
+          .then(async () => {
+            if (state.contractAddress) {
+              await updateSnapshot();
+              await updateRoleFlags();
+            }
+          })
+          .catch((error) => showAlert(error.message));
       });
     }
 
     ids("connectButton").addEventListener("click", async () => {
       try {
         await connectWallet();
-        await updateSnapshot();
-        await updateRoleFlags();
+        if (state.contractAddress) {
+          await updateSnapshot();
+          await updateRoleFlags();
+        } else {
+          resetSnapshot();
+          resetRoleFlags();
+        }
       } catch (error) {
         showAlert(error.message);
       }
@@ -1241,12 +1329,15 @@
       state.contractAddress = null;
       localStorage.removeItem(storageKey);
       setContracts();
+      resetSnapshot();
+      resetRoleFlags();
     });
 
     ids("legacyContract").addEventListener("click", () => {
       ids("contractAddress").value = legacyAddress;
       state.contractAddress = legacyAddress;
       localStorage.setItem(storageKey, legacyAddress);
+      maybeInitProvider();
       setContracts();
     });
 

--- a/docs/agijobmanager_ui.md
+++ b/docs/agijobmanager_ui.md
@@ -25,6 +25,7 @@ You can set the contract address in three ways (the UI uses the first one it fin
 Use the “Contract address” input and click **Save address**.
 
 > The new AGIJobManager mainnet address is not yet known. This UI is designed to work with **any** valid deployment.
+> A helper button is available to prefill the **legacy v0** mainnet address, which is clearly labeled as legacy.
 
 ## Role flows
 


### PR DESCRIPTION
### Motivation
- Make the static dApp robust when no contract/address or provider is present and when wallet/chain changes occur, avoiding stale listeners and confusing UI state.
- Clarify and document the contract-address workflow (query param / localStorage / manual) and provide a clearly labeled legacy helper for the historical v0 address.

### Description
- Added safe reset helpers (`resetSnapshot`, `resetRoleFlags`) and a `maybeInitProvider` helper to initialize provider only when a wallet exists and to avoid leaking stale state in `docs/agijobmanager.html`.
- Hardened `setContracts` to remove previous listeners with `removeAllListeners()` and to guard against repeated event subscriptions via `state.eventSubscribed`.
- Reworked contract-address lifecycle: `loadContractFromQuery` validates stored addresses, `handleSaveContract` initializes provider defensively, and clear/legacy actions reset UI state appropriately.
- Improved wallet event handling to rebind provider/signers on `accountsChanged` and `chainChanged` and to refresh snapshot/role flags only when appropriate.
- Documentation updates: clarified the address helper in `docs/agijobmanager_ui.md` and added a short Web UI pointer to `README.md`.
- Files changed: `docs/agijobmanager.html`, `docs/agijobmanager_ui.md`, `README.md`.

### Testing
- `npm ci` was run and failed due to an optional dependency (`fsevents`) being unsupported on Linux, which is expected for non-macOS environments.
- `npm install --no-optional` completed successfully and installed dependencies.
- `npx truffle compile` completed successfully and compiled the contracts without error.
- `npx ganache -p 8545 --deterministic --quiet` was started and then `npx truffle test` was run, completing successfully with `89 passing` tests.
- `python -m http.server docs` was used to serve the UI and a headless smoke test (Playwright screenshot) confirmed the page renders without console errors in a static environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bb9543fb48333873f07b42e2afa16)