### PR TITLE
Update mainnet deployment record timestamp

### DIFF
--- a/docs/deployments/mainnet.json
+++ b/docs/deployments/mainnet.json
@@ -3,5 +3,5 @@
   "chainId": 1,
   "agiJobManager": "",
   "legacyV0": "0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477",
-  "updatedAt": "2026-01-29T22:57:20Z"
+  "updatedAt": "2026-01-30T00:07:31Z"
 }


### PR DESCRIPTION
### Motivation
- Refresh the authoritative `docs/deployments/mainnet.json` updatedAt timestamp to reflect the current state of the documentation record.

### Description
- Updated `docs/deployments/mainnet.json` `updatedAt` field to `2026-01-30T00:07:31Z` (no other content or behavior changes).

### Testing
- Ran `npm ci` and `npm ci --omit=optional`, both failed due to a platform-optional dependency (`fsevents`) not supported on Linux so dependencies could not be installed.
- Ran `npx truffle compile` and `npx truffle test`, both errored due to missing runtime dependencies (e.g., `dotenv`) because `npm ci` did not complete successfully.
- Served the docs locally with `python3 -m http.server 8000 --directory docs` and confirmed the UI file responds at `http://localhost:8000/ui/agijobmanager.html` (HTTP 200).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697bf553ff648333a5a18021b1a6e71a)