### PR TITLE
docs: expand deployment troubleshooting guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,9 @@ npx truffle migrate --network development
 - `mainnet` needs `ALCHEMY_KEY_MAIN` (or `MAINNET_RPC_URL`) + `PRIVATE_KEYS`.
 - `PRIVATE_KEYS` format: comma-separated, no spaces, keep it local.
 
+**Troubleshooting**
+- Common deployment and verification errors are documented in [`docs/Deployment.md`](docs/Deployment.md#troubleshooting).
+
 > **Deployment caution**: `migrations/2_deploy_contracts.js` hardcodes constructor parameters (token, ENS, NameWrapper, root nodes, Merkle roots). Update them before any production deployment.
 
 ## Security considerations

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -88,7 +88,12 @@ npx truffle run verify AGIJobManager --network mainnet
 - If the Etherscan plugin fails, re-run with `--debug` to capture full output.
 
 ## Troubleshooting
-- **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.
-- **Missing private keys**: ensure `PRIVATE_KEYS` is set and comma-separated.
-- **Verification failures**: confirm compiler version, optimizer runs, and `viaIR` settings match the deployed bytecode.
-- **Nonce conflicts**: avoid running multiple deployment processes with the same keys.
+
+| Symptom | Likely cause | Fix |
+| --- | --- | --- |
+| `Missing RPC URL for sepolia` or `mainnet` | No direct RPC URL or provider key found. | Set `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`, or `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN`, or `INFURA_KEY`. |
+| `Missing PRIVATE_KEYS (comma-separated).` | `PRIVATE_KEYS` unset or empty. | Add at least one deployer key to `PRIVATE_KEYS` (comma-separated). |
+| `Invalid number of parameters for "constructor"` | Constructor args in `migrations/2_deploy_contracts.js` don’t match the target deployment. | Update the migration parameters (token, ENS, NameWrapper, root nodes, Merkle roots) before deploying. |
+| `Returned error: insufficient funds` | Deployer account lacks ETH on target network. | Fund the deployer account and retry. |
+| Verification fails with mismatched bytecode | Compiler settings don’t match deployment. | Ensure `SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, and `SOLC_EVM_VERSION` match the deployment configuration. |
+| `nonce too low` or `replacement transaction underpriced` | Parallel deploys with the same key or stale nonce. | Run one deployment at a time or reset the nonce in your wallet/provider. |


### PR DESCRIPTION
### Motivation
- Make deployment and verification guidance more discoverable and actionable for engineers, integrators, and operators. 
- Reduce common deployment failures by consolidating troubleshooting steps into a clear table linked from the top-level README.

### Description
- Add a troubleshooting callout to `README.md` that links to the expanded `docs/Deployment.md` troubleshooting section. 
- Expand and consolidate the `Troubleshooting` table in `docs/Deployment.md` with concrete symptoms, likely causes, and fixes (RPC URL, private keys, constructor params, insufficient funds, verification mismatches, nonce issues). 
- This change is documentation-only and does not modify any contracts; `contracts/AGIJobManager.sol` was explicitly not changed.

### Testing
- Ran `npm install` to populate dependencies (install completed; `npm audit` reported vulnerabilities as informational). 
- Ran `npx truffle compile`, which completed successfully using `solc: 0.8.33`. 
- Ran `npm test`, which executed the Truffle test suite and smoke tests and completed with `92 passing` tests. 
- CI workflow was detected at `.github/workflows/ci.yml`; no new CI badges were added because the existing README badge already references this workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d16d6bfb48333be3aa7a531b3b8ca)