### PR TITLE
Clarify dispute resolution semantics in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,6 +171,7 @@ npx truffle migrate --network development
 - **Token compatibility**: ERC‑20 must return `true` for `transfer`/`transferFrom`.
 - **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
 - **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline unless off‑chain policies intervene.
+- **Dispute strings**: `resolveDispute` accepts any string, but only the exact `agent win` / `employer win` values trigger settlement; other strings just clear the dispute flag.
 
 See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known limitations.
 

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -92,6 +92,7 @@ stateDiagram-v2
 - `resolveDispute` accepts any resolution string, but only two canonical strings trigger on-chain actions:
   - `agent win` → `_completeJob`
   - `employer win` → employer refund + `completed = true`
+  - The string match is case-sensitive; any other value only clears the dispute flag.
 
 ## Reputation mechanics
 - **Agent reputation**: derived from payout and completion time via `calculateReputationPoints`, then stored through `enforceReputationGrowth` (diminishing returns with a cap).

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -12,6 +12,7 @@ This document summarizes security considerations specific to the current `AGIJob
 **Primary trust assumptions**
 - **Owner powers**: can pause flows, update token address, thresholds, allowlists/blacklists, metadata fields, add AGI types, and withdraw ERC‑20 escrow.
 - **Moderator powers**: resolve disputes with arbitrary strings. Only the canonical strings `agent win` and `employer win` trigger on-chain payout or refund.
+  - These strings are case-sensitive; any other resolution clears the dispute flag without settlement actions.
 - **Validator set**: validators are allowlisted or ENS/Merkle‑gated; the contract does not enforce decentralization.
 
 ## Hardened improvements (vs. historical v0)


### PR DESCRIPTION
### Motivation
- Make dispute-resolution behavior explicit and audit-friendly by documenting that `resolveDispute` accepts any string but only the exact, case-sensitive values `agent win` and `employer win` trigger on‑chain settlement actions, preventing operator or integrator confusion.

### Description
- Updated `README.md`, `docs/AGIJobManager.md`, and `docs/Security.md` to state the canonical resolution strings and that the string match is case-sensitive, and to explain that non-canonical strings only clear the `disputed` flag; no contract source was modified.
- No changes were made to `contracts/AGIJobManager.sol` in accordance with repository constraints.

### Testing
- Ran `npm install`, `npx truffle compile`, and `npx truffle test --network test`, where compilation completed (`solc 0.8.33`) and the test suite passed (92 passing).
- The repository's standard CI workflow (`.github/workflows/ci.yml`) is present and the local smoke/test steps exercised the same build/test steps used by CI; all automated checks run locally succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d2c99273c8333af20a90a16122208)