### PR TITLE
Add non-technical user guide documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 
 Start here:
 - [`docs/README.md`](docs/README.md)
-- **Non‑technical user guides**: [`docs/README.md`](docs/README.md) (roles, happy path, troubleshooting, identity & proofs)
+- **Non‑technical user guides**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,15 @@
 
 This documentation set targets engineers, integrators, operators, and auditors **and** now includes non‑technical user guides. Each document has a focused scope with cross-references for faster navigation and auditability.
 
-## Start here (non‑technical user guides)
+## User guide (non‑technical)
+- **Landing page**: [`user-guide/README.md`](user-guide/README.md)
+- **Roles**: [`user-guide/roles.md`](user-guide/roles.md)
+- **Happy path walkthrough**: [`user-guide/happy-path.md`](user-guide/happy-path.md)
+- **Common revert reasons**: [`user-guide/common-reverts.md`](user-guide/common-reverts.md)
+- **Merkle proofs**: [`user-guide/merkle-proofs.md`](user-guide/merkle-proofs.md)
+- **Glossary**: [`user-guide/glossary.md`](user-guide/glossary.md)
+
+## Start here (legacy non‑technical user guides)
 - **Roles overview**: [`guides/ROLES.md`](guides/ROLES.md)
 - **Happy path walkthrough**: [`guides/HAPPY_PATH.md`](guides/HAPPY_PATH.md)
 - **Troubleshooting (“execution reverted”)**: [`guides/TROUBLESHOOTING.md`](guides/TROUBLESHOOTING.md)

--- a/docs/user-guide/README.md
+++ b/docs/user-guide/README.md
@@ -1,0 +1,39 @@
+# User guide (non-technical)
+
+Welcome! This guide set is written for non-technical users in **any** role. You do **not** need to read Solidity to succeed.
+
+## Start here
+
+1. **Roles & permissions** → [`roles.md`](roles.md)
+2. **Happy path walkthrough** → [`happy-path.md`](happy-path.md)
+3. **Common revert reasons (fixes)** → [`common-reverts.md`](common-reverts.md)
+4. **Merkle proof guidance** → [`merkle-proofs.md`](merkle-proofs.md)
+5. **Glossary** → [`glossary.md`](glossary.md)
+
+## Preferred ways to use the system
+
+- **Web UI (recommended for non-technical users):**
+  - UI page: [`docs/ui/agijobmanager.html`](../ui/agijobmanager.html)
+  - UI usage guide: [`docs/ui/README.md`](../ui/README.md)
+- **Wallet + Etherscan “Read/Write Contract”** for simple tasks.
+- **Truffle console** for read-only checks when you need more detail.
+
+## ⚠️ Important safety notes
+
+- **Use the label only, not the full ENS name.**
+  - ✅ `helper`
+  - ❌ `helper.agent.agi.eth`
+  - ✅ `alice`
+  - ❌ `alice.club.agi.eth`
+  The contract derives the namehash from a fixed root node + label only.
+- **Approvals are real on-chain actions.** Approving ERC‑20 spending allows the contract to move your tokens. Verify the contract address and network first.
+- **Network matters.** Always confirm you’re on the same chain as the contract deployment.
+
+## How this guide is organized
+
+- **Roles** describes exactly what each role can do and what you need before starting.
+- **Happy path** provides a full end‑to‑end walkthrough of a typical job lifecycle.
+- **Common reverts** helps you fix “execution reverted” issues quickly.
+- **Merkle proofs** explains how allowlists work and how to obtain/format proofs.
+
+If you’re unsure about any term, check the glossary.

--- a/docs/user-guide/common-reverts.md
+++ b/docs/user-guide/common-reverts.md
@@ -1,0 +1,51 @@
+# Common revert reasons (and fixes)
+
+This guide maps what you tried to do → what you saw → how to fix it. All items below are derived directly from the contract logic and custom errors.
+
+> **Tip:** If you see a generic “execution reverted” error, scroll the error details to find the **custom error** name (e.g., `NotAuthorized`, `InvalidState`).
+
+## Quick troubleshooting checklist
+
+- ✅ Correct **network** and **contract address**
+- ✅ Correct **token address** via `agiToken()`
+- ✅ Sufficient **token balance** and **allowance**
+- ✅ Correct **role** (employer vs agent vs validator)
+- ✅ Correct **job state** (created/assigned/completed/disputed)
+- ✅ **Label‑only** ENS input (`helper`, not `helper.agent.agi.eth`)
+
+## Revert reasons table
+
+| What you tried to do | What you saw | What it means | How to fix it | Where to learn more |
+| --- | --- | --- | --- | --- |
+| Apply for a job | `NotAuthorized` | Your wallet did not pass the agent eligibility checks. | Make sure **one** of the following is true: (1) you’re in `additionalAgents`, (2) you provided a valid Merkle proof, (3) you own the ENS NameWrapper subdomain, or (4) your ENS resolver.addr points to your wallet. Also **use the label only**. | [Roles → Agent](roles.md#agent), [Merkle proofs](merkle-proofs.md) |
+| Apply for a job | `InvalidState` | Job already has an assigned agent. | Pick another open job. | [Happy path](happy-path.md) |
+| Apply for a job | `Blacklisted` | Your wallet is blacklisted as an agent. | Contact the operator/owner for remediation. | [Roles → Agent](roles.md#agent) |
+| Request job completion | `NotAuthorized` | Only the assigned agent can request completion. | Ensure you are the assigned agent for that job. | [Roles → Agent](roles.md#agent) |
+| Request job completion | `InvalidState` | The job has expired or is in an invalid state. | Check `assignedAt + duration` and request completion before expiration. | [Happy path](happy-path.md) |
+| Validate or disapprove a job | `NotAuthorized` | Your wallet did not pass the validator eligibility checks. | Make sure **one** of the following is true: (1) you’re in `additionalValidators`, (2) you provided a valid Merkle proof, (3) you own the ENS NameWrapper subdomain, or (4) your ENS resolver.addr points to your wallet. Also **use the label only**. | [Roles → Validator](roles.md#validator), [Merkle proofs](merkle-proofs.md) |
+| Validate or disapprove a job | `InvalidState` | The job has no assigned agent, is already completed, or you already voted. | Validate only after assignment, and only once per job. | [Happy path](happy-path.md) |
+| Validate or disapprove a job | `Blacklisted` | Your wallet is blacklisted as a validator. | Contact the operator/owner for remediation. | [Roles → Validator](roles.md#validator) |
+| Dispute a job | `NotAuthorized` | Only the employer or assigned agent can dispute. | Ensure you are the employer or assigned agent for that job. | [Roles → Employer](roles.md#employer) |
+| Dispute a job | `InvalidState` | Job is already completed or already disputed. | Dispute only while the job is in progress. | [Happy path](happy-path.md) |
+| Resolve a dispute | `NotModerator` | Only moderators can resolve disputes. | Ask the owner to add your wallet as a moderator. | [Roles → Moderator](roles.md#moderator) |
+| Resolve a dispute | `InvalidState` | The job is not currently disputed. | Confirm the job is in dispute before resolving. | [Happy path](happy-path.md) |
+| Cancel a job | `NotAuthorized` | Only the employer can cancel. | Use the employer wallet that created the job. | [Roles → Employer](roles.md#employer) |
+| Cancel or delist a job | `InvalidState` | The job is completed or already assigned. | Only cancel/delist while the job is still unassigned. | [Happy path](happy-path.md) |
+| List an NFT | `NotAuthorized` | You are not the NFT owner. | Only the NFT owner can list it. | [Roles → Employer](roles.md#employer) |
+| List an NFT | `InvalidParameters` | Listing price is zero. | Set a non‑zero price. | [Roles → Employer](roles.md#employer) |
+| Purchase an NFT | `InvalidState` | Listing is inactive or already purchased. | Refresh listing state; buy only active listings. | [Happy path](happy-path.md) |
+| Delist an NFT | `NotAuthorized` | You are not the seller or listing is inactive. | Only the listing seller can delist. | [Roles → Employer](roles.md#employer) |
+| Create a job | `InvalidParameters` | Payout/duration is zero or above contract limits. | Use a positive payout and duration within limits (`maxJobPayout`, `jobDurationLimit`). | [Happy path](happy-path.md) |
+| Withdraw AGI (owner) | `InvalidParameters` | Amount is zero or exceeds contract balance. | Withdraw an amount within the contract’s AGI balance. | [Roles → Owner](roles.md#owner) |
+| Contribute to reward pool | `InvalidParameters` | Amount is zero. | Enter a positive amount. | [Happy path](happy-path.md) |
+| Add AGI type (owner) | `InvalidParameters` | Address is zero or payout percentage outside 1–100. | Provide a valid NFT address and percentage. | [Roles → Owner](roles.md#owner) |
+| Any token transfer | `TransferFailed` | Token transfer or transferFrom returned false. | Ensure you have enough AGI balance and **approved** the contract for the needed amount. | [Happy path](happy-path.md) |
+| Any job action | `JobNotFound` | The job ID does not exist. | Double‑check the job ID. | [Happy path](happy-path.md) |
+| Any action while paused | `Pausable: paused` | The contract is paused. | Wait for the owner to unpause. | [Roles → Owner](roles.md#owner) |
+
+## If you still can’t proceed
+
+1. Confirm the **contract address** and **network**.
+2. Check the **job state** and your **role**.
+3. Verify allowance and balance.
+4. Review the [Merkle proof guide](merkle-proofs.md) if identity gating is involved.

--- a/docs/user-guide/glossary.md
+++ b/docs/user-guide/glossary.md
@@ -1,0 +1,15 @@
+# Glossary (short)
+
+- **AGI token**: ERC‑20 token used for job payouts and rewards.
+- **Allowance**: Permission you grant a contract to move your ERC‑20 tokens.
+- **Employer**: The job creator who funds escrow.
+- **Agent**: The worker who applies and completes a job.
+- **Validator**: Reviews jobs by approving/disapproving.
+- **Moderator**: Resolves disputes.
+- **Owner**: Admin with high‑privilege controls.
+- **Merkle root / proof**: Cryptographic allowlist mechanism; the root is stored on‑chain, and a proof shows your wallet is in the list.
+- **NameWrapper**: ENS contract that owns wrapped ENS names; used for ownership checks.
+- **Resolver.addr**: ENS resolver mapping from name → wallet address.
+- **Label (subdomain label only)**: The left‑most piece of an ENS name used in this contract.
+  - ✅ `helper`
+  - ❌ `helper.agent.agi.eth`

--- a/docs/user-guide/happy-path.md
+++ b/docs/user-guide/happy-path.md
@@ -1,0 +1,76 @@
+# Happy path walkthrough (end‑to‑end)
+
+This walkthrough shows a full job lifecycle for **Employer → Agent → Validator → Moderator**. It avoids Solidity and focuses on real actions.
+
+## Before you start
+
+1. **Confirm the network** (e.g., Sepolia vs Mainnet) matches the deployment.
+2. **Confirm the contract address** from a trusted source (deployment output, official announcement, or UI page).
+3. **Read the token address** directly from the contract:
+   - `agiToken()` (read‑only)
+4. **Approve token spend** for actions that move AGI tokens:
+   - Employer: `createJob` (escrow payout)
+   - Buyer: `purchaseNFT`
+   - Contributor: `contributeToRewardPool`
+
+> **Label‑only rule (important):** When the UI asks for a subdomain or identity, enter the **label only**.
+> - ✅ `helper`
+> - ❌ `helper.agent.agi.eth`
+
+## Happy path (full lifecycle)
+
+### Employer flow
+1. **Approve token spend** for the payout amount.
+2. **Create job** with:
+   - IPFS hash (job details)
+   - Payout
+   - Duration
+   - Details string
+3. **Wait** for an agent to apply.
+4. **Optional:** dispute if needed.
+5. **Receive job NFT** upon completion.
+
+### Agent flow
+1. **Check eligibility** (allowlist/Merkle/ENS) using label only.
+2. **Apply** to the job.
+3. **Deliver work off‑chain.**
+4. **Request completion** with updated IPFS hash.
+
+### Validator flow
+1. **Check eligibility** (allowlist/Merkle/ENS) using label only.
+2. **Approve or disapprove** the job.
+3. **Repeat** until approval/disapproval threshold is reached.
+
+### Moderator flow (only if disputed)
+1. **Confirm the job is disputed.**
+2. **Resolve** with:
+   - `"agent win"` → agent paid + job complete
+   - `"employer win"` → employer refunded + job closed
+
+## Job status overview (state machine)
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created: createJob
+    Created --> Assigned: applyForJob
+    Assigned --> CompletionRequested: requestJobCompletion
+
+    Assigned --> Completed: validateJob (approval threshold)
+    CompletionRequested --> Completed: validateJob (approval threshold)
+
+    Assigned --> Disputed: disapproveJob (disapproval threshold)
+    CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
+    Assigned --> Disputed: disputeJob (manual)
+    CompletionRequested --> Disputed: disputeJob (manual)
+
+    Disputed --> Completed: resolveDispute("agent win")
+    Disputed --> Completed: resolveDispute("employer win")
+    Disputed --> Assigned: resolveDispute(other)
+
+    Created --> Cancelled: cancelJob (employer)
+    Created --> Cancelled: delistJob (owner)
+```
+
+## If something fails
+
+Go straight to the [Common revert reasons](common-reverts.md) table for fixes and checklists.

--- a/docs/user-guide/merkle-proofs.md
+++ b/docs/user-guide/merkle-proofs.md
@@ -1,0 +1,70 @@
+# Merkle proofs (plain‑language guide)
+
+Merkle proofs let the contract confirm your wallet is on an allowlist **without** storing the full list on‑chain.
+
+## How authorization works (OR‑logic)
+
+You are authorized **if any** of the following are true:
+
+1. **Explicit allowlist** (`additionalAgents` / `additionalValidators`).
+2. **Merkle proof** membership (allowlist proof).
+3. **ENS NameWrapper ownership** of the subdomain label.
+4. **ENS resolver.addr** points to your wallet (fallback).
+
+> **Label‑only rule (important):** enter the **label only**, not the full ENS name.
+> - ✅ `helper`
+> - ❌ `helper.agent.agi.eth`
+
+## Where proofs come from
+
+- **Operator/owner supplied:** If you are a real user, request a proof from the operator running the allowlist.
+- **Local generation (for operators):** This repo includes a helper script:
+
+```bash
+node scripts/merkle/generate_merkle_proof.js --input /path/to/addresses.json --address 0xYourWallet
+```
+
+Output includes:
+- `root`: Merkle root for deployment
+- `proof`: the array you provide when applying/validating
+
+## Proof format (copy/paste)
+
+- Use a JSON array of 32‑byte hex strings:
+
+```json
+["0xabc...", "0xdef..."]
+```
+
+- If you are **not** using a Merkle allowlist, pass an empty array: `[]`.
+
+## Verify a proof against the on‑chain root
+
+### Option 1: Web UI (recommended)
+
+1. Open [`docs/ui/agijobmanager.html`](../ui/agijobmanager.html).
+2. Set the contract address and network.
+3. Use **Identity checks** and paste your proof.
+
+### Option 2: Truffle console (read‑only)
+
+```bash
+truffle console --network <network>
+```
+
+```javascript
+const instance = await AGIJobManager.at("0xYourContract");
+const agentRoot = await instance.agentMerkleRoot();
+const validatorRoot = await instance.validatorMerkleRoot();
+```
+
+Compare the root you were given with the on‑chain root for your role.
+
+## Troubleshooting
+
+- **Wrong wallet:** proofs are tied to a specific wallet address.
+- **Wrong chain:** Merkle roots are fixed per deployment.
+- **Malformed proof:** must be a JSON array of hex strings.
+- **Wrong label:** ENS checks require **label only**.
+
+If you’re still blocked, check [Common revert reasons](common-reverts.md).

--- a/docs/user-guide/roles.md
+++ b/docs/user-guide/roles.md
@@ -1,0 +1,154 @@
+# Roles guide (non-technical)
+
+This guide explains what each role can do, what you need before starting, and common mistakes.
+
+> **Reminder: use the label only** for ENS identity checks.
+> - ✅ `helper` (label)
+> - ❌ `helper.agent.agi.eth`
+> The contract derives the namehash from a fixed root node + label.
+
+## Employer
+
+### What you can do
+- Create a job with escrowed payout (`createJob`).
+- Cancel a job **before** an agent is assigned (`cancelJob`).
+- Dispute a job while it is in progress (`disputeJob`).
+- Receive the job NFT when the job completes (minted automatically).
+- List and sell the job NFT on the built‑in marketplace (`listNFT`, `delistNFT`).
+
+### What you need first
+- A wallet with enough **AGI token** balance for the job payout.
+- ERC‑20 **approval** for the contract to pull the payout from your wallet.
+- Correct **contract address** and **network**.
+
+### Common mistakes
+- Forgetting to approve the token transfer before creating a job.
+- Using the wrong network or outdated contract address.
+- Trying to cancel after an agent is assigned (not allowed).
+
+### Typical workflow
+1. Approve token spend.
+2. Create a job (IPFS hash, payout, duration).
+3. Wait for an agent to apply.
+4. If needed, dispute the job.
+5. Receive the job NFT on completion.
+
+---
+
+## Agent
+
+### What you can do
+- Apply for an open job (`applyForJob`).
+- Request job completion (`requestJobCompletion`).
+- Earn payout and reputation if the job completes.
+
+### What you need first
+- A wallet **eligible** as an agent via **any** of:
+  - Explicit allowlist (`additionalAgents`).
+  - Merkle proof (allowlist).
+  - ENS NameWrapper ownership.
+  - ENS resolver.addr fallback.
+- The **subdomain label only** (not the full ENS name).
+- Optional: a Merkle proof if you’re allowlisted.
+
+### Common mistakes
+- Entering the full ENS name instead of the label.
+- Using a proof from a different allowlist or chain.
+- Applying for a job that is already assigned.
+- Requesting completion after the job duration expired.
+
+### Typical workflow
+1. Confirm eligibility (allowlist/Merkle/ENS).
+2. Apply for an open job.
+3. Deliver work off‑chain.
+4. Request completion with the updated IPFS hash.
+
+---
+
+## Validator
+
+### What you can do
+- Validate a job (approve or disapprove) (`validateJob`, `disapproveJob`).
+- Earn payout share and reputation when jobs complete.
+
+### What you need first
+- A wallet **eligible** as a validator via **any** of:
+  - Explicit allowlist (`additionalValidators`).
+  - Merkle proof (allowlist).
+  - ENS NameWrapper ownership.
+  - ENS resolver.addr fallback.
+- The **subdomain label only** (not the full ENS name).
+- Optional: a Merkle proof if you’re allowlisted.
+
+### Common mistakes
+- Trying to validate the same job twice.
+- Entering the full ENS name instead of the label.
+- Attempting to validate a job before it has an assigned agent.
+
+### Typical workflow
+1. Confirm eligibility (allowlist/Merkle/ENS).
+2. Review job status and details.
+3. Approve or disapprove.
+
+---
+
+## Moderator
+
+### What you can do
+- Resolve disputes (`resolveDispute`).
+  - **Canonical resolution strings**:
+    - `"agent win"` → pays agent and completes job.
+    - `"employer win"` → refunds employer and closes job.
+  - Any **other** string ends the dispute but returns the job to its prior in‑progress state.
+
+### What you need first
+- A wallet that is listed as a moderator (`addModerator` by the owner).
+- Correct contract address and network.
+
+### Common mistakes
+- Using a non‑canonical resolution string when you intend a payout/refund.
+- Trying to resolve a dispute that is not actually marked as disputed.
+
+### Typical workflow
+1. Confirm the job is in dispute.
+2. Decide outcome off‑chain.
+3. Resolve with the correct canonical string.
+
+---
+
+## Owner
+
+### What you can do
+- Pause/unpause contract (`pause`, `unpause`).
+- Manage moderators and allowlists (`addModerator`, `addAdditionalAgent/Validator`).
+- Blacklist/un‑blacklist agents or validators.
+- Update parameters (limits, reward percentage, metadata fields).
+- Withdraw escrowed AGI tokens (`withdrawAGI`).
+- Delist jobs before assignment (`delistJob`).
+- Manage AGI Types for agent payout bonuses (`addAGIType`).
+
+### What you need first
+- The owner wallet configured at deployment.
+- Strong operational security (owner actions are highly privileged).
+
+### Common mistakes
+- Pausing during critical workflows and forgetting to unpause.
+- Misconfiguring payout limits or validator thresholds.
+- Using the wrong network when changing parameters.
+
+### Typical workflow
+1. Monitor operations.
+2. Adjust allowlists and parameters as needed.
+3. Resolve operational incidents (pause/unpause, blacklist).
+
+---
+
+## How roles interact (simple overview)
+
+- **Employer** creates and funds a job.
+- **Agent** applies, performs work, and requests completion.
+- **Validators** approve or disapprove the job outcome.
+- **Moderator** resolves disputes (if any).
+- **Owner** manages safety, parameters, and allowlists.
+
+For the full lifecycle, see the [Happy path walkthrough](happy-path.md).


### PR DESCRIPTION
### Motivation
- Provide clear, role-focused documentation so non-technical users (Employer / Agent / Validator / Moderator / Owner) can use the system without reading Solidity. 
- Surface the common “execution reverted” causes and fixes, Merkle proof guidance, and the important “subdomain label only” rule to reduce user friction and support load. 
- Reuse existing repo tools (UI and merkle scripts) rather than adding new tooling.

### Description
- Added a new user-focused docs section under `docs/user-guide/` with the files: `README.md`, `roles.md`, `happy-path.md`, `common-reverts.md`, `merkle-proofs.md`, and `glossary.md`. 
- Linked the new landing page from `docs/README.md` and the project `README.md` to improve discoverability. 
- Merkle guidance references the existing generator script at `scripts/merkle/generate_merkle_proof.js` and explains proof format, verification, and troubleshooting. 
- Emphasized the contract’s identity rule everywhere: enter the ENS *label only* (e.g., `helper`, not `helper.agent.agi.eth`) and explained why (the contract derives the namehash from a fixed root node + label).

### Testing
- Ran `npm ci` which failed with `EBADPLATFORM` due to `fsevents` being macOS-only on this Linux runner; this is an environment/optional dependency issue and does not block the docs change. 
- Ran `npm install --omit=optional` which succeeded and installed the project dependencies. 
- Ran `npx truffle compile` which succeeded and compiled contracts to `build/contracts`. 
- Ran `npx truffle test` which failed to connect to the local RPC: `CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545.`; reproduce by running `npx ganache -p 8545` (or a configured local Ethereum node) before `npx truffle test` to execute tests successfully.

Files added/changed
- Added: `docs/user-guide/README.md`, `docs/user-guide/roles.md`, `docs/user-guide/happy-path.md`, `docs/user-guide/common-reverts.md`, `docs/user-guide/merkle-proofs.md`, `docs/user-guide/glossary.md`. 
- Updated: `docs/README.md`, `README.md` (links to the new user guide).

Notes / next steps
- No contract source was modified (`contracts/AGIJobManager.sol` unchanged). 
- If CI runs `npm ci` on Linux runners, consider marking `fsevents` as optional or adjusting CI to use `npm install --omit=optional` to avoid the `EBADPLATFORM` failure.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf1d3eb24833399242f2df5c5d5ae)