### PR TITLE
Add non-technical user guide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 
 Start here:
 - [`docs/README.md`](docs/README.md)
-- **Non‑technical user guides**: [`docs/README.md`](docs/README.md) (roles, happy path, troubleshooting, identity & proofs)
+- **Non‑technical user guide (landing page)**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This documentation set targets engineers, integrators, operators, and auditors **and** now includes non‑technical user guides. Each document has a focused scope with cross-references for faster navigation and auditability.
 
 ## Start here (non‑technical user guides)
+- **User guide (landing page)**: [`user-guide/README.md`](user-guide/README.md)
 - **Roles overview**: [`guides/ROLES.md`](guides/ROLES.md)
 - **Happy path walkthrough**: [`guides/HAPPY_PATH.md`](guides/HAPPY_PATH.md)
 - **Troubleshooting (“execution reverted”)**: [`guides/TROUBLESHOOTING.md`](guides/TROUBLESHOOTING.md)

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,24 @@
+# User guide (non-technical)
+
+Welcome! This guide is written for **non‑technical users** across all roles. You do **not** need to read Solidity to use AGIJobManager.
+
+## Start here
+- **Roles (Employer / Agent / Validator / Moderator / Owner)**: [`roles.md`](roles.md)
+- **Happy‑path walkthrough** (step‑by‑step): [`happy-path.md`](happy-path.md)
+- **Common revert reasons** (what went wrong + fixes): [`common-reverts.md`](common-reverts.md)
+- **Merkle proofs & identity checks**: [`merkle-proofs.md`](merkle-proofs.md)
+- **Glossary**: [`glossary.md`](glossary.md)
+
+## How to use the system
+You can interact using:
+- **Web UI** (recommended): [`docs/ui/agijobmanager.html`](../ui/agijobmanager.html)
+- **Etherscan** (read‑only + write with connected wallet)
+- **Truffle console** (read‑only calls and troubleshooting)
+
+> ⚠️ **Subdomain label only**: When the app asks for an identity **subdomain**, always enter the **label only** (e.g., `helper`, **not** `helper.agent.agi.eth`). The contract derives the full name from a fixed root node + label.
+
+## Quick checklist
+- ✅ Use the **correct network** and **official contract address**.
+- ✅ Read the **token address** from the contract (don’t guess it).
+- ✅ **Approve** token spend *before* creating a job or buying an NFT.
+- ✅ If you’re an **Agent** or **Validator**, confirm eligibility via **allowlist**, **Merkle proof**, or **ENS** (see `merkle-proofs.md`).

--- a/docs/user-guide/common-reverts.md
+++ b/docs/user-guide/common-reverts.md
@@ -1,0 +1,52 @@
+# Common revert reasons (and fixes)
+
+This guide is based **directly on the contract’s revert conditions**. It explains what failed and how to fix it without reading Solidity.
+
+> ⚠️ **Subdomain label only**: If a call asks for a subdomain, use the **label only** (e.g., `helper`, **not** `helper.agent.agi.eth`). A full ENS name often causes `NotAuthorized`.
+
+## Quick legend
+- **Custom errors**: `NotAuthorized`, `NotModerator`, `Blacklisted`, `InvalidParameters`, `InvalidState`, `JobNotFound`, `TransferFailed`.
+- **Other common reverts**: `Ownable: caller is not the owner`, `Pausable: paused`.
+
+## Revert table
+
+| What you tried to do | What you saw | What it means | How to fix it | Where to learn more |
+| --- | --- | --- | --- | --- |
+| Create a job | `InvalidParameters` | Payout or duration is zero/too large. | Choose payout > 0 and ≤ max payout; choose duration > 0 and ≤ duration limit. | [`happy-path.md`](happy-path.md), [`roles.md`](roles.md) |
+| Create a job | `TransferFailed` | Token transfer from your wallet failed. | Ensure correct token, enough balance, and **approve** the contract. | [`happy-path.md`](happy-path.md) |
+| Apply for a job | `JobNotFound` | Job ID doesn’t exist. | Check job ID in the UI/Etherscan. | [`happy-path.md`](happy-path.md) |
+| Apply for a job | `InvalidState` | Job already has an assigned agent. | Pick a job that is still unassigned. | [`roles.md`](roles.md) |
+| Apply for a job | `Blacklisted` | Your wallet is blacklisted as an agent. | Contact the operator to resolve. | [`roles.md`](roles.md) |
+| Apply for a job | `NotAuthorized` | Identity checks failed. | Use **label only**, correct Merkle proof, or be explicitly allowlisted. | [`merkle-proofs.md`](merkle-proofs.md) |
+| Request job completion | `NotAuthorized` | You are not the assigned agent. | Only the assigned agent can request completion. | [`roles.md`](roles.md) |
+| Request job completion | `InvalidState` | Job duration expired. | Request completion before the duration ends. | [`happy-path.md`](happy-path.md) |
+| Validate a job | `JobNotFound` | Job ID doesn’t exist. | Recheck job ID. | [`happy-path.md`](happy-path.md) |
+| Validate a job | `InvalidState` | Job has no assigned agent or is already completed. | Validate only active, assigned jobs. | [`roles.md`](roles.md) |
+| Validate a job | `Blacklisted` | Your wallet is blacklisted as a validator. | Contact the operator to resolve. | [`roles.md`](roles.md) |
+| Validate a job | `NotAuthorized` | Identity checks failed. | Use **label only**, correct Merkle proof, or be explicitly allowlisted. | [`merkle-proofs.md`](merkle-proofs.md) |
+| Validate a job | `InvalidState` | You already approved/disapproved. | Only vote once per job. | [`roles.md`](roles.md) |
+| Disapprove a job | `InvalidState` | Job has no assigned agent or is already completed. | Disapprove only active, assigned jobs. | [`roles.md`](roles.md) |
+| Disapprove a job | `NotAuthorized` | Identity checks failed. | Use **label only**, correct Merkle proof, or be explicitly allowlisted. | [`merkle-proofs.md`](merkle-proofs.md) |
+| Dispute a job | `InvalidState` | Job is already disputed or completed. | Only dispute active, undisputed jobs. | [`happy-path.md`](happy-path.md) |
+| Dispute a job | `NotAuthorized` | You are not the employer or assigned agent. | Only those two roles can dispute. | [`roles.md`](roles.md) |
+| Resolve a dispute | `NotModerator` | You are not a moderator. | Ask the owner to add you as moderator. | [`roles.md`](roles.md) |
+| Resolve a dispute | `InvalidState` | Job is not disputed. | Only resolve when the job is in dispute. | [`roles.md`](roles.md) |
+| Cancel a job | `NotAuthorized` | You are not the employer. | Only the employer can cancel. | [`roles.md`](roles.md) |
+| Cancel a job | `InvalidState` | Job already assigned or completed. | Cancel only before assignment. | [`roles.md`](roles.md) |
+| Delist a job (owner) | `Ownable: caller is not the owner` | You are not the owner. | Use the owner wallet. | [`roles.md`](roles.md) |
+| Delist a job (owner) | `InvalidState` | Job already assigned or completed. | Delist only before assignment. | [`roles.md`](roles.md) |
+| List an NFT | `NotAuthorized` | You are not the NFT owner. | Only the NFT owner can list. | [`roles.md`](roles.md) |
+| List an NFT | `InvalidParameters` | Price is zero. | Set a price > 0. | [`roles.md`](roles.md) |
+| Purchase an NFT | `InvalidState` | Listing is not active. | Choose an active listing. | [`roles.md`](roles.md) |
+| Purchase an NFT | `TransferFailed` | Token transfer failed. | Approve the contract and ensure balance. | [`happy-path.md`](happy-path.md) |
+| Delist an NFT | `NotAuthorized` | You are not the seller or listing is inactive. | Only the seller can delist an active listing. | [`roles.md`](roles.md) |
+| Withdraw AGI (owner) | `InvalidParameters` | Amount is zero or exceeds balance. | Use a valid amount within contract balance. | [`roles.md`](roles.md) |
+| Contribute to reward pool | `InvalidParameters` | Amount is zero. | Use a non‑zero amount. | [`roles.md`](roles.md) |
+| Add AGI type | `InvalidParameters` | NFT address is zero or payout % is invalid. | Provide a valid address and 1–100%. | [`roles.md`](roles.md) |
+| Set validator reward % | `InvalidParameters` | Percentage is 0 or > 100. | Use 1–100. | [`roles.md`](roles.md) |
+| Any action while paused | `Pausable: paused` | The contract is paused by the owner. | Wait for unpause or contact operator. | [`roles.md`](roles.md) |
+
+## Still stuck?
+- Double‑check **network**, **contract address**, and **token address**.
+- Ensure you’re using the correct **wallet** for the role.
+- If you rely on identity checks, verify **label‑only** subdomain and proof format.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -1,0 +1,12 @@
+# Glossary (short)
+
+- **AGI token**: The ERC‑20 token used for job payouts and NFT purchases. Read its address from the contract.
+- **Allowlist**: A list of approved wallet addresses. The owner can add wallets directly or via Merkle proofs.
+- **Merkle root / proof / leaf**: The cryptographic root stored on‑chain, the proof you provide, and the hashed wallet address (leaf).
+- **Subdomain label**: The short label only (e.g., `alice`). **Do not** enter the full ENS name.
+- **Root node**: The fixed ENS root used by the contract to build full names from labels.
+- **NameWrapper**: ENS contract that holds wrapped name ownership.
+- **Resolver**: ENS resolver contract that maps a name to an address.
+- **Job states**: Created → Assigned → CompletionRequested → Completed / Disputed / Cancelled.
+- **Approval / Disapproval threshold**: Number of validator approvals/disapprovals needed to complete or dispute a job.
+- **IPFS hash**: A content identifier (CID) pointing to job details or deliverables.

--- a/docs/user-guide/happy-path.md
+++ b/docs/user-guide/happy-path.md
@@ -1,0 +1,76 @@
+# Happy path walkthrough (end‑to‑end)
+
+This is the simplest, **non‑technical** path for a successful job lifecycle.
+
+> ⚠️ **Subdomain label only**: When entering an identity subdomain, use **only the label** (e.g., `helper`, **not** `helper.agent.agi.eth`). The contract derives the full name from a fixed root node + label.
+
+## Before you start
+1. **Choose the correct network** (e.g., Sepolia or Mainnet) and connect your wallet.
+2. **Get the official contract address** (from a verified deployment announcement, README, or operator). Do not guess.
+3. **Read the AGI token address from the contract** (read‑only call to `agiToken`).
+4. **Approve token spend before actions that transfer AGI**:
+   - Employer: approve **before** `createJob`.
+   - Buyer: approve **before** `purchaseNFT`.
+5. If you’re an **Agent** or **Validator**, confirm eligibility (allowlist, Merkle proof, or ENS ownership). See [`merkle-proofs.md`](merkle-proofs.md).
+
+## Recommended UI entry point
+Use the Web UI: [`docs/ui/agijobmanager.html`](../ui/agijobmanager.html)
+- You can also use Etherscan (write with wallet) or Truffle console for read‑only checks.
+
+## Job lifecycle (state machine)
+```mermaid
+stateDiagram-v2
+    [*] --> Created: createJob
+    Created --> Assigned: applyForJob
+    Assigned --> CompletionRequested: requestJobCompletion
+
+    Assigned --> Completed: validateJob (approval threshold)
+    CompletionRequested --> Completed: validateJob (approval threshold)
+
+    Assigned --> Disputed: disapproveJob (disapproval threshold)
+    CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
+    Assigned --> Disputed: disputeJob (manual)
+    CompletionRequested --> Disputed: disputeJob (manual)
+
+    Disputed --> Completed: resolveDispute("agent win")
+    Disputed --> Completed: resolveDispute("employer win")
+    Disputed --> Assigned: resolveDispute(other)
+
+    Created --> Cancelled: cancelJob (employer)
+    Created --> Cancelled: delistJob (owner)
+```
+
+## Employer happy path
+1. **Approve AGI tokens** for the contract.
+2. **Create job** with:
+   - IPFS hash (job spec)
+   - Payout amount
+   - Duration
+3. Wait for an agent to apply.
+4. (Optional) If there’s a disagreement, open a dispute.
+5. Receive job NFT on completion.
+
+## Agent happy path
+1. **Verify eligibility** (allowlist / Merkle / ENS ownership).
+2. **Apply for job** with your subdomain **label only** and proof if required.
+3. Complete the work off‑chain and upload final artifacts to IPFS.
+4. **Request completion** with the new IPFS hash.
+5. If a dispute occurs, provide evidence to the moderator.
+
+## Validator happy path
+1. **Verify eligibility** (allowlist / Merkle / ENS ownership).
+2. **Review job details** and evaluate the deliverables.
+3. **Approve** or **disapprove**:
+   - Approvals add toward completion.
+   - Disapprovals can trigger a dispute.
+
+## Moderator happy path
+1. Review evidence off‑chain.
+2. Call `resolveDispute` with **exact** resolution strings:
+   - `agent win` or `employer win`.
+3. Confirm the job state is updated and payouts/refunds executed.
+
+## Quick reminders
+- A **completion request** is not required for validators to approve, but it signals that the agent is done.
+- Disputes can be raised by the employer or assigned agent.
+- Always use **label only** for subdomain inputs (no full ENS name).

--- a/docs/user-guide/merkle-proofs.md
+++ b/docs/user-guide/merkle-proofs.md
@@ -1,0 +1,58 @@
+# Merkle proofs & identity checks
+
+This page explains **how identity gating works** and how to obtain and use a Merkle proof.
+
+> ⚠️ **Subdomain label only**: When an action asks for a subdomain, enter **only the label** (e.g., `helper`, **not** `helper.agent.agi.eth`). The contract combines the label with a fixed root node.
+
+## How identity checks work (OR‑logic)
+For **Agents** and **Validators**, the contract accepts **any one** of these paths:
+1. **Additional allowlist** (set by the owner): `additionalAgents` / `additionalValidators`.
+2. **Merkle proof** (address is in an allowlist committed on‑chain).
+3. **ENS NameWrapper ownership** (`NameWrapper.ownerOf`).
+4. **ENS resolver address** (`Resolver.addr`) as a fallback.
+
+If any of these succeeds, you are authorized.
+
+## What is a Merkle proof (plain language)?
+A Merkle proof is a **short cryptographic receipt** that proves your wallet is in a list **without exposing the whole list on‑chain**. The contract stores only a single hash called the **Merkle root**.
+
+## Where do proofs come from?
+- **From the operator/maintainer**: The allowlist and Merkle root are configured at deployment and **cannot be changed**. Ask the operator for your proof if you’re allowlisted.
+- **From this repo (generator script)**: If you are the operator, you can generate proofs locally using:
+  ```bash
+  node scripts/merkle/generate_merkle_proof.js --input /path/to/addresses.json --address 0xYourWallet
+  ```
+  The script outputs:
+  - `root`: Merkle root (must match the on‑chain root),
+  - `proof`: array of `0x…` 32‑byte hashes.
+
+## Proof format (important)
+Most UIs and tools expect a **JSON array of bytes32 strings**:
+```json
+["0xabc...", "0xdef..."]
+```
+- An **empty proof** is `[]` (use this only if you are allowlisted or using ENS ownership).
+- Do **not** include commas in a single string; it must be a JSON array.
+
+## How to verify your proof
+### Option A: Web UI (recommended)
+Use the **Identity Checks** section in [`docs/ui/agijobmanager.html`](../ui/agijobmanager.html). It verifies the Merkle proof and ENS ownership **before** you submit a transaction.
+
+### Option B: Truffle console (read‑only)
+1. Open a console on the correct network:
+   ```bash
+   npx truffle console --network sepolia
+   ```
+2. Read the on‑chain Merkle root:
+   ```js
+   const c = await AGIJobManager.deployed();
+   await c.agentMerkleRoot(); // or validatorMerkleRoot()
+   ```
+3. Compare that root to the `root` returned by the proof generator.
+
+## Troubleshooting checklist
+- **Wrong wallet**: the proof is tied to a specific address.
+- **Wrong root**: the Merkle root on‑chain must match the root used to generate the proof.
+- **Wrong network**: proof won’t work if you’re on a different chain/deployment.
+- **Malformed proof**: must be a JSON array of `0x` 32‑byte hashes.
+- **Full ENS name used**: only the **label** is accepted.

--- a/docs/user-guide/roles.md
+++ b/docs/user-guide/roles.md
@@ -1,0 +1,157 @@
+# Roles guide (non‑technical)
+
+This page explains what each role can do, what you need first, common mistakes, and the typical workflow. All role checks are enforced **on‑chain**.
+
+> ⚠️ **Subdomain label only**: When asked for a subdomain, use **only the label** (e.g., `helper`, **not** `helper.agent.agi.eth`). The contract derives the full name from a fixed root node + label.
+
+---
+
+## Employer
+
+**What you can do (plain language)**
+- Create a new job and fund escrow (`createJob`).
+- Cancel a job **before** an agent is assigned (`cancelJob`).
+- Dispute a job if things go wrong (`disputeJob`).
+- Receive the job NFT on completion (minted automatically).
+- List or delist your job NFT (`listNFT`, `delistNFT`), or buy other job NFTs (`purchaseNFT`).
+
+**What you need first**
+- A wallet with enough **AGI token** to fund the job payout.
+- **Token approval** for the contract (required before `createJob`).
+- The **correct network** + **official contract address**.
+
+**Common mistakes**
+- Skipping token approval (transaction reverts with `TransferFailed`).
+- Using the wrong network or wrong contract address.
+- Payout or duration outside allowed limits.
+- Trying to cancel after an agent is assigned (invalid state).
+- Forgetting to use a valid IPFS hash for job details.
+
+**Typical workflow**
+1. Approve the contract to spend your AGI tokens.
+2. Create a job (provide IPFS hash, payout, duration).
+3. Wait for an agent to apply.
+4. If needed, dispute the job; otherwise, wait for validator approvals.
+5. Receive the job NFT once completed.
+
+---
+
+## Agent
+
+**What you can do (plain language)**
+- Apply for a job (`applyForJob`).
+- Submit a completion request with updated IPFS details (`requestJobCompletion`).
+- Dispute a job if needed (`disputeJob`).
+- Earn payout and reputation when a job is completed.
+
+**What you need first**
+- A wallet.
+- **Eligibility** via any one of these (OR‑logic):
+  - Added directly by the owner (`additionalAgents`), **or**
+  - A valid **Merkle proof**, **or**
+  - ENS ownership (NameWrapper `ownerOf`), **or**
+  - ENS resolver `addr` match (fallback).
+- **Subdomain label only** (e.g., `alice`, **not** `alice.agent.agi.eth`).
+
+**Common mistakes**
+- Using the **full ENS name** instead of the label only.
+- Passing the wrong Merkle proof (or proof for another wallet).
+- Trying to apply after an agent is already assigned.
+- Requesting completion **after** the job duration expired.
+- Applying while blacklisted.
+
+**Typical workflow**
+1. Confirm you’re eligible (allowlist, Merkle proof, or ENS ownership).
+2. Apply for a job using your subdomain **label only**.
+3. Deliver work off‑chain and update the IPFS hash.
+4. Request completion.
+5. If disputed, cooperate with moderators; otherwise, wait for validator approvals.
+
+---
+
+## Validator
+
+**What you can do (plain language)**
+- Approve jobs (`validateJob`) or disapprove jobs (`disapproveJob`).
+- Earn a validator payout share and reputation when a job completes.
+
+**What you need first**
+- A wallet.
+- **Eligibility** via any one of these (OR‑logic):
+  - Added directly by the owner (`additionalValidators`), **or**
+  - A valid **Merkle proof**, **or**
+  - ENS ownership (NameWrapper `ownerOf`), **or**
+  - ENS resolver `addr` match (fallback).
+- **Subdomain label only** (e.g., `helper`, **not** `helper.club.agi.eth`).
+
+**Common mistakes**
+- Using the full ENS name instead of the label only.
+- Validating/disapproving **twice** (invalid state).
+- Trying to validate a job with no assigned agent.
+- Acting while blacklisted.
+
+**Typical workflow**
+1. Confirm you’re eligible (allowlist, Merkle proof, or ENS ownership).
+2. Check job details (IPFS hash + expected deliverables).
+3. Approve or disapprove using your subdomain **label only** and proof (if required).
+4. If approval threshold is met, job completes automatically.
+
+---
+
+## Moderator
+
+**What you can do (plain language)**
+- Resolve disputes (`resolveDispute`).
+
+**What you need first**
+- Your wallet must be added by the owner as a moderator.
+- Understand the **canonical resolution strings**:
+  - `agent win` → completes the job and pays the agent.
+  - `employer win` → refunds the employer and closes the job.
+  - Any other text only clears the dispute flag (no payout).
+
+**Common mistakes**
+- Using the wrong resolution string (no payout/refund happens).
+- Trying to resolve a job that is not disputed.
+- Attempting to resolve without being a moderator.
+
+**Typical workflow**
+1. Review evidence off‑chain.
+2. Call `resolveDispute` with **exact** resolution text.
+3. Confirm the dispute flag is cleared and payouts/refunds executed.
+
+---
+
+## Owner (operator)
+
+**What you can do (plain language)**
+- Pause/unpause the system (`pause`, `unpause`).
+- Add/remove moderators (`addModerator`, `removeModerator`).
+- Manage allowlists and blacklists (`addAdditionalAgent`, `addAdditionalValidator`, `blacklistAgent`, `blacklistValidator`).
+- Adjust parameters (approvals, payouts, limits, metadata).
+- Withdraw escrowed AGI tokens (`withdrawAGI`).
+- Delist a job before assignment (`delistJob`).
+- Add AGI types for payout bonuses (`addAGIType`).
+
+**What you need first**
+- Owner wallet (the deploying wallet or current owner).
+- Operational policy for allowlists, disputes, and parameters.
+
+**Common mistakes**
+- Using a non‑owner wallet (fails with Ownable error).
+- Updating parameters without communicating to users.
+- Delisting a job after an agent is assigned (invalid state).
+
+**Typical workflow**
+1. Maintain allowlists, moderators, and blacklists.
+2. Monitor disputes and job throughput.
+3. Adjust parameters as needed.
+
+---
+
+## How roles interact (simple overview)
+1. **Employer** creates and funds a job.
+2. **Agent** applies and works on the job.
+3. **Validator(s)** approve or disapprove the work.
+4. If disputed, a **Moderator** resolves the dispute.
+5. The job completes or is refunded; the **Employer** receives the job NFT.


### PR DESCRIPTION
### Motivation
- Provide clear, role-focused, non-technical documentation so any user (Employer / Agent / Validator / Moderator / Owner) can operate the system without reading Solidity. 
- Surface common failure modes (revert reasons) and practical fixes to reduce support friction. 
- Explain Merkle proof generation/format and the contract’s OR‑logic for identity gating, and emphasize the important UX requirement “subdomain label only.”

### Description
- Added a new user documentation section under `docs/user-guide/` with six files: `README.md`, `roles.md`, `happy-path.md`, `common-reverts.md`, `merkle-proofs.md`, and `glossary.md`, covering roles, an end-to-end walkthrough, a table of contract-derived revert reasons, Merkle proof guidance, and a short glossary. 
- Linked the new user guide from the docs index (`docs/README.md`) and the project root `README.md` for discoverability, keeping changes minimal and avoiding any edits to `contracts/AGIJobManager.sol`. 
- The Merkle guide references the in-repo generator script `scripts/merkle/generate_merkle_proof.js` and shows the required JSON `bytes32[]` proof format and Truffle console read-only verification steps. 
- All docs repeatedly call out the required input style “subdomain label only” (e.g., `helper`, not `helper.agent.agi.eth`) and point users to the Web UI (`docs/ui/agijobmanager.html`) or Etherscan/Truffle for interaction.

### Testing
- `npm ci` failed due to platform incompatibility for `fsevents` on Linux (expected native optional dependency), so I ran `npm install` instead which completed (with dependency deprecation warnings). 
- `npx truffle compile` succeeded and produced contract artifacts (compile warnings only). 
- `npx truffle test` could not run because the test runner could not connect to a local node at `http://127.0.0.1:8545` (no local Ganache instance started), so tests were not executed; reproduction: start a local chain (`npx ganache -p 8545`) and re-run `npx truffle test`. 
- Verified docs files and internal links by opening the new files and updating `docs/README.md` and `README.md` to include the landing page; the new Markdown files are renderable and cross-linked for GitHub.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf1d3eb24833399242f2df5c5d5ae)