### PR TITLE
Decode AGIJobManager custom errors in static UI

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -78,6 +78,23 @@ If `truffle test` fails with an ABI mismatch, run `npm run ui:abi` and commit th
   verifies membership off-chain; on-chain checks are authoritative.
 - ENS checks mirror the contract’s fallback logic: Merkle → NameWrapper.ownerOf → Resolver.addr.
 
+## Common Reverts & Fixes
+
+- **NotModerator** — Only a moderator can resolve disputes.
+  - Fix: Ask the contract owner to add your address via `addModerator()`.
+- **NotAuthorized** — Role/identity proof is missing or invalid.
+  - Fix: Ensure your wallet controls the ENS subdomain label entered (NameWrapper/Resolver), or provide a valid Merkle proof, or be explicitly allowlisted via `additionalAgents` / `additionalValidators`.
+- **Blacklisted** — Address is blocked for this role.
+  - Fix: Ask moderators/owner to remove the blacklist entry.
+- **InvalidParameters** — Payout/duration violate bounds.
+  - Fix: Keep payout/duration > 0 and within `maxJobPayout` / `jobDurationLimit`.
+- **InvalidState** — Action is not valid for the current job lifecycle state.
+  - Fix: Ensure the job is assigned/not completed, completion is within duration, validations are before completion, disputes are only when not completed, etc.
+- **JobNotFound** — Job ID does not exist or was delisted/cancelled.
+  - Fix: Verify the job ID is still active.
+- **TransferFailed** — ERC‑20 transfer returned false.
+  - Fix: Check token balance/allowance, approve AGIJobManager, and ensure the token is not paused/blocked.
+
 ## Mainnet scalability: pagination + event indexing
 
 The UI no longer enumerates every job or token ID. Instead it:

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -646,6 +646,7 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/ethers@6.13.4/dist/ethers.umd.min.js" integrity="sha384-7x3tVmE2MSjFk3rjql7YVSE2LEAFloT+1B5Nj0b3V5/hWRUsStlHHY2mySsRkmmF" crossorigin="anonymous"></script>
+  <script src="./lib/errorDecoder.js"></script>
   <script>
     const { ethers } = window;
 
@@ -659,6 +660,7 @@
       agiTokenAddress: null,
       agiTokenDecimals: 18,
       agiTokenSymbol: "",
+      token: null,
       contract: null,
       readContract: null,
       eventSubscribed: false,
@@ -1019,6 +1021,7 @@
       const token = new ethers.Contract(tokenAddress, erc20Abi, state.provider);
       state.agiTokenDecimals = Number(await token.decimals());
       state.agiTokenSymbol = await token.symbol();
+      state.token = token;
       return token;
     }
 
@@ -1171,12 +1174,24 @@
       setText("identityResolver", resolverText);
     }
 
+    function buildErrorContext(action) {
+      return {
+        jm: state.contract,
+        token: state.token,
+        chainId: state.chainId,
+        userAddress: state.walletAddress,
+        action,
+      };
+    }
+
     async function preflight(contract, method, args) {
       try {
         await contract.getFunction(method).staticCall(...args);
       } catch (error) {
-        const message = error.shortMessage || error.message || "Transaction would revert.";
-        throw new Error(message);
+        const friendly = AGIJMErrorDecoder?.friendlyError
+          ? AGIJMErrorDecoder.friendlyError(error, buildErrorContext({ type: "preflight", method }))
+          : (error.shortMessage || error.message || "Transaction would revert.");
+        throw new Error(friendly);
       }
     }
 
@@ -1184,11 +1199,18 @@
       if (!state.contract) {
         throw new Error("Connect a wallet to send transactions.");
       }
-      await preflight(state.contract, method, args);
-      const tx = await state.contract.getFunction(method)(...args);
-      logEvent(`⏳ ${description} — ${tx.hash}`);
-      await tx.wait();
-      logEvent(`✅ ${description} confirmed`);
+      try {
+        await preflight(state.contract, method, args);
+        const tx = await state.contract.getFunction(method)(...args);
+        logEvent(`⏳ ${description} — ${tx.hash}`);
+        await tx.wait();
+        logEvent(`✅ ${description} confirmed`);
+      } catch (error) {
+        const friendly = AGIJMErrorDecoder?.friendlyError
+          ? AGIJMErrorDecoder.friendlyError(error, buildErrorContext({ type: "transaction", method, description }))
+          : (error.shortMessage || error.message || "Transaction failed.");
+        throw new Error(friendly);
+      }
     }
 
     function logEvent(message) {
@@ -1610,8 +1632,10 @@
       try {
         await token.getFunction("approve").staticCall(state.contractAddress, amount);
       } catch (error) {
-        const message = error.shortMessage || error.message || "Approve would revert.";
-        throw new Error(message);
+        const friendly = AGIJMErrorDecoder?.friendlyError
+          ? AGIJMErrorDecoder.friendlyError(error, buildErrorContext({ type: "preflight", method: "approve", description: context }))
+          : (error.shortMessage || error.message || "Approve would revert.");
+        throw new Error(friendly);
       }
       const tx = await token.connect(state.signer).approve(state.contractAddress, amount);
       logEvent(`⏳ ${context} approve — ${tx.hash}`);

--- a/docs/ui/lib/errorDecoder.js
+++ b/docs/ui/lib/errorDecoder.js
@@ -1,0 +1,254 @@
+(function (root, factory) {
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = factory();
+  } else {
+    root.AGIJMErrorDecoder = factory();
+  }
+})(typeof globalThis !== "undefined" ? globalThis : window, function () {
+  "use strict";
+
+  const customErrorHints = {
+    NotModerator: {
+      message: "Only a moderator can perform this action.",
+      hint: "Ask the contract owner to add your address via addModerator(), then retry.",
+    },
+    NotAuthorized: {
+      message: "You don’t have the required role / identity proof for this action.",
+      hint: "For agents/validators: ensure your wallet controls the ENS subdomain label you entered (NameWrapper/Resolver), OR provide a valid Merkle proof, OR be explicitly whitelisted via additionalAgents/additionalValidators.",
+    },
+    Blacklisted: {
+      message: "Your address is blacklisted for this role.",
+      hint: "Contact the owner/moderators to remove the blacklist entry, then retry.",
+    },
+    InvalidParameters: {
+      message: "Invalid parameters.",
+      hint: "Check payout/duration bounds (payout>0, duration>0, payout<=maxJobPayout, duration<=jobDurationLimit).",
+    },
+    InvalidState: {
+      message: "Action not valid in the current job state.",
+      hint: "Check job is assigned/not completed; completion requests must be within duration; disputes only when not completed; validations only when assigned and not completed; etc.",
+    },
+    JobNotFound: {
+      message: "Job not found (may be deleted/cancelled).",
+      hint: "Confirm the Job ID exists and hasn’t been delisted/cancelled.",
+    },
+    TransferFailed: {
+      message: "Token transfer failed.",
+      hint: "Check token balance/allowance; approve the JobManager for the required amount; ensure token is not paused/blocked.",
+    },
+  };
+
+  const panicCodeMap = {
+    0x01: "Assertion violated.",
+    0x11: "Arithmetic overflow/underflow.",
+    0x12: "Division by zero.",
+    0x21: "Invalid enum value.",
+    0x22: "Invalid storage byte array access.",
+    0x31: "Pop from empty array.",
+    0x32: "Array index out of bounds.",
+    0x41: "Memory allocation overflow.",
+    0x51: "Zero-initialized function pointer.",
+  };
+
+  function getSelector(name) {
+    const signature = `${name}()`;
+    if (typeof globalThis !== "undefined") {
+      const maybeEthers = globalThis.ethers;
+      if (maybeEthers && typeof maybeEthers.id === "function") {
+        return maybeEthers.id(signature).slice(0, 10);
+      }
+      const maybeWeb3 = globalThis.web3;
+      if (maybeWeb3 && maybeWeb3.utils && typeof maybeWeb3.utils.sha3 === "function") {
+        return maybeWeb3.utils.sha3(signature).slice(0, 10);
+      }
+    }
+    return null;
+  }
+
+  function buildSelectorMap() {
+    const map = {};
+    Object.keys(customErrorHints).forEach((name) => {
+      const selector = getSelector(name);
+      if (selector) {
+        map[selector.toLowerCase()] = name;
+      }
+    });
+    return map;
+  }
+
+  function extractRevertData(err) {
+    if (!err) return null;
+    return (
+      err.data ||
+      err.error?.data ||
+      err.info?.error?.data ||
+      err.info?.error?.error?.data ||
+      err.cause?.data ||
+      null
+    );
+  }
+
+  function decodeErrorString(data) {
+    const payload = data.slice(10);
+    if (!payload) return null;
+    if (typeof globalThis !== "undefined" && globalThis.ethers && globalThis.ethers.AbiCoder) {
+      const coder = typeof globalThis.ethers.AbiCoder.defaultAbiCoder === "function"
+        ? globalThis.ethers.AbiCoder.defaultAbiCoder()
+        : new globalThis.ethers.AbiCoder();
+      const decoded = coder.decode(["string"], `0x${payload}`);
+      return decoded?.[0] || null;
+    }
+    if (typeof Buffer !== "undefined") {
+      try {
+        const offset = parseInt(payload.slice(0, 64), 16) * 2;
+        const length = parseInt(payload.slice(64 + offset, 128 + offset), 16) * 2;
+        const start = 128 + offset;
+        const hex = payload.slice(start, start + length);
+        return Buffer.from(hex, "hex").toString("utf8");
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  function decodePanic(data) {
+    const payload = data.slice(10);
+    if (typeof globalThis !== "undefined" && globalThis.ethers && globalThis.ethers.AbiCoder) {
+      const coder = typeof globalThis.ethers.AbiCoder.defaultAbiCoder === "function"
+        ? globalThis.ethers.AbiCoder.defaultAbiCoder()
+        : new globalThis.ethers.AbiCoder();
+      const decoded = coder.decode(["uint256"], `0x${payload}`);
+      return Number(decoded?.[0]);
+    }
+    if (payload.length >= 64) {
+      try {
+        return Number(BigInt(`0x${payload.slice(0, 64)}`));
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  function decodeRevertData({ data, jmInterface, tokenInterface }) {
+    if (!data) {
+      return { kind: "unknown", name: null, message: null, hint: null, rawData: null };
+    }
+    const selector = data.slice(0, 10).toLowerCase();
+
+    if (jmInterface && typeof jmInterface.parseError === "function") {
+      try {
+        const parsed = jmInterface.parseError(data);
+        if (parsed) {
+          const meta = customErrorHints[parsed.name] || {};
+          return {
+            kind: "custom",
+            name: parsed.name,
+            message: meta.message || null,
+            hint: meta.hint || null,
+            rawData: data,
+          };
+        }
+      } catch (error) {
+        // ignore
+      }
+    }
+
+    if (tokenInterface && typeof tokenInterface.parseError === "function") {
+      try {
+        const parsed = tokenInterface.parseError(data);
+        if (parsed) {
+          return {
+            kind: "custom",
+            name: parsed.name,
+            message: "Token contract error.",
+            hint: "Check token balance/allowance and token status, then retry.",
+            rawData: data,
+          };
+        }
+      } catch (error) {
+        // ignore
+      }
+    }
+
+    const selectorMap = buildSelectorMap();
+    if (selectorMap[selector]) {
+      const name = selectorMap[selector];
+      const meta = customErrorHints[name] || {};
+      return {
+        kind: "custom",
+        name,
+        message: meta.message || null,
+        hint: meta.hint || null,
+        rawData: data,
+      };
+    }
+
+    if (selector === "0x08c379a0") {
+      const revertString = decodeErrorString(data);
+      return {
+        kind: "revertString",
+        name: "Error",
+        message: revertString || "Execution reverted.",
+        hint: null,
+        rawData: data,
+      };
+    }
+
+    if (selector === "0x4e487b71") {
+      const code = decodePanic(data);
+      const mapped = code !== null ? panicCodeMap[code] : null;
+      return {
+        kind: "panic",
+        name: "Panic",
+        message: mapped || "Unexpected panic.",
+        hint: code !== null ? `Panic code 0x${code.toString(16)}.` : null,
+        rawData: data,
+      };
+    }
+
+    return { kind: "unknown", name: null, message: null, hint: null, rawData: data };
+  }
+
+  function isUserRejected(err) {
+    const code = err?.code;
+    const message = err?.message || "";
+    return code === "ACTION_REJECTED" || code === 4001 || /user rejected/i.test(message);
+  }
+
+  function friendlyError(err, ctx = {}) {
+    if (isUserRejected(err)) {
+      return "Transaction rejected in wallet.";
+    }
+
+    const data = extractRevertData(err);
+    const jmInterface = ctx?.jm?.interface || ctx?.jmInterface || null;
+    const tokenInterface = ctx?.token?.interface || ctx?.tokenInterface || null;
+    const decoded = decodeRevertData({ data, jmInterface, tokenInterface });
+
+    if (decoded.kind === "custom") {
+      const message = decoded.message || "Execution reverted.";
+      const hint = decoded.hint ? `Fix: ${decoded.hint}` : "";
+      return `${decoded.name}: ${message}${hint ? `\n${hint}` : ""}`;
+    }
+
+    if (decoded.kind === "revertString") {
+      return `Reverted: ${decoded.message}`;
+    }
+
+    if (decoded.kind === "panic") {
+      const hint = decoded.hint ? ` ${decoded.hint}` : "";
+      return `Panic: ${decoded.message}${hint}`;
+    }
+
+    return err?.shortMessage || err?.message || "Transaction failed.";
+  }
+
+  return {
+    customErrorHints,
+    extractRevertData,
+    decodeRevertData,
+    friendlyError,
+  };
+});

--- a/test/ui_error_decoder.test.js
+++ b/test/ui_error_decoder.test.js
@@ -1,0 +1,31 @@
+const assert = require("assert");
+
+const decoder = require("../docs/ui/lib/errorDecoder.js");
+
+const customErrors = [
+  "NotModerator",
+  "NotAuthorized",
+  "Blacklisted",
+  "InvalidParameters",
+  "InvalidState",
+  "JobNotFound",
+  "TransferFailed",
+];
+
+describe("UI error decoder", () => {
+  it("maps custom error selectors to friendly messages", () => {
+    customErrors.forEach((name) => {
+      const selector = web3.utils.sha3(`${name}()`).slice(0, 10);
+      const message = decoder.friendlyError({ data: selector }, {});
+
+      assert.ok(
+        message.includes(name),
+        `Expected message to include ${name}, got: ${message}`
+      );
+      assert.ok(
+        message.includes("Fix:") && message.split("Fix:")[1].trim().length > 0,
+        `Expected non-empty fix hint for ${name}, got: ${message}`
+      );
+    });
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve UX by surfacing decoded AGIJobManager custom errors and actionable hints instead of generic "execution reverted" messages for preflight staticCalls and transaction failures.
- Provide a small, testable helper that works both in-browser (with the existing ethers CDN) and in Node for unit tests without changing contracts or UI styling.

### Description

- Add a browser/Node-compatible decoder at `docs/ui/lib/errorDecoder.js` implementing `extractRevertData`, `decodeRevertData`, and `friendlyError`, plus a mapping of AGIJobManager custom errors to messages and hints.
- Wire the decoder into the canonical static UI `docs/ui/agijobmanager.html` by including `./lib/errorDecoder.js`, storing the token contract in `state.token`, adding `buildErrorContext()`, and replacing preflight/transaction/token-approve error paths to surface `AGIJMErrorDecoder.friendlyError()` output.
- Add a minimal unit test `test/ui_error_decoder.test.js` that verifies selectors for each custom error name map to friendly messages and non-empty hints in Node (uses existing `web3` test environment).
- Document the common reverts and fixes in `docs/ui/README.md` under a new "Common Reverts & Fixes" section.

### Testing

- `npm ci` was attempted but fails on this Linux environment due to optional dependency `fsevents@2.3.2` (EBADPLATFORM); this is expected on non‑Darwin platforms and does not block the other automated checks.
- `npm install --omit=optional --no-package-lock` completed successfully and installed dev deps used by Truffle.
- `npx truffle compile` completed successfully and wrote artifacts to `build/contracts`.
- `npx truffle test --network test` ran the full test suite including the new `UI error decoder` test and passed (92 passing), and the decoder test reported success.
- Local smoke deploy: `npx ganache -p 8545` + `npx truffle migrate --network development` completed and deployed `AGIJobManager` to a local chain; UI smoke testing with a browser wallet could not be executed in this headless environment.

Limitations: token custom errors are decoded only if a token interface capable of `parseError` is provided to the decoder; browser-side revert decoding requires a wallet provider to fully exercise UI preflight paths in a real browser session.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c1b489a8c8333b457243316cece91)