### PR TITLE
Decode custom AGIJobManager errors in UI

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -78,6 +78,28 @@ If `truffle test` fails with an ABI mismatch, run `npm run ui:abi` and commit th
   verifies membership off-chain; on-chain checks are authoritative.
 - ENS checks mirror the contract’s fallback logic: Merkle → NameWrapper.ownerOf → Resolver.addr.
 
+## Common Reverts & Fixes
+
+If a transaction is rejected during preflight or execution, the UI will surface a custom
+error name with a fix hint. Common cases include:
+
+- **NotModerator** — Only a moderator can perform this action.  
+  **Fix:** Ask the contract owner to add your address via `addModerator()`, then retry.
+- **NotAuthorized** — Missing required role or identity proof.  
+  **Fix:** Ensure your wallet controls the ENS subdomain label you entered (NameWrapper/Resolver),
+  provide a valid Merkle proof, or be explicitly whitelisted via `additionalAgents` / `additionalValidators`.
+- **Blacklisted** — Address is blacklisted for the role.  
+  **Fix:** Contact the owner/moderators to remove the blacklist entry.
+- **InvalidParameters** — Invalid payout/duration bounds.  
+  **Fix:** Use `payout > 0`, `duration > 0`, `payout <= maxJobPayout`, `duration <= jobDurationLimit`.
+- **InvalidState** — Action not valid in the current job state.  
+  **Fix:** Confirm the job is assigned/not completed; completion requests must be within duration;
+  disputes only when not completed; validations only when assigned and not completed.
+- **JobNotFound** — Job ID missing or cancelled.  
+  **Fix:** Confirm the job ID exists and hasn’t been delisted/cancelled.
+- **TransferFailed** — ERC‑20 transfer returned false.  
+  **Fix:** Check token balance/allowance, approve the JobManager, and ensure the token is not paused.
+
 ## Mainnet scalability: pagination + event indexing
 
 The UI no longer enumerates every job or token ID. Instead it:

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -646,8 +646,10 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/ethers@6.13.4/dist/ethers.umd.min.js" integrity="sha384-7x3tVmE2MSjFk3rjql7YVSE2LEAFloT+1B5Nj0b3V5/hWRUsStlHHY2mySsRkmmF" crossorigin="anonymous"></script>
+  <script src="./lib/errorDecoder.js"></script>
   <script>
     const { ethers } = window;
+    const errorDecoder = window.AGIJMErrorDecoder;
 
     const state = {
       provider: null,
@@ -659,6 +661,7 @@
       agiTokenAddress: null,
       agiTokenDecimals: 18,
       agiTokenSymbol: "",
+      token: null,
       contract: null,
       readContract: null,
       eventSubscribed: false,
@@ -801,6 +804,23 @@
 
     function showAlert(message) {
       window.alert(message);
+    }
+
+    function buildErrorContext(action) {
+      return {
+        jm: state.contract || state.readContract,
+        token: state.token || null,
+        chainId: state.chainId,
+        userAddress: state.walletAddress,
+        action,
+      };
+    }
+
+    function formatFriendlyError(error, context) {
+      if (errorDecoder?.friendlyError) {
+        return errorDecoder.friendlyError(error, context);
+      }
+      return error.shortMessage || error.message || "Transaction failed.";
     }
 
     function resetSnapshot() {
@@ -1017,6 +1037,7 @@
       const tokenAddress = await state.readContract.agiToken();
       state.agiTokenAddress = tokenAddress;
       const token = new ethers.Contract(tokenAddress, erc20Abi, state.provider);
+      state.token = token;
       state.agiTokenDecimals = Number(await token.decimals());
       state.agiTokenSymbol = await token.symbol();
       return token;
@@ -1171,11 +1192,11 @@
       setText("identityResolver", resolverText);
     }
 
-    async function preflight(contract, method, args) {
+    async function preflight(contract, method, args, context) {
       try {
         await contract.getFunction(method).staticCall(...args);
       } catch (error) {
-        const message = error.shortMessage || error.message || "Transaction would revert.";
+        const message = formatFriendlyError(error, context);
         throw new Error(message);
       }
     }
@@ -1184,11 +1205,17 @@
       if (!state.contract) {
         throw new Error("Connect a wallet to send transactions.");
       }
-      await preflight(state.contract, method, args);
-      const tx = await state.contract.getFunction(method)(...args);
-      logEvent(`⏳ ${description} — ${tx.hash}`);
-      await tx.wait();
-      logEvent(`✅ ${description} confirmed`);
+      const context = buildErrorContext(description);
+      await preflight(state.contract, method, args, context);
+      try {
+        const tx = await state.contract.getFunction(method)(...args);
+        logEvent(`⏳ ${description} — ${tx.hash}`);
+        await tx.wait();
+        logEvent(`✅ ${description} confirmed`);
+      } catch (error) {
+        const message = formatFriendlyError(error, context);
+        throw new Error(message);
+      }
     }
 
     function logEvent(message) {
@@ -1607,16 +1634,22 @@
       if (!state.contractAddress) {
         throw new Error("Set a contract address first.");
       }
+      const errorContext = buildErrorContext(`${context} approve`);
       try {
         await token.getFunction("approve").staticCall(state.contractAddress, amount);
       } catch (error) {
-        const message = error.shortMessage || error.message || "Approve would revert.";
+        const message = formatFriendlyError(error, errorContext);
         throw new Error(message);
       }
-      const tx = await token.connect(state.signer).approve(state.contractAddress, amount);
-      logEvent(`⏳ ${context} approve — ${tx.hash}`);
-      await tx.wait();
-      logEvent(`✅ ${context} approve confirmed`);
+      try {
+        const tx = await token.connect(state.signer).approve(state.contractAddress, amount);
+        logEvent(`⏳ ${context} approve — ${tx.hash}`);
+        await tx.wait();
+        logEvent(`✅ ${context} approve confirmed`);
+      } catch (error) {
+        const message = formatFriendlyError(error, errorContext);
+        throw new Error(message);
+      }
     }
 
     async function loadJobs() {

--- a/docs/ui/lib/errorDecoder.js
+++ b/docs/ui/lib/errorDecoder.js
@@ -1,0 +1,240 @@
+(() => {
+  const customErrorCatalog = {
+    NotModerator: {
+      message: "Only a moderator can perform this action.",
+      hint: "Ask the contract owner to add your address via addModerator(), then retry.",
+    },
+    NotAuthorized: {
+      message: "You don’t have the required role / identity proof for this action.",
+      hint: "For agents/validators: ensure your wallet controls the ENS subdomain label you entered (NameWrapper/Resolver), OR provide a valid Merkle proof, OR be explicitly whitelisted via additionalAgents/additionalValidators.",
+    },
+    Blacklisted: {
+      message: "Your address is blacklisted for this role.",
+      hint: "Contact the owner/moderators to remove the blacklist entry, then retry.",
+    },
+    InvalidParameters: {
+      message: "Invalid parameters.",
+      hint: "Check payout/duration bounds (payout>0, duration>0, payout<=maxJobPayout, duration<=jobDurationLimit).",
+    },
+    InvalidState: {
+      message: "Action not valid in the current job state.",
+      hint: "Check job is assigned/not completed; completion requests must be within duration; disputes only when not completed; validations only when assigned and not completed; etc.",
+    },
+    JobNotFound: {
+      message: "Job not found (may be deleted/cancelled).",
+      hint: "Confirm the Job ID exists and hasn’t been delisted/cancelled.",
+    },
+    TransferFailed: {
+      message: "Token transfer failed.",
+      hint: "Check token balance/allowance; approve the JobManager for the required amount; ensure token is not paused/blocked.",
+    },
+  };
+
+  const panicCodes = {
+    0x01: "Assertion violated.",
+    0x11: "Arithmetic overflow/underflow.",
+    0x12: "Division or modulo by zero.",
+    0x21: "Enum conversion out of bounds.",
+    0x22: "Incorrectly encoded storage byte array.",
+    0x31: "Pop on empty array.",
+    0x32: "Array index out of bounds.",
+    0x41: "Memory allocation overflow.",
+    0x51: "Zero-initialized function pointer.",
+  };
+
+  const hasEthers = () => typeof ethers !== "undefined" && ethers && typeof ethers.id === "function";
+
+  function computeSelector(signature) {
+    if (hasEthers()) {
+      return ethers.id(signature).slice(0, 10);
+    }
+    if (typeof module !== "undefined" && module.exports && typeof require === "function") {
+      try {
+        const keccak256 = require("keccak256");
+        return `0x${keccak256(signature).toString("hex").slice(0, 8)}`;
+      } catch (error) {
+        return null;
+      }
+    }
+    return null;
+  }
+
+  const selectorLookup = Object.keys(customErrorCatalog).reduce((acc, name) => {
+    const selector = computeSelector(`${name}()`);
+    if (selector) {
+      acc[selector] = name;
+    }
+    return acc;
+  }, {});
+
+  function extractRevertData(err) {
+    if (!err) return null;
+    const candidates = [
+      err.data,
+      err.error?.data,
+      err.info?.error?.data,
+      err.info?.error?.error?.data,
+      err.cause?.data,
+    ];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      if (typeof candidate === "string") return candidate;
+      if (typeof candidate?.data === "string") return candidate.data;
+    }
+    return null;
+  }
+
+  function decodeErrorString(data) {
+    if (!hasEthers()) return null;
+    try {
+      const coder = ethers.AbiCoder.defaultAbiCoder();
+      const decoded = coder.decode(["string"], `0x${data.slice(10)}`);
+      return decoded?.[0] || null;
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function decodePanic(data) {
+    if (!hasEthers()) return null;
+    try {
+      const coder = ethers.AbiCoder.defaultAbiCoder();
+      const decoded = coder.decode(["uint256"], `0x${data.slice(10)}`);
+      return decoded?.[0];
+    } catch (error) {
+      return null;
+    }
+  }
+
+  function formatCustomError(name, args) {
+    const entry = customErrorCatalog[name];
+    const message = entry?.message || `Contract error: ${name}.`;
+    const hint = entry?.hint || "Review inputs and permissions, then retry.";
+    return {
+      kind: "custom",
+      name,
+      message,
+      hint,
+      args,
+    };
+  }
+
+  function decodeRevertData({ data, jmInterface, tokenInterface }) {
+    if (!data || typeof data !== "string") {
+      return { kind: "unknown", name: null, message: "Transaction failed.", hint: null, rawData: data || null };
+    }
+    const rawData = data;
+    if (jmInterface?.parseError) {
+      try {
+        const parsed = jmInterface.parseError(data);
+        if (parsed?.name) {
+          return { ...formatCustomError(parsed.name, parsed.args), rawData };
+        }
+      } catch (error) {
+        // ignore and try other paths
+      }
+    }
+    if (tokenInterface?.parseError) {
+      try {
+        const parsed = tokenInterface.parseError(data);
+        if (parsed?.name) {
+          return {
+            kind: "custom",
+            name: parsed.name,
+            message: `Token error: ${parsed.name}.`,
+            hint: "Check token configuration and retry.",
+            rawData,
+          };
+        }
+      } catch (error) {
+        // ignore and try other paths
+      }
+    }
+
+    const selector = data.slice(0, 10);
+    if (selectorLookup[selector]) {
+      return { ...formatCustomError(selectorLookup[selector]), rawData };
+    }
+
+    if (selector === "0x08c379a0") {
+      const decoded = decodeErrorString(data);
+      if (decoded) {
+        return {
+          kind: "revertString",
+          name: "Error",
+          message: decoded,
+          hint: "Review the inputs and try again.",
+          rawData,
+        };
+      }
+    }
+
+    if (selector === "0x4e487b71") {
+      const decoded = decodePanic(data);
+      if (decoded !== null && decoded !== undefined) {
+        const code = Number(decoded);
+        return {
+          kind: "panic",
+          name: "Panic",
+          message: panicCodes[code] || `EVM panic code ${code}.`,
+          hint: "Check for arithmetic or bounds issues in inputs.",
+          rawData,
+        };
+      }
+    }
+
+    return { kind: "unknown", name: null, message: "Transaction failed.", hint: null, rawData };
+  }
+
+  function isActionRejected(err) {
+    const code = err?.code || err?.info?.error?.code;
+    return code === "ACTION_REJECTED" || code === 4001;
+  }
+
+  function isNetworkError(err) {
+    const code = err?.code;
+    if (["NETWORK_ERROR", "SERVER_ERROR", "TIMEOUT", "UNKNOWN_ERROR"].includes(code)) {
+      return true;
+    }
+    const message = (err?.message || "").toLowerCase();
+    return message.includes("network") || message.includes("rpc") || message.includes("failed to fetch");
+  }
+
+  function friendlyError(err, ctx = {}) {
+    if (isActionRejected(err)) {
+      return "Transaction rejected in wallet.";
+    }
+
+    const data = extractRevertData(err);
+    const decoded = decodeRevertData({
+      data,
+      jmInterface: ctx.jm?.interface || ctx.jmInterface,
+      tokenInterface: ctx.token?.interface || ctx.tokenInterface,
+    });
+
+    if (decoded.kind !== "unknown") {
+      const header = decoded.name ? `${decoded.name}: ${decoded.message}` : decoded.message;
+      return decoded.hint ? `${header}\nFix: ${decoded.hint}` : header;
+    }
+
+    if (isNetworkError(err)) {
+      const message = err?.shortMessage || err?.message || "Network/RPC error.";
+      return `${message}\nFix: Check your wallet connection and RPC endpoint, then retry.`;
+    }
+
+    return err?.shortMessage || err?.message || "Transaction failed.";
+  }
+
+  const exported = {
+    extractRevertData,
+    decodeRevertData,
+    friendlyError,
+    customErrorCatalog,
+  };
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = exported;
+  } else {
+    window.AGIJMErrorDecoder = exported;
+  }
+})();

--- a/test/ui_error_decoder.test.js
+++ b/test/ui_error_decoder.test.js
@@ -1,0 +1,26 @@
+const assert = require("assert");
+
+const decoder = require("../docs/ui/lib/errorDecoder.js");
+
+const { customErrorCatalog, friendlyError } = decoder;
+
+describe("UI error decoder", () => {
+  it("maps AGIJobManager custom errors to friendly messages", () => {
+    const errorNames = Object.keys(customErrorCatalog);
+
+    for (const name of errorNames) {
+      const selector = web3.utils.sha3(`${name}()`).slice(0, 10);
+      const err = { data: selector };
+      const message = friendlyError(err, {});
+
+      assert.ok(
+        message.includes(name),
+        `Expected friendlyError to include error name ${name}`,
+      );
+      assert.ok(
+        message.includes("Fix:"),
+        `Expected friendlyError to include a fix hint for ${name}`,
+      );
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Improve UX by replacing opaque “execution reverted” messages with decoded custom error names, a short human message, and actionable “how to fix” hints for AGIJobManager flows (ENS/Merkle gating and job lifecycle).
- Surface clearer messages both for preflight `staticCall` failures and for actual transaction sends (user rejection vs revert vs RPC/network).
- Keep changes minimal and compatible with the static GitHub Pages UI (no build step, no contract edits). 

### Description

- Added a small, browser+Node-compatible error decoder at `docs/ui/lib/errorDecoder.js` that implements `extractRevertData`, `decodeRevertData`, and `friendlyError`, plus a catalog mapping AGIJobManager custom errors to user message/hints.
- Wired the decoder into the canonical static UI `docs/ui/agijobmanager.html` by including the script and replacing/wrapping existing error handling in preflight (`staticCall`), `sendTx`, and token approval flows so UI logs/alerts show decoded error name + hint.
- Added a deterministic Node test `test/ui_error_decoder.test.js` that requires the decoder and asserts each custom error selector maps to a friendly message containing the error name and a fix hint.
- Documented the common reverts and fixes in `docs/ui/README.md` under a new “Common Reverts & Fixes” section.
- Changes are limited to UI + tests; `contracts/AGIJobManager.sol` is untouched and no network/compiler settings were modified.

### Testing

- Installed deps: `npm ci` (failed on optional `fsevents` platform), then `npm ci --force` (succeeded with warnings). 
- Compile: `npx truffle compile` (succeeded). 
- Unit test suite: `npx truffle test` (initial attempt failed because Ganache was not running; after starting Ganache the full test suite passed: reported `92 passing`).
- ABI sync guard: UI ABI smoke test passed during `truffle test`.
- Decoder unit test: `test/ui_error_decoder.test.js` passed as part of the test run (asserts each custom error yields a name + hint).
- Local smoke verification: deployed to local Ganache via `npx truffle migrate --network development` and executed an integration script (`npx truffle exec /tmp/ui_error_smoke.js --network development`) that triggered representative preflight/revert cases and printed friendly outputs for `NotAuthorized`, `InvalidParameters`, `NotModerator`, and `InvalidState`.
- Limitations: token custom errors will be decoded only if a token ABI/interface with `parseError` is available or if the selector matches a known mapping; the decoder falls back to revert string / panic decoding and to original error text for unknown shapes; the UI decoder attempts multiple common error shapes from ethers v6 and provider/Truffle error envelopes but extremely atypical RPC error shapes may still surface the raw message.

Files changed

- Added: `docs/ui/lib/errorDecoder.js` (new helper). 
- Modified: `docs/ui/agijobmanager.html` (include decoder, wire friendly error handling into `preflight`, `sendTx`, `approveToken`, and token caching). 
- Modified: `docs/ui/README.md` (add Common Reverts & Fixes). 
- Added test: `test/ui_error_decoder.test.js`.

Commands run (high-level)

- `npm ci` (failed due to optional `fsevents` platform constraint) then `npm ci --force` (succeeded with warnings). 
- `npx truffle compile` (success). 
- `npx truffle test` (ran tests; required starting Ganache; final run: all tests passed, including the new decoder test). 
- `npx truffle migrate --network development` (success). 
- `npx truffle exec /tmp/ui_error_smoke.js --network development` (smoke verification showing decoded messages).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c1b489a8c8333b457243316cece91)