### PR TITLE
Refine user guide: common revert cases and owner allowlist wording

### DIFF
--- a/docs/user-guide/common-reverts.md
+++ b/docs/user-guide/common-reverts.md
@@ -39,9 +39,12 @@ This guide maps what you tried to do → what you saw → how to fix it. All ite
 | Withdraw AGI (owner) | `InvalidParameters` | Amount is zero or exceeds contract balance. | Withdraw an amount within the contract’s AGI balance. | [Roles → Owner](roles.md#owner) |
 | Contribute to reward pool | `InvalidParameters` | Amount is zero. | Enter a positive amount. | [Happy path](happy-path.md) |
 | Add AGI type (owner) | `InvalidParameters` | Address is zero or payout percentage outside 1–100. | Provide a valid NFT address and percentage. | [Roles → Owner](roles.md#owner) |
+| Update validator reward percentage (owner) | `InvalidParameters` | Percentage is zero or above 100. | Use a percentage between 1 and 100. | [Roles → Owner](roles.md#owner) |
 | Any token transfer | `TransferFailed` | Token transfer or transferFrom returned false. | Ensure you have enough AGI balance and **approved** the contract for the needed amount. | [Happy path](happy-path.md) |
 | Any job action | `JobNotFound` | The job ID does not exist. | Double‑check the job ID. | [Happy path](happy-path.md) |
 | Any action while paused | `Pausable: paused` | The contract is paused. | Wait for the owner to unpause. | [Roles → Owner](roles.md#owner) |
+| Owner‑only action (pause, allowlist, blacklist, etc.) | `Ownable: caller is not the owner` | The action requires the contract owner. | Switch to the owner wallet or ask the owner to perform the action. | [Roles → Owner](roles.md#owner) |
+| List an NFT | `ERC721: invalid token ID` | The token does not exist (job not completed/minted yet). | Verify the job completed and the NFT was issued before listing. | [Roles → Employer](roles.md#employer) |
 
 ## If you still can’t proceed
 

--- a/docs/user-guide/roles.md
+++ b/docs/user-guide/roles.md
@@ -120,7 +120,7 @@ This guide explains what each role can do, what you need before starting, and co
 
 ### What you can do
 - Pause/unpause contract (`pause`, `unpause`).
-- Manage moderators and allowlists (`addModerator`, `addAdditionalAgent/Validator`).
+- Manage moderators and allowlists (`addModerator`, `addAdditionalAgent`, `addAdditionalValidator`).
 - Blacklist/un‑blacklist agents or validators.
 - Update parameters (limits, reward percentage, metadata fields).
 - Withdraw escrowed AGI tokens (`withdrawAGI`).


### PR DESCRIPTION
### Motivation
- Improve non-technical user experience by documenting additional common revert reasons and clarifying owner allowlist function names so users can troubleshoot without reading Solidity.

### Description
- Added new revert table rows in `docs/user-guide/common-reverts.md` for owner-only actions (`Ownable: caller is not the owner`), `ERC721: invalid token ID`, and `Update validator reward percentage (owner)` to explain causes and fixes.
- Clarified owner allowlist function names in `docs/user-guide/roles.md` by listing `addAdditionalAgent` and `addAdditionalValidator` explicitly.
- Only documentation files were changed and no contracts or runtime code were modified.

### Testing
- `npm ci` failed due to an OS-specific `fsevents` platform restriction on Linux; this is a platform dependency issue and not caused by the docs changes.
- `npm install` completed (audit warnings), and `npx truffle compile` succeeded with compiler warnings but produced artifacts.
- `npx truffle test` failed because it could not connect to a local node at `http://127.0.0.1:8545` (no Ganache instance running).
- Files changed: `docs/user-guide/common-reverts.md`, `docs/user-guide/roles.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf6eadbe08333a653b3f5e6bb3b59)