### PR TITLE
Add minimal Playwright UI smoke tests + local migration and smoke checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: UI smoke test
+        run: npm run test:ui

--- a/docs/ui/SMOKE_TEST.md
+++ b/docs/ui/SMOKE_TEST.md
@@ -1,0 +1,67 @@
+# AGIJobManager UI smoke checklist (local dev)
+
+This checklist validates the static UI against a local Ganache chain without MetaMask.
+It focuses on the core flows that should never silently break.
+
+## Prereqs
+
+```bash
+npm install
+```
+
+## 1) Start a local chain (Ganache)
+
+```bash
+npx ganache --server.host 127.0.0.1 --server.port 8545 \
+  --chain.chainId 1337 --chain.networkId 1337 \
+  --wallet.mnemonic "test test test test test test test test test test test junk"
+```
+
+## 2) Deploy contracts locally (Truffle)
+
+```bash
+npx truffle migrate --network development --reset
+```
+
+> Note: The local migration deploys `MockERC20` and mints tokens to the first two accounts so the UI can approve and create a job.
+
+## 3) Serve the UI locally
+
+From the repo root:
+
+```bash
+python3 -m http.server 8000 --directory docs
+```
+
+Open:
+
+```
+http://localhost:8000/ui/agijobmanager.html?contract=<DEPLOYED_ADDRESS>
+```
+
+You can get `<DEPLOYED_ADDRESS>` from `build/contracts/AGIJobManager.json` under the `networks.1337.address` key.
+
+## 4) Smoke steps
+
+### Connect + refresh
+1. Click **Connect Wallet**.
+2. Confirm the pill shows **Connected** and the wallet address is populated.
+3. Click **Refresh snapshot** and confirm `Owner` and `AGI Token` populate.
+4. Confirm the Activity Log shows **External ABI loaded**.
+
+### Approve payout + create job
+1. In **Approve AGI token**, enter `1` (token units) and click **Approve token**.
+2. In **Create job**, fill:
+   - IPFS hash: `QmTestHash`
+   - Payout: `1`
+   - Duration: `3600`
+   - Details: `UI smoke test`
+3. Click **Create job** and confirm success in the Activity Log.
+4. Click **Load jobs** and verify at least one row appears.
+
+## Common failures
+- **Wrong contract address** → Snapshot and jobs fail to load; update the query param.
+- **Wrong chainId** → UI warns about unsupported network; switch to Ganache (1337).
+- **No token balance** → Approve/Create fails; ensure the local migration minted tokens.
+- **ABI mismatch** → External ABI fetch fails or preflight errors; run `npm run ui:abi` after compiling.
+- **Indexer warnings** → Filters are disabled if event indexing is unavailable; still load jobs via the fallback path.

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,9 +1,26 @@
 const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
 
-module.exports = function (deployer) {
-  deployer.deploy(
+module.exports = async function (deployer, network, accounts) {
+  const localNetworks = new Set(["development", "test"]);
+  const isLocal = localNetworks.has(network);
+  let tokenAddress = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
+
+  if (isLocal) {
+    await deployer.deploy(MockERC20);
+    const token = await MockERC20.deployed();
+    const mintTo = (accounts && accounts.length ? accounts[0] : (await web3.eth.getAccounts())[0]);
+    const mintAmount = web3.utils.toWei("100000");
+    await token.mint(mintTo, mintAmount);
+    if (accounts && accounts[1]) {
+      await token.mint(accounts[1], mintAmount);
+    }
+    tokenAddress = token.address;
+  }
+
+  await deployer.deploy(
     AGIJobManager,
-    "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
+    tokenAddress,
     "https://ipfs.io/ipfs/",
     "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
     "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
@@ -13,4 +30,3 @@ module.exports = function (deployer) {
     "0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b"
   );
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
       },
       "devDependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",
+        "@playwright/test": "^1.49.0",
         "@truffle/hdwallet-provider": "^2.1.15",
         "dotenv": "^16.4.5",
         "ganache": "^7.9.2",
@@ -1907,6 +1908,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -14913,6 +14930,53 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "docs:interface": "node scripts/generate-interface-doc.js",
     "lint": "solhint \"contracts/**/*.sol\"",
     "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js",
-    "ui:abi": "node scripts/ui/export_abi.js"
+    "ui:abi": "node scripts/ui/export_abi.js",
+    "test:ui": "node scripts/ui/run-ui-tests.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5"
@@ -21,6 +22,7 @@
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.6.0",
     "solhint": "^5.0.3",
-    "truffle": "^5.11.5"
+    "truffle": "^5.11.5",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/scripts/ui/run-ui-tests.js
+++ b/scripts/ui/run-ui-tests.js
@@ -1,0 +1,156 @@
+const http = require('http');
+const path = require('path');
+const fs = require('fs');
+const { spawn } = require('child_process');
+const net = require('net');
+
+const repoRoot = path.resolve(__dirname, '..', '..');
+const docsRoot = path.join(repoRoot, 'docs');
+
+const rpcPort = 8545;
+const rpcHost = '127.0.0.1';
+const mnemonic = 'test test test test test test test test test test test junk';
+
+function waitForPort(port, host, timeoutMs = 15_000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const tryConnect = () => {
+      const socket = net.createConnection(port, host);
+      socket.on('connect', () => {
+        socket.end();
+        resolve();
+      });
+      socket.on('error', () => {
+        socket.destroy();
+        if (Date.now() - start > timeoutMs) {
+          reject(new Error(`Timed out waiting for ${host}:${port}`));
+          return;
+        }
+        setTimeout(tryConnect, 200);
+      });
+    };
+    tryConnect();
+  });
+}
+
+function runCommand(command, args, options = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { stdio: 'inherit', ...options });
+    child.on('error', reject);
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} exited with code ${code}`));
+    });
+  });
+}
+
+function startGanache() {
+  const args = [
+    'ganache',
+    '--server.host', rpcHost,
+    '--server.port', String(rpcPort),
+    '--chain.chainId', '1337',
+    '--chain.networkId', '1337',
+    '--wallet.mnemonic', mnemonic,
+    '--logging.quiet',
+  ];
+  const child = spawn('npx', args, { stdio: 'inherit' });
+  return child;
+}
+
+function startStaticServer(rootDir) {
+  const mimeTypes = {
+    '.html': 'text/html',
+    '.js': 'text/javascript',
+    '.css': 'text/css',
+    '.json': 'application/json',
+    '.svg': 'image/svg+xml',
+    '.png': 'image/png',
+    '.ico': 'image/x-icon',
+  };
+
+  const server = http.createServer((req, res) => {
+    const baseUrl = `http://${req.headers.host}`;
+    const parsed = new URL(req.url, baseUrl);
+    const pathname = decodeURIComponent(parsed.pathname);
+    let filePath = path.join(rootDir, pathname);
+    if (!filePath.startsWith(rootDir)) {
+      res.statusCode = 403;
+      res.end('Forbidden');
+      return;
+    }
+    if (pathname.endsWith('/')) {
+      filePath = path.join(rootDir, pathname, 'index.html');
+    }
+    fs.readFile(filePath, (err, data) => {
+      if (err) {
+        res.statusCode = 404;
+        res.end('Not found');
+        return;
+      }
+      const ext = path.extname(filePath);
+      res.setHeader('content-type', mimeTypes[ext] || 'application/octet-stream');
+      res.end(data);
+    });
+  });
+
+  return new Promise((resolve, reject) => {
+    server.on('error', reject);
+    server.listen(0, '127.0.0.1', () => {
+      const { port } = server.address();
+      resolve({ server, port });
+    });
+  });
+}
+
+function readDeployedAddress() {
+  const artifactPath = path.join(repoRoot, 'build', 'contracts', 'AGIJobManager.json');
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, 'utf8'));
+  const networks = artifact.networks || {};
+  const networkId = networks['1337'] ? '1337' : Object.keys(networks)[0];
+  if (!networkId || !networks[networkId] || !networks[networkId].address) {
+    throw new Error('Unable to find deployed AGIJobManager address in build/contracts/AGIJobManager.json');
+  }
+  return networks[networkId].address;
+}
+
+async function main() {
+  let ganache;
+  let server;
+  try {
+    ganache = startGanache();
+    await waitForPort(rpcPort, rpcHost);
+
+    await runCommand('npx', ['truffle', 'migrate', '--network', 'development', '--reset'], { cwd: repoRoot });
+
+    const contractAddress = readDeployedAddress();
+
+    const serverInfo = await startStaticServer(docsRoot);
+    server = serverInfo.server;
+    const baseUrl = `http://127.0.0.1:${serverInfo.port}/ui/agijobmanager.html`;
+
+    await runCommand('npx', ['playwright', 'install', '--with-deps', 'chromium'], { cwd: repoRoot });
+
+    await runCommand('npx', ['playwright', 'test', 'tests/ui/agijobmanager.spec.js'], {
+      cwd: repoRoot,
+      env: {
+        ...process.env,
+        UI_BASE_URL: baseUrl,
+        CONTRACT_ADDRESS: contractAddress,
+        CHAIN_RPC_URL: `http://${rpcHost}:${rpcPort}`,
+      },
+    });
+  } finally {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+    if (ganache) {
+      ganache.kill('SIGTERM');
+    }
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/tests/ui/agijobmanager.spec.js
+++ b/tests/ui/agijobmanager.spec.js
@@ -1,0 +1,97 @@
+const { test, expect } = require('@playwright/test');
+
+const baseUrl = process.env.UI_BASE_URL;
+const contractAddress = process.env.CONTRACT_ADDRESS;
+const rpcUrl = process.env.CHAIN_RPC_URL || 'http://127.0.0.1:8545';
+
+if (!baseUrl) {
+  throw new Error('UI_BASE_URL is required');
+}
+if (!contractAddress) {
+  throw new Error('CONTRACT_ADDRESS is required');
+}
+
+async function rpcCall(method, params = []) {
+  const response = await fetch(rpcUrl, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ jsonrpc: '2.0', id: 1, method, params }),
+  });
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message || 'RPC error');
+  }
+  return payload.result;
+}
+
+test.describe('AGIJobManager UI smoke', () => {
+  test.setTimeout(120_000);
+
+  test('connects, refreshes, and creates a job', async ({ page }) => {
+    const jsErrors = [];
+    page.on('pageerror', (err) => jsErrors.push(err));
+    page.on('console', (msg) => {
+      if (msg.type() === 'error') {
+        jsErrors.push(new Error(msg.text()));
+      }
+    });
+
+    await page.addInitScript(({ rpcUrl }) => {
+      const callRpc = async (method, params) => {
+        const response = await fetch(rpcUrl, {
+          method: 'POST',
+          headers: { 'content-type': 'application/json' },
+          body: JSON.stringify({ jsonrpc: '2.0', id: Date.now(), method, params }),
+        });
+        const payload = await response.json();
+        if (payload.error) {
+          throw new Error(payload.error.message || 'RPC error');
+        }
+        return payload.result;
+      };
+
+      window.ethereum = {
+        isMetaMask: false,
+        request: async ({ method, params }) => {
+          if (method === 'eth_requestAccounts') {
+            return callRpc('eth_accounts', []);
+          }
+          return callRpc(method, params || []);
+        },
+        on: () => {},
+        removeListener: () => {},
+      };
+    }, { rpcUrl });
+
+    const [owner] = await rpcCall('eth_accounts');
+
+    await page.goto(`${baseUrl}?contract=${contractAddress}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.locator('#activityLog')).toContainText('External ABI loaded', { timeout: 10_000 });
+
+    await page.getByRole('button', { name: 'Connect Wallet' }).click();
+    await expect(page.locator('#networkPill')).toContainText('Connected', { timeout: 10_000 });
+    await expect(page.locator('#walletAddress')).toContainText(owner);
+
+    await page.getByRole('button', { name: 'Refresh snapshot' }).click();
+    await expect(page.locator('#contractOwner')).toContainText(owner);
+    await expect(page.locator('#agiToken')).toContainText('0x');
+
+    await page.fill('#approveAmount', '1');
+    await page.getByRole('button', { name: 'Approve token' }).click();
+    await expect(page.locator('#activityLog')).toContainText('Employer approve confirmed', { timeout: 15_000 });
+
+    await page.fill('#jobIpfs', 'QmTestHash');
+    await page.fill('#jobPayout', '1');
+    await page.fill('#jobDuration', '3600');
+    await page.fill('#jobDetails', 'UI smoke test');
+    await page.getByRole('button', { name: 'Create job' }).click();
+    await expect(page.locator('#activityLog')).toContainText('Create job confirmed', { timeout: 15_000 });
+
+    await page.getByRole('button', { name: 'Load jobs' }).click();
+    await expect(page.locator('#jobsTable tr')).toHaveCount(1, { timeout: 10_000 });
+
+    if (jsErrors.length) {
+      throw new Error(`UI logged ${jsErrors.length} error(s): ${jsErrors.map((err) => err.message).join('; ')}`);
+    }
+  });
+});


### PR DESCRIPTION
### Motivation

- Prevent silent regressions in the static GitHub Pages UI (`docs/ui/agijobmanager.html`) by adding a small, deterministic smoke test that exercises connect/refresh and a minimal write path. 
- Keep changes minimal and offline-capable by running a local Ganache chain and using an injected EIP-1193 provider stub (no MetaMask nor external secrets). 
- Provide a short manual checklist so maintainers can reproduce and triage fails quickly.

### Description

- Added a manual checklist `docs/ui/SMOKE_TEST.md` describing how to run Ganache, deploy contracts, serve the UI, and perform the minimal smoke flows. 
- Modified `migrations/2_deploy_contracts.js` so local networks (`development`, `test`) deploy `MockERC20` and mint tokens to the first accounts, enabling UI approve/create flows locally while leaving mainnet/sepolia behavior unchanged. 
- Added a Playwright smoke spec `tests/ui/agijobmanager.spec.js` that injects a lightweight `window.ethereum` EIP-1193 shim that proxies JSON-RPC to a local Ganache (`http://127.0.0.1:8545`) and special-cases `eth_requestAccounts`. 
- Added an orchestrator `scripts/ui/run-ui-tests.js` which starts Ganache, runs `truffle migrate --network development --reset`, serves `docs/` over HTTP, installs Playwright Chromium, and runs the spec; it exports `UI_BASE_URL`, `CONTRACT_ADDRESS`, and `CHAIN_RPC_URL` for the spec. 
- Added `test:ui` npm script to run the orchestrator and added `@playwright/test` to `devDependencies`. 
- Wired the UI smoke step into CI: `.github/workflows/ci.yml` now installs Playwright browsers and runs `npm run test:ui` after the existing test step. 
- All changes avoid modifying `contracts/AGIJobManager.sol` and introduce no mainnet/sepolia keys or external RPC secrets.

### Testing

- Ran the existing test suite via `npm test`; contract and JS tests passed (existing suites compiled and ran; build artifacts written; 92 passing tests observed). 
- Ran the new UI orchestrator `npm run test:ui` in this environment: the script successfully started Ganache and ran `truffle migrate` (deployed `MockERC20` and `AGIJobManager`) but Playwright browser installation failed in this sandbox due to environment package fetch errors when running `playwright install --with-deps` (APT fetch error for `libsensors-config` / missing system libs). 
- Notes and remediation: the UI harness and spec are deterministic and offline for RPC/chain (they use local Ganache and local migrations); Playwright browser installation requires network access and certain OS packages which are available on standard CI runners (the workflow includes `npx playwright install --with-deps chromium` and should succeed on `ubuntu-latest`); to reproduce locally run `npx playwright install --with-deps chromium` (or run CI) before `npm run test:ui` if your environment lacks the required browser/system packages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf9b9df70833391464ab040461068)