### PR TITLE
docs: clarify compiler settings for reproducible verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ npm run build
 npm test
 ```
 
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.17`, while the Truffle default compiler is `0.8.33` (configurable via `SOLC_VERSION`). Keep the deploy-time compiler settings consistent for verification.
+
 ## Web UI (GitHub Pages)
 
 - Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -30,6 +30,8 @@ The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS
 
 A template lives in [`.env.example`](../.env.example).
 
+> **Compiler note**: `AGIJobManager.sol` uses `pragma solidity ^0.8.17`, while the default Truffle compiler is `0.8.33`. For reproducible verification, keep `SOLC_VERSION`, optimizer runs, and `viaIR` consistent with the original deployment.
+
 ## Networks configured
 - **test**: in-process Ganache provider for `truffle test`.
 - **development**: local RPC at `127.0.0.1:8545` (Ganache).


### PR DESCRIPTION
### Motivation
- Make the repo documentation explicit about the Solidity pragma vs Truffle/CI compiler setting so developers can reproduce deploy-time bytecode and perform accurate Etherscan verification without guessing compiler options.

### Description
- Add short, visible compiler/pragma guidance in the root `README.md` Quickstart and a companion note in `docs/Deployment.md` to explain that `AGIJobManager.sol` uses `pragma solidity ^0.8.17` while the Truffle default in this repo is `0.8.33`, and to instruct maintainers to keep `SOLC_VERSION`, optimizer runs, and `viaIR` consistent for verification; files changed: `README.md`, `docs/Deployment.md`.

### Testing
- Ran the repository validation steps: `npm install` (succeeded), `npm run build` which runs `truffle compile` (succeeded; artifacts written using `solc 0.8.33`), and `npm test` (succeeded; Truffle test suite completed with all tests passing — 92 passing, plus ABI smoke test passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2865276c8333abc7f4f3c5ae9b1c)