### PR TITLE
Add Playwright UI smoke tests, local Ganache harness, and manual smoke checklist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium
+
+      - name: UI smoke test
+        run: npm run test:ui

--- a/docs/ui/SMOKE_TEST.md
+++ b/docs/ui/SMOKE_TEST.md
@@ -1,0 +1,77 @@
+# AGIJobManager UI Smoke Test Checklist (Local Chain)
+
+This checklist is for the static UI at `docs/ui/agijobmanager.html`. It assumes a local Ganache chain and the repo’s Truffle migrations.
+
+## 1) Start Ganache locally
+
+```bash
+npx ganache -p 8545 --wallet.mnemonic "test test test test test test test test test test test junk"
+```
+
+> Tip: the mnemonic matches the repo’s default `GANACHE_MNEMONIC` fallback in `truffle-config.js`.
+
+## 2) Deploy contracts locally
+
+```bash
+npx truffle migrate --network development --reset
+```
+
+Notes:
+- The local migration deploys mock ENS/NameWrapper plus a mock ERC‑20 token and mints it to account[0].
+- The deployed AGIJobManager address is written to `build/contracts/AGIJobManager.json`.
+
+## 3) Serve the UI locally
+
+From the repo root:
+
+```bash
+python3 -m http.server 8000 --directory docs
+```
+
+## 4) Open the UI with the local contract
+
+Extract the deployed address:
+
+```bash
+node -e "const a=require('./build/contracts/AGIJobManager.json');const id=Object.keys(a.networks)[0];console.log(a.networks[id].address)"
+```
+
+Open:
+
+```
+http://localhost:8000/ui/agijobmanager.html?contract=0xYourContract
+```
+
+## 5) Manual smoke checklist
+
+**Connect + refresh**
+1. Click **Connect Wallet**.
+2. Confirm the network pill shows “Connected”.
+3. Click **Refresh snapshot**.
+4. Verify the snapshot fields populate (Owner, Token address, Next Job ID, etc.).
+
+**Approve payout + create job**
+1. In **Approve AGI token**, set a small amount (e.g., `10`) and click **Approve token**.
+2. In **Create job**, fill:
+   - IPFS hash: `QmUiSmokeTest`
+   - Payout: `1`
+   - Duration: `60`
+   - Details: `UI smoke test job`
+3. Click **Create job**.
+4. Confirm the activity log shows “Create job confirmed”.
+5. Confirm **Next Job ID** increments to `1`.
+
+**Load jobs**
+1. Click **Sync events** (if available) to build the local index.
+2. Use **Refresh** to verify the jobs table renders at least one job row.
+
+## Common failures + fixes
+
+- **Wrong contract address**: snapshot fields stay “—”.
+  - Fix: re-open with the correct `?contract=0x...`.
+- **Wrong chainId**: network pill shows unsupported.
+  - Fix: ensure Ganache is running on `1337` and the wallet is connected to it.
+- **No token balance / approval**: create job reverts with TransferFailed.
+  - Fix: ensure the local migration minted tokens to the connected account and approve the payout again.
+- **ABI mismatch / external ABI not loading**:
+  - Fix: run `npm run ui:abi` after `truffle compile`, then reload.

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -810,9 +810,11 @@
   </main>
 
   <script src="https://cdn.jsdelivr.net/npm/ethers@6.13.4/dist/ethers.umd.min.js" integrity="sha384-7x3tVmE2MSjFk3rjql7YVSE2LEAFloT+1B5Nj0b3V5/hWRUsStlHHY2mySsRkmmF" crossorigin="anonymous"></script>
+  <script src="./lib/indexer.js"></script>
   <script src="./lib/errorDecoder.js"></script>
   <script>
     const { ethers } = window;
+    const { sortLogs } = window.AGIJMIndexer;
 
     const state = {
       provider: null,
@@ -1283,7 +1285,7 @@
       if (!trimmed) {
         throw new Error(`${fieldLabel} is required.`);
       }
-      if (!/^\\d+$/.test(trimmed)) {
+      if (!/^\d+$/.test(trimmed)) {
         throw new Error(`${fieldLabel} must be an integer.`);
       }
       return BigInt(trimmed);
@@ -2267,14 +2269,6 @@
         }
       }
       return logs;
-    }
-
-    function sortLogs(logs) {
-      return logs.sort((a, b) => {
-        if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
-        if (a.transactionIndex !== b.transactionIndex) return a.transactionIndex - b.transactionIndex;
-        return a.logIndex - b.logIndex;
-      });
     }
 
     function ensureJobEntry(jobId) {

--- a/docs/ui/lib/indexer.js
+++ b/docs/ui/lib/indexer.js
@@ -1,0 +1,17 @@
+(() => {
+  const sortLogs = (logs) => logs.sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
+    if (a.transactionIndex !== b.transactionIndex) return a.transactionIndex - b.transactionIndex;
+    return a.logIndex - b.logIndex;
+  });
+
+  const api = { sortLogs };
+
+  if (typeof window !== "undefined") {
+    window.AGIJMIndexer = api;
+  }
+
+  if (typeof module !== "undefined" && module.exports) {
+    module.exports = api;
+  }
+})();

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,7 +1,34 @@
 const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
 
-module.exports = function (deployer) {
-  deployer.deploy(
+module.exports = async function (deployer, network, accounts) {
+  const isLocal = ["development", "test", "ui", "playwright"].includes(network);
+  if (isLocal) {
+    const zeroRoot = `0x${"0".repeat(64)}`;
+    await deployer.deploy(MockERC20);
+    const token = await MockERC20.deployed();
+    await token.mint(accounts[0], web3.utils.toWei("100000"));
+    await deployer.deploy(MockENS);
+    const ens = await MockENS.deployed();
+    await deployer.deploy(MockNameWrapper);
+    const nameWrapper = await MockNameWrapper.deployed();
+    await deployer.deploy(
+      AGIJobManager,
+      token.address,
+      "https://ipfs.io/ipfs/",
+      ens.address,
+      nameWrapper.address,
+      zeroRoot,
+      zeroRoot,
+      zeroRoot,
+      zeroRoot
+    );
+    return;
+  }
+
+  await deployer.deploy(
     AGIJobManager,
     "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
     "https://ipfs.io/ipfs/",
@@ -13,4 +40,3 @@ module.exports = function (deployer) {
     "0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b"
   );
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,23 @@
       },
       "devDependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",
+        "@playwright/test": "^1.49.0",
         "@truffle/hdwallet-provider": "^2.1.15",
         "dotenv": "^16.4.5",
+        "ethers": "^6.13.4",
         "ganache": "^7.9.2",
         "keccak256": "^1.0.6",
         "merkletreejs": "^0.6.0",
         "solhint": "^5.0.3",
         "truffle": "^5.11.5"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@apollo/protobufjs": {
       "version": "1.2.7",
@@ -606,6 +615,55 @@
         "eth-ens-namehash": "^2.0.8",
         "ethers": "^5.0.13",
         "js-sha3": "^0.8.0"
+      }
+    },
+    "node_modules/@ensdomains/ensjs/node_modules/ethers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.8.0",
+        "@ethersproject/abstract-provider": "5.8.0",
+        "@ethersproject/abstract-signer": "5.8.0",
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/base64": "5.8.0",
+        "@ethersproject/basex": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/contracts": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hdnode": "5.8.0",
+        "@ethersproject/json-wallets": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/networks": "5.8.0",
+        "@ethersproject/pbkdf2": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/random": "5.8.0",
+        "@ethersproject/rlp": "5.8.0",
+        "@ethersproject/sha2": "5.8.0",
+        "@ethersproject/signing-key": "5.8.0",
+        "@ethersproject/solidity": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@ethersproject/transactions": "5.8.0",
+        "@ethersproject/units": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@ethersproject/web": "5.8.0",
+        "@ethersproject/wordlists": "5.8.0"
       }
     },
     "node_modules/@ensdomains/resolver": {
@@ -1715,6 +1773,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
@@ -1907,6 +1991,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -6867,14 +6967,14 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
-      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
       "dev": true,
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -6883,36 +6983,82 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/abi": "5.8.0",
-        "@ethersproject/abstract-provider": "5.8.0",
-        "@ethersproject/abstract-signer": "5.8.0",
-        "@ethersproject/address": "5.8.0",
-        "@ethersproject/base64": "5.8.0",
-        "@ethersproject/basex": "5.8.0",
-        "@ethersproject/bignumber": "5.8.0",
-        "@ethersproject/bytes": "5.8.0",
-        "@ethersproject/constants": "5.8.0",
-        "@ethersproject/contracts": "5.8.0",
-        "@ethersproject/hash": "5.8.0",
-        "@ethersproject/hdnode": "5.8.0",
-        "@ethersproject/json-wallets": "5.8.0",
-        "@ethersproject/keccak256": "5.8.0",
-        "@ethersproject/logger": "5.8.0",
-        "@ethersproject/networks": "5.8.0",
-        "@ethersproject/pbkdf2": "5.8.0",
-        "@ethersproject/properties": "5.8.0",
-        "@ethersproject/providers": "5.8.0",
-        "@ethersproject/random": "5.8.0",
-        "@ethersproject/rlp": "5.8.0",
-        "@ethersproject/sha2": "5.8.0",
-        "@ethersproject/signing-key": "5.8.0",
-        "@ethersproject/solidity": "5.8.0",
-        "@ethersproject/strings": "5.8.0",
-        "@ethersproject/transactions": "5.8.0",
-        "@ethersproject/units": "5.8.0",
-        "@ethersproject/wallet": "5.8.0",
-        "@ethersproject/web": "5.8.0",
-        "@ethersproject/wordlists": "5.8.0"
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ethjs-abi": {
@@ -14913,6 +15059,53 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,18 @@
     "docs:interface": "node scripts/generate-interface-doc.js",
     "lint": "solhint \"contracts/**/*.sol\"",
     "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js",
+    "test:ui": "node scripts/ui/run_ui_smoke_test.js",
     "ui:abi": "node scripts/ui/export_abi.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.0",
     "@openzeppelin/test-helpers": "^0.5.16",
     "@truffle/hdwallet-provider": "^2.1.15",
     "dotenv": "^16.4.5",
+    "ethers": "^6.13.4",
     "ganache": "^7.9.2",
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.6.0",

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -1,0 +1,13 @@
+const { defineConfig } = require("@playwright/test");
+
+module.exports = defineConfig({
+  testDir: "ui-tests",
+  testMatch: "**/*.spec.js",
+  timeout: 60_000,
+  expect: { timeout: 20_000 },
+  use: {
+    headless: true,
+    baseURL: process.env.UI_BASE_URL || "http://127.0.0.1:4173",
+  },
+  reporter: [["list"]],
+});

--- a/scripts/ui/run_ui_smoke_test.js
+++ b/scripts/ui/run_ui_smoke_test.js
@@ -1,0 +1,170 @@
+const path = require("node:path");
+const fs = require("node:fs");
+const http = require("node:http");
+const { spawn } = require("node:child_process");
+const ganache = require("ganache");
+
+const RPC_PORT = 8545;
+const UI_PORT = 4173;
+const MNEMONIC = "test test test test test test test test test test test junk";
+
+const projectRoot = path.resolve(__dirname, "..", "..");
+const docsRoot = path.join(projectRoot, "docs");
+const ethersBundlePath = path.join(projectRoot, "node_modules", "ethers", "dist", "ethers.umd.min.js");
+
+const contentTypes = {
+  ".html": "text/html",
+  ".js": "application/javascript",
+  ".css": "text/css",
+  ".json": "application/json",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+};
+
+const runCommand = (command, args, options = {}) =>
+  new Promise((resolve, reject) => {
+    const child = spawn(command, args, {
+      stdio: "inherit",
+      shell: process.platform === "win32",
+      ...options,
+    });
+    child.on("exit", (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`${command} ${args.join(" ")} exited with code ${code}`));
+    });
+  });
+
+const rpcRequest = async (method, params = []) => {
+  const response = await fetch(`http://127.0.0.1:${RPC_PORT}`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+  });
+  const payload = await response.json();
+  if (payload.error) {
+    throw new Error(payload.error.message || "RPC error");
+  }
+  return payload.result;
+};
+
+const startUiServer = () =>
+  new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const urlPath = decodeURIComponent((req.url || "/").split("?")[0]);
+
+      if (urlPath === "/rpc") {
+        if (req.method === "OPTIONS") {
+          res.writeHead(204, {
+            "Access-Control-Allow-Origin": "*",
+            "Access-Control-Allow-Methods": "POST, OPTIONS",
+            "Access-Control-Allow-Headers": "Content-Type",
+          });
+          res.end();
+          return;
+        }
+
+        let body = "";
+        req.on("data", (chunk) => {
+          body += chunk;
+        });
+        req.on("end", async () => {
+          try {
+            const rpcResponse = await fetch(`http://127.0.0.1:${RPC_PORT}`, {
+              method: "POST",
+              headers: { "Content-Type": "application/json" },
+              body,
+            });
+            const payload = await rpcResponse.text();
+            res.writeHead(200, {
+              "Content-Type": "application/json",
+              "Access-Control-Allow-Origin": "*",
+            });
+            res.end(payload);
+          } catch (error) {
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            res.end(error.message);
+          }
+        });
+        return;
+      }
+
+      if (urlPath === "/ui/ethers.umd.min.js") {
+        fs.readFile(ethersBundlePath, (err, data) => {
+          if (err) {
+            res.writeHead(500, { "Content-Type": "text/plain" });
+            res.end("Failed to load ethers bundle");
+            return;
+          }
+          res.writeHead(200, { "Content-Type": "application/javascript" });
+          res.end(data);
+        });
+        return;
+      }
+
+      const safePath = path.normalize(urlPath).replace(/^(\.\.[/\\])+/, "");
+      const filePath = path.join(docsRoot, safePath);
+      const resolvedPath = fs.statSync(filePath, { throwIfNoEntry: false })?.isDirectory()
+        ? path.join(filePath, "index.html")
+        : filePath;
+
+      fs.readFile(resolvedPath, (err, data) => {
+        if (err) {
+          res.writeHead(404, { "Content-Type": "text/plain" });
+          res.end("Not found");
+          return;
+        }
+        const ext = path.extname(resolvedPath);
+        res.writeHead(200, { "Content-Type": contentTypes[ext] || "application/octet-stream" });
+        res.end(data);
+      });
+    });
+
+    server.listen(UI_PORT, "127.0.0.1", () => resolve(server));
+  });
+
+const main = async () => {
+  const ganacheServer = ganache.server({
+    wallet: { mnemonic: MNEMONIC, totalAccounts: 10, defaultBalance: 1000 },
+    logging: { quiet: true },
+    chain: { chainId: 1337, networkId: 1337, hardfork: "london" },
+    miner: { blockGasLimit: 100_000_000 },
+  });
+
+  await ganacheServer.listen(RPC_PORT);
+
+  let uiServer;
+  try {
+    await runCommand("node", ["--test", path.join("ui-tests", "indexer.unit.test.js")], { cwd: projectRoot });
+    await runCommand("npx", ["truffle", "migrate", "--network", "development", "--reset"], { cwd: projectRoot });
+
+    const networkId = await rpcRequest("net_version");
+    const artifactPath = path.join(projectRoot, "build", "contracts", "AGIJobManager.json");
+    const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+    const deployed = artifact.networks[networkId];
+    if (!deployed || !deployed.address) {
+      throw new Error(`No AGIJobManager deployment found for network ${networkId}.`);
+    }
+
+    uiServer = await startUiServer();
+
+    await runCommand("npx", ["playwright", "test", "--config=playwright.config.js"], {
+      cwd: projectRoot,
+      env: {
+        ...process.env,
+        UI_BASE_URL: `http://127.0.0.1:${UI_PORT}`,
+        UI_RPC_URL: `http://127.0.0.1:${UI_PORT}/rpc`,
+        UI_CONTRACT_ADDRESS: deployed.address,
+      },
+    });
+  } finally {
+    if (uiServer) {
+      await new Promise((resolve) => uiServer.close(resolve));
+    }
+    await ganacheServer.close();
+  }
+};
+
+main().catch((error) => {
+  console.error(error);
+  process.exitCode = 1;
+});

--- a/ui-tests/indexer.unit.test.js
+++ b/ui-tests/indexer.unit.test.js
@@ -1,0 +1,20 @@
+const test = require("node:test");
+const assert = require("node:assert/strict");
+
+const { sortLogs } = require("../docs/ui/lib/indexer");
+
+test("sortLogs orders by blockNumber, transactionIndex, then logIndex", () => {
+  const logs = [
+    { blockNumber: 10, transactionIndex: 2, logIndex: 5, id: "late" },
+    { blockNumber: 9, transactionIndex: 3, logIndex: 1, id: "block-9" },
+    { blockNumber: 10, transactionIndex: 1, logIndex: 9, id: "tx-1" },
+    { blockNumber: 10, transactionIndex: 1, logIndex: 2, id: "tx-1-log-2" },
+  ];
+
+  const ordered = sortLogs(logs);
+
+  assert.deepStrictEqual(
+    ordered.map((log) => log.id),
+    ["block-9", "tx-1-log-2", "tx-1", "late"]
+  );
+});

--- a/ui-tests/ui.smoke.spec.js
+++ b/ui-tests/ui.smoke.spec.js
@@ -1,0 +1,102 @@
+const { test, expect } = require("@playwright/test");
+const fs = require("node:fs");
+const path = require("node:path");
+
+const baseUrl = process.env.UI_BASE_URL || "http://127.0.0.1:4173";
+const rpcUrl = process.env.UI_RPC_URL || "http://127.0.0.1:8545";
+const contractAddress = process.env.UI_CONTRACT_ADDRESS;
+
+test("connects, refreshes, and creates a job on local chain", async ({ page }) => {
+  if (!contractAddress) {
+    throw new Error("UI_CONTRACT_ADDRESS must be set for UI smoke tests.");
+  }
+
+  const uiHtml = fs.readFileSync(path.join(process.cwd(), "docs", "ui", "agijobmanager.html"), "utf8");
+  const patchedHtml = uiHtml.replace(
+    /<script src="https:\/\/cdn\.jsdelivr\.net\/npm\/ethers@6\.13\.4\/dist\/ethers\.umd\.min\.js"[^>]*><\/script>/,
+    '<script src="/ui/ethers.umd.min.js"></script>'
+  );
+
+  await page.route("**/ui/agijobmanager.html*", (route) =>
+    route.fulfill({ status: 200, body: patchedHtml, contentType: "text/html" })
+  );
+
+  page.on("dialog", (dialog) => {
+    dialog.dismiss();
+  });
+
+  await page.addInitScript(
+    ({ rpcUrl }) => {
+      const listeners = {};
+      const request = async ({ method, params = [] }) => {
+        if (method === "eth_requestAccounts") {
+          const accounts = await request({ method: "eth_accounts" });
+          return accounts;
+        }
+        if ((method === "eth_call" || method === "eth_estimateGas") && params[0] && !params[0].from) {
+          const accounts = await request({ method: "eth_accounts" });
+          if (accounts && accounts.length) {
+            params[0] = { ...params[0], from: accounts[0] };
+          }
+        }
+        const response = await fetch(rpcUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+        });
+        const payload = await response.json();
+        if (payload.error) {
+          console.error("RPC error", method, payload.error);
+          throw new Error(payload.error.message || "RPC error");
+        }
+        return payload.result;
+      };
+
+      window.ethereum = {
+        request,
+        on: (event, handler) => {
+          listeners[event] = handler;
+        },
+        removeListener: (event) => {
+          delete listeners[event];
+        },
+      };
+    },
+    { rpcUrl }
+  );
+
+  await page.goto(`${baseUrl}/ui/agijobmanager.html?contract=${contractAddress}`, { waitUntil: "networkidle" });
+
+  const activityLog = page.locator("#activityLog");
+  await expect(activityLog).toContainText("External ABI loaded.");
+  await expect(page.locator("#contractAddress")).toHaveValue(contractAddress);
+
+  const accounts = await page.evaluate(() => window.ethereum.request({ method: "eth_accounts" }));
+  await expect(accounts.length).toBeGreaterThan(0);
+
+  await page.click("#connectButton");
+  await expect(page.locator("#networkPill")).toContainText("Connected");
+  await expect(page.locator("#walletAddress")).not.toHaveText("Not connected");
+
+  await page.click("#refreshSnapshot");
+  await expect(page.locator("#contractName")).toHaveText("AGIJobs");
+  await expect(page.locator("#contractSymbol")).toHaveText("Job");
+  await expect(page.locator("#contractOwner")).not.toHaveText("—");
+  await expect(page.locator("#agiToken")).not.toHaveText("—");
+  await expect(page.locator("#agiTokenSymbol")).not.toHaveText("—");
+
+  await page.fill("#approveAmount", "10");
+  await page.click("#approveToken");
+  await expect(activityLog).toContainText("✅ Employer approve confirmed");
+
+  await page.fill("#jobIpfs", "QmUiSmokeTest");
+  await page.fill("#jobPayout", "1");
+  await page.fill("#jobDuration", "60");
+  await page.fill("#jobDetails", "UI smoke test job");
+  await expect(page.locator("#jobIpfs")).toHaveValue("QmUiSmokeTest");
+  await expect(page.locator("#jobPayout")).toHaveValue("1");
+  await expect(page.locator("#jobDuration")).toHaveValue("60");
+  await page.click("#createJob");
+  await expect(activityLog).toContainText("✅ Create job confirmed");
+  await expect(page.locator("#contractNextJob")).toHaveText("1");
+});


### PR DESCRIPTION
### Motivation

- Prevent silent regressions in the static GitHub Pages UI (docs/ui/agijobmanager.html) by adding minimal, deterministic regression coverage for core flows (connect, refresh, approve, create job, and ABI/indexer sanity).
- Keep changes minimal and offline-friendly by using a local Ganache instance, mock dependencies in local migrations, and an injected EIP-1193 provider stub (no MetaMask or external keys required).

### Description

- Add an orchestrator script `scripts/ui/run_ui_smoke_test.js` that boots a local Ganache, runs Truffle migrations (local mocks + token minting), serves `docs/` over HTTP and launches Playwright to run the smoke spec against the static UI via a proxied RPC endpoint.
- Add Playwright smoke spec `ui-tests/ui.smoke.spec.js` that injects a lightweight EIP-1193 `window.ethereum` provider which proxies JSON-RPC to the local chain, verifies connect/refresh flows, approves tokens, and exercises `createJob` (asserts activity log and nextJob counter).
- Extract the UI log sorting helper into `docs/ui/lib/indexer.js` and add a small unit test `ui-tests/indexer.unit.test.js` that validates deterministic ordering of logs (blockNumber, transactionIndex, logIndex), plus small UI parsing fix (`parseUint` regex) to make the UI deterministic for tests.
- Wire up scripts and CI: add `npm run test:ui`, add dev deps (`@playwright/test`, `ethers`) and a Playwright config, and extend `.github/workflows/ci.yml` to install Playwright Chromium and run `npm run test:ui`; add manual checklist `docs/ui/SMOKE_TEST.md` describing how to reproduce locally.

### Testing

- Ran the repository test suite: `npm test` completed successfully and existing tests passed (test output showed 92 passing).
- Ran the new unit test: `node --test ui-tests/indexer.unit.test.js` (or via orchestrator) and it passed (sortLogs unit test OK).
- Ran the full UI smoke flow locally via `npm run test:ui` which: started Ganache, executed `truffle migrate --network development --reset` (deploying mocks and the local AGIJobManager), served the UI, and ran Playwright; the Playwright spec passed (1 passed) and validated connect/refresh/approve/create flow.
- CI notes: added `npx playwright install --with-deps chromium` and a `UI smoke test` step in the existing CI job to run `npm run test:ui` in CI; Playwright browser install is included to avoid manual browser downloads in CI.

If anything fails in CI due to missing system libraries for Chromium, the workflow installs the Playwright browser with `--with-deps` to reduce such issues; further CI tuning (container images) can be done if the runner environment is restrictive.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf9b9df70833391464ab040461068)