### PR TITLE
Ensure AGIJobManager UI loads token decimals before parsing amounts

### DIFF
--- a/docs/agijobmanager.html
+++ b/docs/agijobmanager.html
@@ -1375,6 +1375,7 @@
 
     ids("approveToken").addEventListener("click", async () => {
       try {
+        await ensureToken();
         const amount = parseTokenAmount(ids("approveAmount").value, "Approve amount");
         await approveToken(amount, "Employer");
         await updateRoleFlags();
@@ -1387,6 +1388,7 @@
       try {
         const ipfs = ids("jobIpfs").value.trim();
         if (!ipfs) throw new Error("IPFS hash is required.");
+        await ensureToken();
         const payout = parseTokenAmount(ids("jobPayout").value, "Payout");
         const duration = parseUint(ids("jobDuration").value, "Duration");
         const details = ids("jobDetails").value.trim();
@@ -1493,6 +1495,7 @@
 
     ids("approvePurchase").addEventListener("click", async () => {
       try {
+        await ensureToken();
         const amount = parseTokenAmount(ids("purchaseApproveAmount").value, "Approve amount");
         await approveToken(amount, "Purchase");
         await updateRoleFlags();
@@ -1504,6 +1507,7 @@
     ids("listNft").addEventListener("click", async () => {
       try {
         const tokenId = parseUint(ids("listTokenId").value, "Token ID");
+        await ensureToken();
         const price = parseTokenAmount(ids("listPrice").value, "Price");
         await sendTx("listNFT", [tokenId, price], "List NFT");
       } catch (error) {


### PR DESCRIPTION
### Motivation
- Prevent incorrect token unit parsing by ensuring AGI token metadata (decimals & symbol) is loaded before converting user-entered amounts, avoiding malformed approvals/listings/createJob payouts.

### Description
- Call `ensureToken()` before parsing amounts in the Employer approve flow, `createJob`, buyer approve flow, and NFT `listNFT` flow to guarantee `agiTokenDecimals` is available. 
- Keep all changes limited to the static UI at `docs/agijobmanager.html` and do not modify any Solidity contracts. 
- Preserve existing safety behavior: no auto-connect, preflight `staticCall` checks, address validation, and event listener cleanup via `removeAllListeners()` in the UI code.
- Files changed: `docs/agijobmanager.html` (small JS additions to load token metadata prior to amount parsing).

### Testing
- `npm ci` — failed on this platform due to optional dependency `fsevents` (expected on non-darwin hosts). 
- `npm install --omit=optional` — succeeded and installed dependencies. 
- `npx truffle compile` — succeeded and wrote artifacts to `build/contracts`. 
- Launched a local node with `npx ganache -p 8545` then ran `npx truffle test` — tests passed (`89 passing`). 
- Served the UI with `python -m http.server 8000 --directory docs` and performed a smoke-load and screenshot of `docs/agijobmanager.html` to verify the page renders; a browser snapshot artifact was generated during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bbe5a4cc88333887983f607153419)