### PR TITLE
Add Playwright UI smoke coverage for local Ganache flows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,9 @@ jobs:
 
       - name: Test
         run: npm run test
+
+      - name: Install Playwright Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: UI smoke test
+        run: npm run test:ui

--- a/docs/ui/SMOKE_TEST.md
+++ b/docs/ui/SMOKE_TEST.md
@@ -1,0 +1,70 @@
+# UI smoke test checklist (local dev)
+
+This checklist validates the static UI against a local Ganache chain (no external RPCs, no wallet extensions).
+
+## Prereqs
+
+- Install dependencies:
+  ```bash
+  npm install
+  ```
+- Ensure Truffle artifacts are built:
+  ```bash
+  npm run build
+  ```
+
+## 1) Start Ganache locally
+
+Use the deterministic mnemonic so accounts are stable:
+
+```bash
+npx ganache --wallet.mnemonic "test test test test test test test test test test test junk" --chain.chainId 1337 --chain.networkId 1337 --port 8545
+```
+
+## 2) Deploy contracts locally
+
+The development migration deploys mock ERC-20 + ENS contracts for local UI testing.
+
+```bash
+npx truffle migrate --network development --reset
+```
+
+## 3) Serve the UI
+
+From the repo root:
+
+```bash
+python3 -m http.server 8000 -d docs
+```
+
+Open in the browser:
+
+```
+http://localhost:8000/ui/agijobmanager.html?contract=<AGIJobManager_ADDRESS>
+```
+
+You can find the deployed address in `build/contracts/AGIJobManager.json` under the `networks` entry for `1337`.
+
+## 4) Manual UI smoke checklist
+
+### Connect + refresh
+- Click **Connect Wallet** → status should show **Connected** and a wallet address.
+- Click **Refresh snapshot** → owner/token fields should populate.
+- Confirm the Activity Log includes **External ABI loaded.**
+
+### Employer flow (happy path)
+- **Approve AGI token**: enter a small amount (e.g., `1`) → click **Approve token**.
+- **Create job**: fill `IPFS hash`, `Payout`, `Duration`, optional `Details` → click **Create job**.
+- Click **Load jobs** → the new job should appear in the table.
+
+### Optional role checks
+- Switch accounts to verify the UI updates (connect → disconnect → reconnect).
+- Use **Clear** to reset the contract address.
+
+## Common failures & fixes
+
+- **Wrong contract address** → Confirm the `?contract=` query and `build/contracts/AGIJobManager.json` networks entry.
+- **Wrong chainId** → Ganache should report `1337`. The UI will warn if the chain differs.
+- **No token balance / approve fails** → The development migration mints mock AGI to account[0].
+- **ABI mismatch / UI says “Fallback ABI used.”** → Run `npm run ui:abi` and serve the UI over HTTP (not `file://`).
+- **Write actions disabled** → Ensure the contract address is deployed on the active chain and the UI shows “Connected”.

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -1193,7 +1193,7 @@
         return;
       }
       const value = ids("cancelJobId").value.trim();
-      button.disabled = !/^\\d+$/.test(value);
+      button.disabled = !/^\d+$/.test(value);
     }
 
     function updateAdminPanel() {
@@ -1283,7 +1283,7 @@
       if (!trimmed) {
         throw new Error(`${fieldLabel} is required.`);
       }
-      if (!/^\\d+$/.test(trimmed)) {
+      if (!/^\d+$/.test(trimmed)) {
         throw new Error(`${fieldLabel} must be an integer.`);
       }
       return BigInt(trimmed);

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,7 +1,47 @@
 const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
 
-module.exports = function (deployer) {
-  deployer.deploy(
+module.exports = async function (deployer, network, accounts) {
+  if (network === "development" || network === "test") {
+    await deployer.deploy(MockERC20);
+    await deployer.deploy(MockENS);
+    await deployer.deploy(MockResolver);
+    await deployer.deploy(MockNameWrapper);
+
+    const token = await MockERC20.deployed();
+    const ens = await MockENS.deployed();
+    const resolver = await MockResolver.deployed();
+    const nameWrapper = await MockNameWrapper.deployed();
+
+    const clubRootNode = web3.utils.soliditySha3({ type: "string", value: "club-root" });
+    const agentRootNode = web3.utils.soliditySha3({ type: "string", value: "agent-root" });
+    const validatorRoot = web3.utils.soliditySha3({ type: "string", value: "validator-root" });
+    const agentRoot = web3.utils.soliditySha3({ type: "string", value: "agent-merkle-root" });
+
+    await ens.setResolver(clubRootNode, resolver.address);
+    await ens.setResolver(agentRootNode, resolver.address);
+
+    await deployer.deploy(
+      AGIJobManager,
+      token.address,
+      "ipfs://local/",
+      ens.address,
+      nameWrapper.address,
+      clubRootNode,
+      agentRootNode,
+      validatorRoot,
+      agentRoot
+    );
+
+    const mintAmount = web3.utils.toWei("100000");
+    await token.mint(accounts[0], mintAmount);
+    return;
+  }
+
+  await deployer.deploy(
     AGIJobManager,
     "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA",
     "https://ipfs.io/ipfs/",
@@ -13,4 +53,3 @@ module.exports = function (deployer) {
     "0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b"
   );
 };
-

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,14 +12,23 @@
       },
       "devDependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",
+        "@playwright/test": "^1.49.1",
         "@truffle/hdwallet-provider": "^2.1.15",
         "dotenv": "^16.4.5",
+        "ethers": "^6.13.4",
         "ganache": "^7.9.2",
         "keccak256": "^1.0.6",
         "merkletreejs": "^0.6.0",
         "solhint": "^5.0.3",
         "truffle": "^5.11.5"
       }
+    },
+    "node_modules/@adraffy/ens-normalize": {
+      "version": "1.10.1",
+      "resolved": "https://registry.npmjs.org/@adraffy/ens-normalize/-/ens-normalize-1.10.1.tgz",
+      "integrity": "sha512-96Z2IP3mYmF1Xg2cDm8f1gWGf/HUVedQ3FMifV4kG/PQ4yEP51xDtRAEfhVNt5f/uzpNkZHwWQuUcu6D6K+Ekw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@apollo/protobufjs": {
       "version": "1.2.7",
@@ -606,6 +615,55 @@
         "eth-ens-namehash": "^2.0.8",
         "ethers": "^5.0.13",
         "js-sha3": "^0.8.0"
+      }
+    },
+    "node_modules/@ensdomains/ensjs/node_modules/ethers": {
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
+      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+        },
+        {
+          "type": "individual",
+          "url": "https://www.buymeacoffee.com/ricmoo"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@ethersproject/abi": "5.8.0",
+        "@ethersproject/abstract-provider": "5.8.0",
+        "@ethersproject/abstract-signer": "5.8.0",
+        "@ethersproject/address": "5.8.0",
+        "@ethersproject/base64": "5.8.0",
+        "@ethersproject/basex": "5.8.0",
+        "@ethersproject/bignumber": "5.8.0",
+        "@ethersproject/bytes": "5.8.0",
+        "@ethersproject/constants": "5.8.0",
+        "@ethersproject/contracts": "5.8.0",
+        "@ethersproject/hash": "5.8.0",
+        "@ethersproject/hdnode": "5.8.0",
+        "@ethersproject/json-wallets": "5.8.0",
+        "@ethersproject/keccak256": "5.8.0",
+        "@ethersproject/logger": "5.8.0",
+        "@ethersproject/networks": "5.8.0",
+        "@ethersproject/pbkdf2": "5.8.0",
+        "@ethersproject/properties": "5.8.0",
+        "@ethersproject/providers": "5.8.0",
+        "@ethersproject/random": "5.8.0",
+        "@ethersproject/rlp": "5.8.0",
+        "@ethersproject/sha2": "5.8.0",
+        "@ethersproject/signing-key": "5.8.0",
+        "@ethersproject/solidity": "5.8.0",
+        "@ethersproject/strings": "5.8.0",
+        "@ethersproject/transactions": "5.8.0",
+        "@ethersproject/units": "5.8.0",
+        "@ethersproject/wallet": "5.8.0",
+        "@ethersproject/web": "5.8.0",
+        "@ethersproject/wordlists": "5.8.0"
       }
     },
     "node_modules/@ensdomains/resolver": {
@@ -1715,6 +1773,32 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/@noble/curves": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@noble/curves/-/curves-1.2.0.tgz",
+      "integrity": "sha512-oYclrNgRaM9SsBUBVbb8M6DTV7ZHRTKugureoYEncY5c65HOmRzvSiTE3y5CYaPYJA/GVkrhXEoF0M3Ya9PMnw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "1.3.2"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@noble/curves/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
     "node_modules/@noble/hashes": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.1.2.tgz",
@@ -1907,6 +1991,22 @@
       "license": "ISC",
       "bin": {
         "semver": "bin/semver"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.1.tgz",
+      "integrity": "sha512-6LdVIUERWxQMmUSSQi0I53GgCBYgM2RpGngCPY7hSeju+VrKjq3lvs7HpJoPbDiY5QM5EYRtRX5fvrinnMAz3w==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@pnpm/config.env-replace": {
@@ -6867,14 +6967,14 @@
       }
     },
     "node_modules/ethers": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/ethers/-/ethers-5.8.0.tgz",
-      "integrity": "sha512-DUq+7fHrCg1aPDFCHx6UIPb3nmt2XMpM7Y/g2gLhsl3lIBqeAfOJIl1qEvRf2uq3BiKxmh6Fh5pfp2ieyek7Kg==",
+      "version": "6.16.0",
+      "resolved": "https://registry.npmjs.org/ethers/-/ethers-6.16.0.tgz",
+      "integrity": "sha512-U1wulmetNymijEhpSEQ7Ct/P/Jw9/e7R1j5XIbPRydgV2DjLVMsULDlNksq3RQnFgKoLlZf88ijYtWEXcPa07A==",
       "dev": true,
       "funding": [
         {
           "type": "individual",
-          "url": "https://gitcoin.co/grants/13/ethersjs-complete-simple-and-tiny-2"
+          "url": "https://github.com/sponsors/ethers-io/"
         },
         {
           "type": "individual",
@@ -6883,36 +6983,82 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "@ethersproject/abi": "5.8.0",
-        "@ethersproject/abstract-provider": "5.8.0",
-        "@ethersproject/abstract-signer": "5.8.0",
-        "@ethersproject/address": "5.8.0",
-        "@ethersproject/base64": "5.8.0",
-        "@ethersproject/basex": "5.8.0",
-        "@ethersproject/bignumber": "5.8.0",
-        "@ethersproject/bytes": "5.8.0",
-        "@ethersproject/constants": "5.8.0",
-        "@ethersproject/contracts": "5.8.0",
-        "@ethersproject/hash": "5.8.0",
-        "@ethersproject/hdnode": "5.8.0",
-        "@ethersproject/json-wallets": "5.8.0",
-        "@ethersproject/keccak256": "5.8.0",
-        "@ethersproject/logger": "5.8.0",
-        "@ethersproject/networks": "5.8.0",
-        "@ethersproject/pbkdf2": "5.8.0",
-        "@ethersproject/properties": "5.8.0",
-        "@ethersproject/providers": "5.8.0",
-        "@ethersproject/random": "5.8.0",
-        "@ethersproject/rlp": "5.8.0",
-        "@ethersproject/sha2": "5.8.0",
-        "@ethersproject/signing-key": "5.8.0",
-        "@ethersproject/solidity": "5.8.0",
-        "@ethersproject/strings": "5.8.0",
-        "@ethersproject/transactions": "5.8.0",
-        "@ethersproject/units": "5.8.0",
-        "@ethersproject/wallet": "5.8.0",
-        "@ethersproject/web": "5.8.0",
-        "@ethersproject/wordlists": "5.8.0"
+        "@adraffy/ens-normalize": "1.10.1",
+        "@noble/curves": "1.2.0",
+        "@noble/hashes": "1.3.2",
+        "@types/node": "22.7.5",
+        "aes-js": "4.0.0-beta.5",
+        "tslib": "2.7.0",
+        "ws": "8.17.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/ethers/node_modules/@noble/hashes": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.3.2.tgz",
+      "integrity": "sha512-MVC8EAQp7MvEcm30KWENFjgR+Mkmf+D189XJTkFIlwohU5hcBbn1ZkKq7KVTi2Hme3PMGF390DaL52beVrIihQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/ethers/node_modules/@types/node": {
+      "version": "22.7.5",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.7.5.tgz",
+      "integrity": "sha512-jML7s2NAzMWc//QSJ1a3prpk78cOPchGvXJsC3C6R6PSMoooztvRVQEz89gmBTBY1SPMaqo5teB4uNHPdetShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.19.2"
+      }
+    },
+    "node_modules/ethers/node_modules/aes-js": {
+      "version": "4.0.0-beta.5",
+      "resolved": "https://registry.npmjs.org/aes-js/-/aes-js-4.0.0-beta.5.tgz",
+      "integrity": "sha512-G965FqalsNyrPqgEGON7nIx1e/OVENSgiEIzyC63haUMuvNnwIgIjMs52hlTCKhkBny7A2ORNlfY9Zu+jmGk1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/tslib": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.7.0.tgz",
+      "integrity": "sha512-gLXCKdN1/j47AiHiOkJN69hJmcbGTHI0ImLmbYLHykhgeN0jVGola9yVjFgzCUklsZQMW55o+dW7IXv3RCXDzA==",
+      "dev": true,
+      "license": "0BSD"
+    },
+    "node_modules/ethers/node_modules/undici-types": {
+      "version": "6.19.8",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.19.8.tgz",
+      "integrity": "sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ethers/node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/ethjs-abi": {
@@ -14913,6 +15059,53 @@
       "optional": true,
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.1.tgz",
+      "integrity": "sha512-+2uTZHxSCcxjvGc5C891LrS1/NlxglGxzrC4seZiVjcYVQfUa87wBL6rTDqzGjuoWNjnBzRqKmF6zRYGMvQUaQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.58.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.58.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.1.tgz",
+      "integrity": "sha512-bcWzOaTxcW+VOOGBCQgnaKToLJ65d6AqfLVKEWvexyS3AS6rbXl+xdpYRMGSRBClPvyj44njOWoxjNdL/H9UNg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/pluralize": {

--- a/package.json
+++ b/package.json
@@ -8,15 +8,18 @@
     "docs:interface": "node scripts/generate-interface-doc.js",
     "lint": "solhint \"contracts/**/*.sol\"",
     "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js",
+    "test:ui": "node scripts/ui/run_ui_smoke.js",
     "ui:abi": "node scripts/ui/export_abi.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5"
   },
   "devDependencies": {
+    "@playwright/test": "^1.49.1",
     "@openzeppelin/test-helpers": "^0.5.16",
     "@truffle/hdwallet-provider": "^2.1.15",
     "dotenv": "^16.4.5",
+    "ethers": "^6.13.4",
     "ganache": "^7.9.2",
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.6.0",

--- a/scripts/ui/run_ui_smoke.js
+++ b/scripts/ui/run_ui_smoke.js
@@ -1,0 +1,176 @@
+const { spawn } = require("child_process");
+const fs = require("fs");
+const http = require("http");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..", "..");
+const DOCS_ROOT = path.join(ROOT, "docs");
+const BUILD_ARTIFACT = path.join(ROOT, "build", "contracts", "AGIJobManager.json");
+const RPC_URL = "http://127.0.0.1:8545";
+const SERVER_HOST = "127.0.0.1";
+const SERVER_PORT = 4173;
+
+function waitForPort(port, host, timeoutMs = 15000) {
+  const start = Date.now();
+  return new Promise((resolve, reject) => {
+    const attempt = () => {
+      const socket = http
+        .request({ host, port, method: "GET", path: "/" }, () => {
+          socket.destroy();
+          resolve();
+        })
+        .on("error", () => {
+          socket.destroy();
+          if (Date.now() - start > timeoutMs) {
+            reject(new Error(`Timed out waiting for ${host}:${port}`));
+            return;
+          }
+          setTimeout(attempt, 250);
+        });
+      socket.end();
+    };
+    attempt();
+  });
+}
+
+async function waitForRpc(timeoutMs = 15000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const response = await fetch(RPC_URL, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ jsonrpc: "2.0", id: 1, method: "net_version", params: [] }),
+      });
+      if (response.ok) {
+        return;
+      }
+    } catch (error) {
+      // ignore until timeout
+    }
+    await new Promise((resolve) => setTimeout(resolve, 250));
+  }
+  throw new Error("Timed out waiting for Ganache RPC.");
+}
+
+function spawnProcess(command, args, options = {}) {
+  return spawn(command, args, { stdio: "inherit", shell: false, ...options });
+}
+
+function startStaticServer() {
+  const server = http.createServer((req, res) => {
+    const reqPath = decodeURIComponent((req.url || "/").split("?")[0]);
+    const safePath = path.normalize(reqPath).replace(/^(\.\.[/\\])+/, "");
+    let filePath = path.join(DOCS_ROOT, safePath);
+
+    if (reqPath === "/") {
+      filePath = path.join(DOCS_ROOT, "index.html");
+    }
+
+    fs.stat(filePath, (err, stats) => {
+      if (err || !stats.isFile()) {
+        res.statusCode = 404;
+        res.end("Not found");
+        return;
+      }
+      const ext = path.extname(filePath).toLowerCase();
+      const contentType = {
+        ".html": "text/html",
+        ".js": "application/javascript",
+        ".json": "application/json",
+        ".css": "text/css",
+        ".svg": "image/svg+xml",
+        ".png": "image/png",
+        ".jpg": "image/jpeg",
+        ".jpeg": "image/jpeg",
+        ".ico": "image/x-icon",
+      }[ext] || "application/octet-stream";
+      res.setHeader("Content-Type", contentType);
+      fs.createReadStream(filePath).pipe(res);
+    });
+  });
+
+  return new Promise((resolve) => {
+    server.listen(SERVER_PORT, SERVER_HOST, () => {
+      resolve(server);
+    });
+  });
+}
+
+async function readContractAddress() {
+  if (!fs.existsSync(BUILD_ARTIFACT)) {
+    throw new Error("AGIJobManager artifact not found. Did migration run?");
+  }
+  const artifact = JSON.parse(fs.readFileSync(BUILD_ARTIFACT, "utf8"));
+  const response = await fetch(RPC_URL, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ jsonrpc: "2.0", id: 2, method: "net_version", params: [] }),
+  });
+  const payload = await response.json();
+  const networkId = payload.result;
+  const networkEntry = artifact.networks?.[networkId];
+  if (!networkEntry || !networkEntry.address) {
+    throw new Error(`No deployment found for network id ${networkId}.`);
+  }
+  return networkEntry.address;
+}
+
+async function run() {
+  const ganache = spawnProcess("npx", [
+    "ganache",
+    "--wallet.mnemonic",
+    "test test test test test test test test test test test junk",
+    "--chain.chainId",
+    "1337",
+    "--chain.networkId",
+    "1337",
+    "--logging.quiet",
+    "--port",
+    "8545",
+  ]);
+
+  let server;
+  try {
+    await waitForRpc();
+
+    const migrate = spawnProcess("npx", ["truffle", "migrate", "--network", "development", "--reset"], {
+      cwd: ROOT,
+    });
+    const migrateCode = await new Promise((resolve) => migrate.on("close", resolve));
+    if (migrateCode !== 0) {
+      throw new Error(`Truffle migrate failed with exit code ${migrateCode}`);
+    }
+
+    const contractAddress = await readContractAddress();
+    server = await startStaticServer();
+    await waitForPort(SERVER_PORT, SERVER_HOST);
+
+    const env = {
+      ...process.env,
+      UI_BASE_URL: `http://${SERVER_HOST}:${SERVER_PORT}`,
+      UI_CONTRACT: contractAddress,
+      UI_RPC_URL: RPC_URL,
+    };
+    const testProcess = spawnProcess("npx", ["playwright", "test", "ui-tests/ui-smoke.spec.js"], {
+      cwd: ROOT,
+      env,
+    });
+    const testCode = await new Promise((resolve) => testProcess.on("close", resolve));
+    if (testCode !== 0) {
+      throw new Error(`Playwright tests failed with exit code ${testCode}`);
+    }
+  } finally {
+    if (server) {
+      await new Promise((resolve) => server.close(resolve));
+    }
+    if (ganache) {
+      ganache.kill("SIGTERM");
+    }
+  }
+}
+
+run().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/ui-tests/ui-smoke.spec.js
+++ b/ui-tests/ui-smoke.spec.js
@@ -1,0 +1,194 @@
+const path = require("path");
+const { test, expect } = require("@playwright/test");
+
+function resolveEthersUmd() {
+  const entryPath = require.resolve("ethers");
+  return path.join(path.dirname(entryPath), "..", "dist", "ethers.umd.min.js");
+}
+
+function buildProviderScript(rpcUrl) {
+  return `
+    (() => {
+      const rpcUrl = ${JSON.stringify(rpcUrl)};
+      const listeners = {};
+      const sendRpc = async (method, params = []) => {
+        const response = await fetch(rpcUrl, {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({ jsonrpc: "2.0", id: Date.now(), method, params }),
+        });
+        const payload = await response.json();
+        if (payload.error) {
+          throw new Error(payload.error.message || "RPC error");
+        }
+        return payload.result;
+      };
+      window.ethereum = {
+        isMetaMask: false,
+        request: async ({ method, params }) => {
+          if (method === "eth_requestAccounts") {
+            return sendRpc("eth_accounts", []);
+          }
+          const nextParams = Array.isArray(params) ? [...params] : [];
+          if ((method === "eth_call" || method === "eth_estimateGas") && nextParams[0] && !nextParams[0].from) {
+            const [from] = await sendRpc("eth_accounts", []);
+            if (from) {
+              nextParams[0] = { ...nextParams[0], from };
+            }
+          }
+          return sendRpc(method, nextParams);
+        },
+        on: (event, handler) => {
+          listeners[event] = listeners[event] || [];
+          listeners[event].push(handler);
+        },
+        removeListener: (event, handler) => {
+          if (!listeners[event]) return;
+          listeners[event] = listeners[event].filter((fn) => fn !== handler);
+        },
+      };
+      window.ethereum.send = (method, params) => window.ethereum.request({ method, params });
+      window.ethereum.sendAsync = (payload, callback) => {
+        window.ethereum
+          .request({ method: payload.method, params: payload.params || [] })
+          .then((result) => callback(null, { jsonrpc: "2.0", id: payload.id, result }))
+          .catch((error) => callback(error, null));
+      };
+    })();
+  `;
+}
+
+test.describe("AGIJobManager UI smoke", () => {
+  test("connects, refreshes, approves, and creates a job", async ({ page }) => {
+    test.setTimeout(120000);
+    const baseUrl = process.env.UI_BASE_URL;
+    const contractAddress = process.env.UI_CONTRACT;
+    const rpcUrl = process.env.UI_RPC_URL;
+
+    if (!baseUrl || !contractAddress || !rpcUrl) {
+      throw new Error("Missing UI_BASE_URL, UI_CONTRACT, or UI_RPC_URL env vars.");
+    }
+
+    const errors = [];
+    page.on("pageerror", (error) => errors.push(error));
+    page.on("console", (msg) => {
+      if (msg.type() === "error") {
+        errors.push(new Error(msg.text()));
+      }
+    });
+    page.on("dialog", (dialog) => {
+      errors.push(new Error(`Dialog: ${dialog.message()}`));
+      dialog.dismiss().catch(() => {});
+    });
+
+    await page.route("https://cdn.jsdelivr.net/npm/ethers@6.13.4/dist/ethers.umd.min.js", async (route) => {
+      await route.fulfill({
+        path: resolveEthersUmd(),
+        contentType: "application/javascript",
+      });
+    });
+
+    await page.route("**/agijobmanager.html*", async (route) => {
+      const response = await route.fetch();
+      let body = await response.text();
+      body = body.replace(/integrity=\"[^\"]*\"/g, "");
+      await route.fulfill({
+        status: response.status(),
+        headers: response.headers(),
+        body,
+      });
+    });
+
+    await page.route(rpcUrl, async (route) => {
+      const request = route.request();
+      if (request.method() === "OPTIONS") {
+        await route.fulfill({
+          status: 204,
+          headers: {
+            "access-control-allow-origin": "*",
+            "access-control-allow-methods": "POST, OPTIONS",
+            "access-control-allow-headers": "content-type",
+          },
+        });
+        return;
+      }
+      const response = await route.fetch();
+      const body = await response.body();
+      await route.fulfill({
+        status: response.status(),
+        headers: {
+          ...response.headers(),
+          "access-control-allow-origin": "*",
+        },
+        body,
+      });
+    });
+
+    await page.addInitScript(buildProviderScript(rpcUrl));
+
+    await page.goto(`${baseUrl}/ui/agijobmanager.html?contract=${contractAddress}`, {
+      waitUntil: "domcontentloaded",
+    });
+
+    await expect(page.locator("#activityLog")).toContainText("External ABI loaded.");
+
+    const envProbe = await page.evaluate(() => ({
+      hasEthers: Boolean(window.ethers),
+      hasEthereum: Boolean(window.ethereum),
+      hasRequest: Boolean(window.ethereum && window.ethereum.request),
+    }));
+    expect(envProbe.hasEthers).toBe(true);
+    expect(envProbe.hasEthereum).toBe(true);
+    expect(envProbe.hasRequest).toBe(true);
+
+    const accountProbe = await page.evaluate(async () => {
+      try {
+        const accounts = await window.ethereum.request({ method: "eth_accounts" });
+        return { accounts };
+      } catch (error) {
+        return { error: error?.message || String(error) };
+      }
+    });
+    if (accountProbe.error) {
+      throw new Error(`EIP-1193 probe failed: ${accountProbe.error}`);
+    }
+    if (!Array.isArray(accountProbe.accounts) || accountProbe.accounts.length === 0) {
+      throw new Error("EIP-1193 probe returned no accounts.");
+    }
+
+    await page.click("#connectButton");
+    await expect(page.locator("#walletAddress")).not.toContainText("Not connected", { timeout: 10000 });
+    await expect(page.locator("#networkPill")).toContainText("Connected", { timeout: 10000 });
+
+    await page.click("#refreshSnapshot");
+    await expect(page.locator("#contractOwner")).not.toHaveText("—");
+    await expect(page.locator("#agiToken")).not.toHaveText("—");
+
+    await expect(page.locator("#approveToken")).toBeEnabled();
+
+    await page.fill("#approveAmount", "1");
+    await page.click("#approveToken");
+    await page.waitForTimeout(500);
+    if (errors.length) {
+      throw errors[0];
+    }
+    await expect(page.locator("#activityLog")).toContainText("approve confirmed", { timeout: 20000 });
+
+    await page.fill("#jobIpfs", "QmUiSmokeJob");
+    await page.fill("#jobPayout", "1");
+    await page.fill("#jobDuration", "3600");
+    await page.fill("#jobDetails", "UI smoke test job");
+    await expect(page.locator("#jobDuration")).toHaveValue("3600");
+    await page.click("#createJob");
+    await page.waitForTimeout(500);
+    if (errors.length) {
+      throw errors[0];
+    }
+    await expect(page.locator("#activityLog")).toContainText("Create job confirmed", { timeout: 20000 });
+
+    await page.click("#loadJobs");
+    await expect(page.locator("#jobsTable tr")).toHaveCount(1);
+
+    expect(errors).toEqual([]);
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent silent regressions in the static GitHub Pages UI by adding a minimal, deterministic smoke test that exercises connect/refresh/approve/create flows without a real wallet extension. 
- Make the local UI write path feasible and repeatable by deploying mock contracts and seeding balances during development migrations. 
- Keep changes minimal and focused on testing, documentation, and a tiny UI validation fix so the UI remains the single source-of-truth file (`docs/ui/agijobmanager.html`).

### Description
- Add a manual checklist `docs/ui/SMOKE_TEST.md` documenting how to run Ganache, deploy contracts, serve the UI, and smoke-test core flows.  
- Add a Playwright smoke spec `ui-tests/ui-smoke.spec.js` that injects an EIP-1193 provider stub (forwards JSON-RPC to `http://127.0.0.1:8545`), stubs `ethers.umd.min.js`, and asserts: ABI load, Connect Wallet, Refresh snapshot, Approve token, Create job, and that the jobs table shows the created job.  
- Add an orchestrator script `scripts/ui/run_ui_smoke.js` that spawns Ganache (deterministic mnemonic), runs `truffle migrate --network development --reset`, starts a small static HTTP server serving `docs/`, and runs the Playwright spec; the script ensures cleanup.  
- Update migrations `migrations/2_deploy_contracts.js` to deploy local `MockERC20`, `MockENS`, `MockResolver`, `MockNameWrapper` when run on `development`/`test`, wire resolvers, deploy `AGIJobManager` against those mocks and mint deterministic token balances to the first account so the UI write path is available offline.  
- Add `npm` wiring and dev deps: new `npm run test:ui`, add Playwright + `ethers` to dev deps so the tests run in CI and locally.  
- CI: extend `.github/workflows/ci.yml` to install Playwright Chromium and run `npm run test:ui` after the existing tests.  
- Small UI correctness fix: tighten the integer regex in `docs/ui/agijobmanager.html` (`/^\d+$/`) for `parseUint`/button enablement so numeric duration/cancel inputs are accepted as intended.

### Testing
- Ran unit/contract test suite: `npm test` (Truffle + repo tests) — completed successfully (existing test suite ran; ABI smoke checks passed).  
- Ran UI smoke end-to-end: `npx playwright install --with-deps chromium` then `npm run test:ui` (this starts Ganache, runs migrations, serves the UI, runs the Playwright spec). The Playwright spec executed headless and passed the happy path assertions (connect, refresh, approve, create job, jobs table row present).  
- Note on network: Playwright browser binaries are downloaded if not present (CI step `npx playwright install --with-deps chromium` is added); the UI/contract interactions themselves are deterministic and run entirely against a local Ganache instance seeded by the migrations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697cf9b9df70833391464ab040461068)