### PR TITLE
Docs: clarify ABI load logging in UI README

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -55,7 +55,8 @@ npm run ui:abi
 
 The UI attempts to load `./abi/AGIJobManager.json` at runtime. If it cannot fetch the file
 (for example when opened via `file://`), it falls back to the embedded ABI and logs the
-fallback in the Activity Log.
+fallback in the Activity Log. You should see “External ABI loaded” when served over HTTP
+and “Fallback ABI used” when opened via `file://`.
 
 If `truffle test` fails with an ABI mismatch, run `npm run ui:abi` and commit the updated ABI file.
 


### PR DESCRIPTION
### Motivation
- Make the UI ABI loading behavior explicit in the UI README so maintainers and users can easily tell whether the UI is using the exported ABI or the embedded fallback.

### Description
- Update `docs/ui/README.md` to note that the UI logs “External ABI loaded” when the runtime fetch of `./abi/AGIJobManager.json` succeeds (HTTP) and “Fallback ABI used” when the fetch fails (for example when opened via `file://`).

### Testing
- Ran `npm install --no-optional` which completed successfully, and `npx truffle compile` which compiled the contracts successfully.
- Ran `npm run ui:abi` which exported the ABI to `docs/ui/abi/AGIJobManager.json` successfully.
- Ran `npx truffle test --network test` which executed the test suite (including the `UI ABI sync` checks) and all tests passed.
- `npm ci` fails on this Linux runner due to `fsevents` being macOS-only, which is expected on non-Darwin platforms.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c00173b7c83338a84ab0e1e34136f)