### PR TITLE
Guard purchaseNFT with nonReentrant and add reentrancy regression test

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -450,7 +450,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit NFTListed(tokenId, msg.sender, price);
     }
 
-    function purchaseNFT(uint256 tokenId) external {
+    function purchaseNFT(uint256 tokenId) external nonReentrant {
         Listing storage listing = listings[tokenId];
         if (!listing.isActive) revert InvalidState();
         _tFrom(msg.sender, listing.seller, listing.price);
@@ -552,4 +552,3 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         return highestPercentage;
     }
 }
-

--- a/contracts/test/ReentrantERC20.sol
+++ b/contracts/test/ReentrantERC20.sol
@@ -1,0 +1,47 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+interface IAGIJobManager {
+    function purchaseNFT(uint256 tokenId) external;
+}
+
+contract ReentrantERC20 is ERC20 {
+    address public manager;
+    uint256 public reenterTokenId;
+    bool public reenterEnabled;
+    bool public reenterAttempted;
+    bool public reentrancyBlocked;
+
+    constructor() ERC20("Reentrant AGI", "rAGI") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function setReentry(address _manager, uint256 _tokenId, bool _enabled) external {
+        manager = _manager;
+        reenterTokenId = _tokenId;
+        reenterEnabled = _enabled;
+        reenterAttempted = false;
+        reentrancyBlocked = false;
+    }
+
+    function approveManager(uint256 amount) external {
+        require(manager != address(0), "manager not set");
+        _approve(address(this), manager, amount);
+    }
+
+    function transferFrom(address from, address to, uint256 amount) public override returns (bool) {
+        if (reenterEnabled && !reenterAttempted && manager != address(0)) {
+            reenterAttempted = true;
+            try IAGIJobManager(manager).purchaseNFT(reenterTokenId) {
+                reentrancyBlocked = false;
+            } catch {
+                reentrancyBlocked = true;
+            }
+        }
+        return super.transferFrom(from, to, amount);
+    }
+}

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -29,9 +29,9 @@ See [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md) for details.
 
 ## Reentrancy posture
 `ReentrancyGuard` is applied to:
-- `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `cancelJob`, `withdrawAGI`, `contributeToRewardPool`.
+- `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `cancelJob`, `withdrawAGI`, `contributeToRewardPool`, `purchaseNFT`.
 
-Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, `purchaseNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and `_transfer` (ERC‑721) rather than `safeTransferFrom`.
+Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and `_transfer` (ERC‑721) rather than `safeTransferFrom`.
 
 ## Known limitations and assumptions
 - **Root immutability**: there are no on-chain setters for root nodes or Merkle roots after deployment. Misconfiguration requires redeployment.


### PR DESCRIPTION
### Motivation
- Harden the NFT marketplace purchase flow by protecting any function that moves value and calls external token contracts to reduce reentrancy risk. 
- Provide a behavioral regression that proves the guard is enforced (not just added as a modifier).

### Description
- Add `nonReentrant` to `purchaseNFT(uint256 tokenId)` in `contracts/AGIJobManager.sol` with a single-line change to the function signature while preserving existing behavior and style.
- Add a test-only ERC-20 `contracts/test/ReentrantERC20.sol` that attempts a single re-entrant `purchaseNFT(...)` from `transferFrom` and records whether the re-entrant call was blocked.
- Add a regression test to `test/nftMarketplace.test.js` that wires `ReentrantERC20` into a fresh `AGIJobManager` deployment, triggers a re-entrancy attempt during purchase, and asserts the re-entrant call was blocked and the secondary NFT remained listed/owned.
- Update `docs/Security.md` to reflect the updated reentrancy posture by listing `purchaseNFT` among functions guarded by `ReentrancyGuard`.

### Testing
- `npm ci` — failed due to platform-specific dependency (`fsevents`) filtered for macOS, see note; this is an environmental/package-manager issue and not a code regression.
- `npm install` — succeeded.
- `npm run build` — succeeded and contracts compiled successfully (solc 0.8.33).
- `npm run test` — succeeded; full test suite passed (93 passing), including the new `blocks reentrancy during NFT purchase` test that would fail without `nonReentrant`.
- `npm run test:ui` — succeeded (UI smoke test passed).
- `npm run lint` — ran (no blocking issues introduced by these edits).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d30904a048333b8c4d1e3b508ffd1)