### PR TITLE
Add explicit reentrancy assertion for NFT purchase and update security docs

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -33,6 +33,8 @@ See [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md) for details.
 
 Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and `_transfer` (ERC‑721) rather than `safeTransferFrom`.
 
+The regression suite includes a reentrant ERC‑20 purchase attempt to assert that `purchaseNFT` rejects reentry while still completing the outer purchase.
+
 ## Known limitations and assumptions
 - **Root immutability**: there are no on-chain setters for root nodes or Merkle roots after deployment. Misconfiguration requires redeployment.
 - **ENS dependency**: ownership checks rely on ENS registry, NameWrapper, and resolver behavior.

--- a/test/nftMarketplace.test.js
+++ b/test/nftMarketplace.test.js
@@ -179,6 +179,9 @@ contract("AGIJobManager NFT marketplace", (accounts) => {
 
     await managerReentrant.purchaseNFT(tokenIdA, { from: buyer });
 
+    const reenterAttempted = await reentrant.reenterAttempted();
+    assert.strictEqual(reenterAttempted, true, "reentrant call should have been attempted");
+
     const reentrancyBlocked = await reentrant.reentrancyBlocked();
     assert.strictEqual(reentrancyBlocked, true, "reentrant call should be blocked");
 


### PR DESCRIPTION
### Motivation
- Ensure the `purchaseNFT` reentrancy hardening is behaviorally exercised by tests; the contract already uses `nonReentrant`, so add a concrete regression assertion that the reentrant ERC‑20 path is attempted and recorded while being blocked, and document that the suite exercises this scenario.

### Description
- Modified `test/nftMarketplace.test.js` to assert the reentrant ERC‑20 path was attempted (`ReentrantERC20.reenterAttempted`) in the marketplace reentrancy regression, and added a brief note in `docs/Security.md` stating the regression suite includes the reentrant ERC‑20 purchase attempt.

### Testing
- Ran `npm install --omit=optional`, `npm run build`, `npm run test`, `npm run test:ui`, and `npm run lint` locally and they succeeded, while `npm ci` fails on Linux due to an optional `fsevents` platform restriction; the full test run shows `93 passing` and the UI smoke tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d337ff6b88333abeb572816647564)