### PR TITLE
Harden wallet event binding hygiene in UI

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -74,6 +74,7 @@ The UI listens for EIP-1193 wallet events and rebinds in-place without a page re
 - **accountsChanged**: switches to the active account, rebuilds the provider/signer, refreshes snapshots/role flags, and re-subscribes contract events.
 - **chainChanged**: rebuilds the provider/signer, updates chain metadata, checks contract deployment, and disables writes if unsupported.
 - **disconnect**: clears signer state and disables all write actions.
+- Event handlers are bound once at startup; the UI clears prior bindings before attaching to avoid duplicate listeners.
 
 Default supported chainIds:
 

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -2579,6 +2579,7 @@
       loadContractFromQuery();
       loadKnownDeployment();
       initNetwork();
+      unbindWalletEvents();
       bindWalletEvents();
       updateNetworkPill();
       setWriteEnabled(false);


### PR DESCRIPTION
### Motivation
- Prevent duplicate EIP-1193 wallet event listeners (duplicate logs, memory leaks and misbound re-initializations) by ensuring prior handlers are removed before binding during UI bootstrap.

### Description
- Call `unbindWalletEvents()` before `bindWalletEvents()` in `docs/ui/agijobmanager.html` so event handlers are cleared and then attached exactly once at startup.
- Document the single-binding behavior in `docs/ui/README.md` under the Wallet event handling notes.

### Testing
- `npm ci` — failed due to platform-specific optional dependency (`fsevents`) on Linux (EBADPLATFORM). 
- `npm install` — succeeded (dependencies installed).
- `npx truffle compile` — succeeded (contracts compiled and artifacts written).
- `npx truffle test` — failed to run because no local Ethereum node was available at `http://127.0.0.1:8545` (connection error).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c254177148333a34aa74ba244965c)