### PR TITLE
Handle ENS/NameWrapper availability in eligibility evaluator

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -107,7 +107,7 @@ The **Eligibility Evaluator** in the Identity checks card answers “Would I pas
 5. **ENS resolver addr**
 
 Notes:
-- **Label input:** use the same *label only* (subdomain) you would submit on-chain. The evaluator reads the Agent/Validator action inputs first (apply/validate), then falls back to the generic Identity label field.
+- **Label input:** use the same *label only* (subdomain) you would submit on-chain. The evaluator reads the Agent/Validator action inputs first (apply/validate/disapprove), then falls back to the generic Identity label field.
 - **Merkle proof format:** paste a JSON `bytes32[]` array (e.g., `["0xabc...", "0xdef..."]`). Blank means an empty proof (`[]`).
 
 ## Known limitations

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -1482,11 +1482,17 @@
         [rootNode, ethers.id(label)]
       );
 
-      if (nameWrapperAddress === ethers.ZeroAddress || ensAddress === ethers.ZeroAddress) {
+      const [ensCode, nameWrapperCode] = await Promise.all([
+        ensAddress !== ethers.ZeroAddress ? state.provider.getCode(ensAddress) : "0x",
+        nameWrapperAddress !== ethers.ZeroAddress ? state.provider.getCode(nameWrapperAddress) : "0x",
+      ]);
+      const ensAvailable = ensAddress !== ethers.ZeroAddress && ensCode !== "0x";
+      const nameWrapperAvailable = nameWrapperAddress !== ethers.ZeroAddress && nameWrapperCode !== "0x";
+      if (!ensAvailable || !nameWrapperAvailable) {
         details.ensUnavailable = true;
       }
 
-      if (nameWrapperAddress !== ethers.ZeroAddress) {
+      if (nameWrapperAvailable) {
         try {
           const nameWrapper = new ethers.Contract(nameWrapperAddress, nameWrapperAbi, state.provider);
           const owner = await nameWrapper.ownerOf(BigInt(details.subnode));
@@ -1506,7 +1512,7 @@
         }
       }
 
-      if (ensAddress !== ethers.ZeroAddress) {
+      if (ensAvailable) {
         try {
           const ens = new ethers.Contract(ensAddress, ensAbi, state.provider);
           const resolverAddress = await ens.resolver(details.subnode);


### PR DESCRIPTION
### Motivation
- Make the UI eligibility evaluator mirror on-chain OR-logic more reliably by avoiding blind ENS/NameWrapper calls on networks where those contracts are not deployed or have no code. 

### Description
- Detect ENS and NameWrapper code presence via `provider.getCode(...)` before attempting `ownerOf`/`resolver` lookups and set `details.ensUnavailable` when missing, preventing spurious failures and matching on-chain fallback behavior (`docs/ui/agijobmanager.html`).
- Only perform NameWrapper/ENS checks when the contracts are actually present (use `ensAvailable` / `nameWrapperAvailable`) so the evaluator continues to the resolver fallback exactly as the contract does.
- Clarify label input precedence to include `disapprove` inputs in the UI README so the evaluator uses the same label fields users will submit on-chain (`docs/ui/README.md`).

### Testing
- Ran `npm install` successfully to install dependencies. 
- Ran `npx truffle compile` successfully and produced artifacts. 
- Ran `npx truffle test` (initial run failed due to no local node), then started Ganache and re-ran `npx truffle test`, which completed successfully with all tests passing (`92 passing`).
- Ran `npx truffle migrate --network development` and `npx truffle exec /tmp/set_additional.js --network development` to deploy and set additional allowlists, both succeeding.
- Attempts to perform an automated browser smoke test (Playwright) to simulate wallet connect + UI Evaluate clicks timed out in this environment, so manual UI smoke verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697c2f4de1f88333b5884f16f1640a7d)