### PR TITLE
Refine user guide: clarify label-only ENS and troubleshooting for Merkle/proof/pauses

### DIFF
--- a/docs/user-guide/common-reverts.md
+++ b/docs/user-guide/common-reverts.md
@@ -41,7 +41,8 @@ This guide maps what you tried to do → what you saw → how to fix it. All ite
 | Add AGI type (owner) | `InvalidParameters` | Address is zero or payout percentage outside 1–100. | Provide a valid NFT address and percentage. | [Roles → Owner](roles.md#owner) |
 | Any token transfer | `TransferFailed` | Token transfer or transferFrom returned false. | Ensure you have enough AGI balance and **approved** the contract for the needed amount. | [Happy path](happy-path.md) |
 | Any job action | `JobNotFound` | The job ID does not exist. | Double‑check the job ID. | [Happy path](happy-path.md) |
-| Any action while paused | `Pausable: paused` | The contract is paused. | Wait for the owner to unpause. | [Roles → Owner](roles.md#owner) |
+| Set validation reward percentage (owner) | `InvalidParameters` | Percentage must be between 1 and 100. | Use a value from 1–100. | [Roles → Owner](roles.md#owner) |
+| Actions protected by pause | `Pausable: paused` | The contract is paused, so `whenNotPaused` actions are blocked. | Wait for the owner to unpause before retrying. | [Roles → Owner](roles.md#owner) |
 
 ## If you still can’t proceed
 

--- a/docs/user-guide/happy-path.md
+++ b/docs/user-guide/happy-path.md
@@ -16,6 +16,7 @@ This walkthrough shows a full job lifecycle for **Employer → Agent → Validat
 > **Label‑only rule (important):** When the UI asks for a subdomain or identity, enter the **label only**.
 > - ✅ `helper`
 > - ❌ `helper.agent.agi.eth`
+> The contract derives the ENS node from a **fixed root node + your label**, so full names won’t match.
 
 ## Happy path (full lifecycle)
 

--- a/docs/user-guide/merkle-proofs.md
+++ b/docs/user-guide/merkle-proofs.md
@@ -14,6 +14,8 @@ You are authorized **if any** of the following are true:
 > **Label‑only rule (important):** enter the **label only**, not the full ENS name.
 > - ✅ `helper`
 > - ❌ `helper.agent.agi.eth`
+>
+> Why: the contract combines a **fixed root node** with your label to derive the ENS node. Full names will not match that calculation.
 
 ## Where proofs come from
 


### PR DESCRIPTION
### Motivation
- Improve non-technical user documentation with small clarifications that reduce confusion around ENS label handling and common execution failures. 
- Surface a focused fix for two usability pain points: why subdomain label-only is required and a missing revert explanation for validation reward parameter boundaries.

### Description
- Clarified the label-only rule in the Happy Path (`docs/user-guide/happy-path.md`) with a short explanation that the contract derives the ENS node from a fixed root node + label. 
- Expanded the Merkle proofs guide (`docs/user-guide/merkle-proofs.md`) to explicitly explain why full ENS names do not match the contract calculation. 
- Added a `InvalidParameters` row for the `setValidationRewardPercentage` case and reworded the paused-action entry in the Common Reverts table (`docs/user-guide/common-reverts.md`). 
- Files changed: `docs/user-guide/happy-path.md`, `docs/user-guide/merkle-proofs.md`, `docs/user-guide/common-reverts.md`.

### Testing
- Ran `npm ci` which failed due to platform-specific dependency `fsevents` (unsupported on Linux), so `npm ci` could not complete. 
- Ran `npm install` which completed successfully and installed dependencies (audit warnings only). 
- Ran `npx truffle compile` which completed successfully and wrote artifacts to `build/contracts`. 
- Ran `npx truffle test` which failed to connect to a local node (`CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545`); to reproduce and fix, start a local Ganache/Hardhat node before running tests (e.g., `npx ganache -p 8545`), then `npx truffle test` should run the test suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf6eadbe08333a653b3f5e6bb3b59)