### PR TITLE
Clarify cancel eligibility checks in UI

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -105,7 +105,7 @@ The UI includes an employer-only **Cancel job** flow that mirrors the contractâ€
 - **Not allowed after completion**.
 - **Only the employer** who created the job can cancel it.
 - **Cancellation refunds the job payout** back to the employer.
-- **Disputed jobs can still be cancelled** as long as they remain unassigned and incomplete.
+- **Disputed jobs must be resolved** (disputes only arise once a job is assigned, so cancellation is no longer possible).
 
 The UI verifies the job struct (`jobs(jobId)`) before sending a transaction and then runs a static-call preflight
 before showing a confirmation dialog. If the job was already cancelled/deleted, the employer address will be `0x0`

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -434,7 +434,7 @@
           <label for="cancelJobId">Job ID</label>
           <input id="cancelJobId" placeholder="0" />
           <button id="cancelJob" class="danger">Cancel job</button>
-          <p class="muted">Employer-only; only before assignment; no cancel after completion.</p>
+          <p class="muted">Employer-only; only before assignment; no cancel after completion or during disputes.</p>
         </div>
         <div>
           <h3>Dispute job (employer)</h3>
@@ -1239,12 +1239,15 @@
       return parsed;
     }
 
-    function describeCancelIneligibility({ employer, assignedAgent, completed }) {
+    function describeCancelIneligibility({ employer, assignedAgent, completed, disputed }) {
       if (employer === ethers.ZeroAddress) {
         return "Job not found or already cancelled.";
       }
       if (employer !== state.walletAddress) {
         return "Only the employer who created the job can cancel it.";
+      }
+      if (disputed) {
+        return "Job is in dispute; cancellation is blocked until it is resolved.";
       }
       if (assignedAgent !== ethers.ZeroAddress) {
         return "Job already assigned; cancellation is only allowed before assignment.";
@@ -1259,9 +1262,11 @@
       const employer = job[1];
       const assignedAgent = job[5];
       const completed = job[7];
+      const disputed = job[11];
       if (!state.walletAddress) return false;
       return employer !== ethers.ZeroAddress
         && employer === state.walletAddress
+        && !disputed
         && assignedAgent === ethers.ZeroAddress
         && !completed;
     }
@@ -1963,6 +1968,7 @@
         employer: job[1],
         assignedAgent: job[5],
         completed: job[7],
+        disputed: job[11],
       });
       if (eligibilityMessage) {
         throw new Error(eligibilityMessage);
@@ -1973,7 +1979,7 @@
         `Cancel job ${jobId}`,
         `Contract: ${state.contractAddress}`,
         `Refund: ${payout}`,
-        "Employer-only; only before assignment; no cancel after completion.",
+        "Employer-only; only before assignment; no cancel after completion or during disputes.",
         "Proceed with cancellation?",
       ].join("\\n");
       if (!window.confirm(confirmMessage)) {


### PR DESCRIPTION
### Motivation
- Ensure the employer-facing Cancel job flow mirrors on-chain semantics by surfacing dispute state as a preflight blocker and preventing ambiguous cancellations.
- Keep the change minimal and purely UI/docs-focused (no contract edits) while preserving existing staticCall preflight, confirmations, and activity logging patterns.

### Description
- Added dispute-awareness to cancel preflight by updating `describeCancelIneligibility` to reject jobs with `disputed == true` and updated the cancel confirmation copy to mention disputes in `docs/ui/agijobmanager.html`.
- Updated `isCancelEligible` to factor the job `disputed` field so inline “Cancel” buttons in the Jobs table are only shown for truly eligible jobs in `docs/ui/agijobmanager.html`.
- Aligned documentation in `docs/ui/README.md` to state that disputed jobs must be resolved before cancellation and explained the UI behavior.
- Files changed: `docs/ui/agijobmanager.html`, `docs/ui/README.md` (UI-only edits, no Solidity or ABI changes).

### Testing
- Ran `npm install` (completed successfully).
- Ran `npx truffle compile` (completed successfully).
- Ran `npx truffle test` initially failed due to no local node, then after launching a local chain with Ganache and re-running `npx truffle test` the full test suite passed (92 passing).
- Deployed to a local development chain with `npx truffle migrate --network development` and executed a local smoke script with `npx truffle exec /tmp/local-smoke.js --network development`, which completed successfully and validated: creating a job, cancelling pre-assignment, and that cancellation fails after assignment.
- Per-UI smoke: served the static UI locally and captured a screenshot of the Employer actions panel to verify the updated copy and controls (visual verification artifact produced).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cabc3fb988333b20fd321577e7dc6)