### PR TITLE
UI: improve network detection and docs for agijobmanager

### DIFF
--- a/docs/agijobmanager.html
+++ b/docs/agijobmanager.html
@@ -5,6 +5,7 @@
   <meta name="viewport" content="width=device-width, initial-scale=1" />
   <title>AGIJobManager — On‑chain Job Escrow & NFT Marketplace</title>
   <link rel="preconnect" href="https://cdn.jsdelivr.net" crossorigin />
+  <link rel="icon" href="data:," />
   <style>
     :root {
       color-scheme: light;
@@ -708,11 +709,12 @@
         pill.className = "pill warn";
         return;
       }
+      const connectionLabel = state.walletAddress ? "" : "Network detected: ";
       if (state.chainId === 1n) {
-        pill.textContent = "Mainnet";
+        pill.textContent = `${connectionLabel}Mainnet`;
         pill.className = "pill ok";
       } else {
-        pill.textContent = `Wrong network (chain ${state.chainId})`;
+        pill.textContent = `${connectionLabel}Wrong network (chain ${state.chainId})`;
         pill.className = "pill danger";
       }
     }
@@ -764,6 +766,16 @@
       if (!window.ethereum) return null;
       state.provider = new ethers.BrowserProvider(window.ethereum);
       return state.provider;
+    }
+
+    async function initNetwork() {
+      if (!window.ethereum) return;
+      try {
+        maybeInitProvider();
+        await refreshNetwork();
+      } catch (error) {
+        // Ignore network detection errors until the user connects.
+      }
     }
 
     function getProvider() {
@@ -838,6 +850,7 @@
     function disconnectWallet() {
       state.signer = null;
       state.walletAddress = null;
+      state.chainId = null;
       setText("walletAddress", "Not connected");
       setText("walletChain", "—");
       updateNetworkPill();
@@ -1570,6 +1583,7 @@
     });
 
     loadContractFromQuery();
+    initNetwork();
     attachWalletListeners();
     updateNetworkPill();
   </script>

--- a/docs/agijobmanager_ui.md
+++ b/docs/agijobmanager_ui.md
@@ -60,6 +60,7 @@ Use the “Contract address” input and click **Save address**.
 
 ### Wrong network
 - The UI is for **Ethereum Mainnet**. Use the “Switch to Mainnet” button.
+- The network pill updates based on your wallet’s current chain; you still need to connect before sending transactions.
 
 ### “Would revert” messages
 - Every state-changing action runs a **static call preflight**. If it would revert, the UI shows the revert reason.


### PR DESCRIPTION
### Motivation
- Improve the dApp UX around network detection without auto-connecting, avoid a favicon 404 in the console, and make the network pill more informative when a wallet is not connected.

### Description
- Add a favicon stub and non-auto-connect network initialization (`initNetwork`), reset `chainId` on disconnect, and adjust `updateNetworkPill` to prefix a "Network detected:" label when the chain is known but no account is connected; call `initNetwork()` on page load; files changed: `docs/agijobmanager.html` and `docs/agijobmanager_ui.md` (minor docs update documenting network pill behavior).

### Testing
- `npm ci` — failed due to optional `fsevents` not supported on Linux (expected in this environment).
- `npm install --omit=optional` — succeeded and installed dependencies.
- `npx truffle compile` — succeeded (contracts compiled; non-blocking compiler warnings reported).
- `npx truffle test` — failed to run because no local node was available at `http://127.0.0.1:8545`.
- `python -m http.server docs` + automated smoke test (headless Firefox screenshot) — succeeded in loading `docs/agijobmanager.html` and produced a UI screenshot for manual review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bde9199688333aa8d261cd12f4641)