### PR TITLE
Add root .env.example and brief README env setup notes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,3 +1,52 @@
+# Copy to .env and keep secrets out of git.
+# PRIVATE_KEYS is only used for deploy/verification workflows; never commit it.
+
+# ---------------------------------------------------------------------------
+# Truffle network configuration (see truffle-config.js)
+# ---------------------------------------------------------------------------
+
+# RPC configuration (prefer direct URLs, or use provider keys below).
+SEPOLIA_RPC_URL=
+MAINNET_RPC_URL=
+
+# Alchemy (used to construct RPC URLs if direct URLs are not set).
+ALCHEMY_KEY=your_alchemy_key_for_sepolia
+ALCHEMY_KEY_MAIN=your_alchemy_key_for_mainnet
+
+# Infura (optional fallback if Alchemy/direct URLs are not set).
+INFURA_KEY=optional_or_unused
+
+# Deployment accounts (comma-separated; no spaces; can be a single key).
+PRIVATE_KEYS=0xabc...,0xdef...
+
+# Verification (truffle-plugin-verify).
+ETHERSCAN_API_KEY=your_etherscan_api_key
+
+# Optional provider tuning.
+RPC_POLLING_INTERVAL_MS=8000
+
+# Network tuning (gas, confirmations, timeouts).
+SEPOLIA_GAS=8000000
+MAINNET_GAS=8000000
+SEPOLIA_GAS_PRICE_GWEI=
+MAINNET_GAS_PRICE_GWEI=
+SEPOLIA_CONFIRMATIONS=2
+MAINNET_CONFIRMATIONS=2
+SEPOLIA_TIMEOUT_BLOCKS=500
+MAINNET_TIMEOUT_BLOCKS=500
+
+# Solidity compiler settings.
+SOLC_VERSION=0.8.33
+SOLC_RUNS=200
+SOLC_VIA_IR=false
+SOLC_EVM_VERSION=london
+
+# Local development (Ganache).
+GANACHE_MNEMONIC=test test test test test test test test test test test junk
+
+# ---------------------------------------------------------------------------
+# ERC-8004 export scripts (see docs/ERC8004.md)
+# ---------------------------------------------------------------------------
 AGIJOBMANAGER_ADDRESS=
 ERC8004_IDENTITY_REGISTRY=
 ERC8004_REPUTATION_REGISTRY=

--- a/README.md
+++ b/README.md
@@ -131,6 +131,12 @@ npx truffle migrate --network development
 
 `truffle-config.js` is the source of truth for networks and env vars. A full guide lives in [`docs/Deployment.md`](docs/Deployment.md).
 
+**Environment setup**
+- Copy `.env.example` → `.env` (keep it local):
+  ```bash
+  cp .env.example .env
+  ```
+
 **Required (Sepolia / Mainnet)**
 - `PRIVATE_KEYS`: comma-separated private keys.
 - RPC configuration, one of:
@@ -146,6 +152,12 @@ npx truffle migrate --network development
 - Provider polling: `RPC_POLLING_INTERVAL_MS`.
 - Compiler settings: `SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`.
 - Local chain: `GANACHE_MNEMONIC`.
+
+**Network notes**
+- `development`/Ganache typically needs no env vars.
+- `sepolia` needs `ALCHEMY_KEY` (or `SEPOLIA_RPC_URL`) + `PRIVATE_KEYS`.
+- `mainnet` needs `ALCHEMY_KEY_MAIN` (or `MAINNET_RPC_URL`) + `PRIVATE_KEYS`.
+- `PRIVATE_KEYS` format: comma-separated, no spaces, keep it local.
 
 > **Deployment caution**: `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token, ENS, NameWrapper, root nodes, Merkle roots). Update them before any production deployment.
 


### PR DESCRIPTION
### Motivation
- Make environment-variable setup explicit and newcomer-friendly by matching the variables referenced in `truffle-config.js` and keeping secrets out of the repo.
- Preserve the existing deployment/erc8004 placeholders while providing safe, non-secret examples for local and remote workflows.
- Keep changes minimal and non-invasive so development/compile workflows are unaffected.

### Description
- Added a root `./.env.example` that lists the RPC keys/URLs (`SEPOLIA_RPC_URL`, `MAINNET_RPC_URL`, `ALCHEMY_KEY`, `ALCHEMY_KEY_MAIN`, `INFURA_KEY`), `PRIVATE_KEYS`, `ETHERSCAN_API_KEY`, optional tuning vars and the existing ERC-8004 export placeholders; the file contains only non-secret placeholders and explanatory comments.
- Added a short `Environment setup` / `Network notes` section to `README.md` explaining `cp .env.example .env`, which vars are needed for `development`/`sepolia`/`mainnet`, and the `PRIVATE_KEYS` format.
- Inspected `.gitignore` and confirmed it already ignores dotenv files (`.env` and `.env.*`) while not ignoring `!.env.example`, so no gitignore changes were required.
- Did not modify `truffle-config.js` logic or contract code; no new runtime guards were added so development compile/tests remain unaffected.

### Testing
- Ran `npm ci` which failed due to an optional dependency platform restriction (`fsevents@2.3.2` is Darwin-only) and is expected on Linux CI/dev hosts; see message in output.
- Used `npm install --omit=optional` which completed successfully and allowed the JS toolchain to install.
- Ran `npx truffle compile` which completed successfully and wrote artifacts to `build/contracts`, demonstrating `truffle-config.js` can be required/used without a local `.env` present.
- Ran `npx truffle test` which failed with `Couldn't connect to node http://127.0.0.1:8545` because no local Ganache node was running (start one with `npx ganache -p 8545` to run tests).

Remaining limitations: `INFURA_KEY` is included as an optional/unused fallback per `truffle-config.js` logic; no secrets were added to the repo.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d0e2be8dc8333a6705e5b1d8815a4)