### PR TITLE
Add reentrancy regression checks for purchaseNFT and document guard

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -32,6 +32,7 @@ See [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md) for details.
 - `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `cancelJob`, `withdrawAGI`, `contributeToRewardPool`, `purchaseNFT`.
 
 Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and `_transfer` (ERC‑721) rather than `safeTransferFrom`.
+Marketplace purchases are guarded because `purchaseNFT` crosses an external ERC‑20 `transferFrom` boundary before transferring the ERC‑721.
 
 ## Known limitations and assumptions
 - **Root immutability**: there are no on-chain setters for root nodes or Merkle roots after deployment. Misconfiguration requires redeployment.

--- a/test/purchaseNFT.reentrancy.truffle.js
+++ b/test/purchaseNFT.reentrancy.truffle.js
@@ -80,9 +80,21 @@ contract("AGIJobManager purchaseNFT reentrancy", (accounts) => {
     await token.setReentry(manager.address, tokenIdB, true, { from: owner });
     await token.approveManager(priceB, { from: owner });
 
+    const buyerBalanceBefore = await token.balanceOf(buyer);
+    const sellerBalanceBefore = await token.balanceOf(employer);
     await expectRevert(
       manager.purchaseNFT(tokenIdA, { from: buyer }),
       "ReentrancyGuard: reentrant call"
+    );
+    const buyerBalanceAfter = await token.balanceOf(buyer);
+    const sellerBalanceAfter = await token.balanceOf(employer);
+    assert(
+      buyerBalanceAfter.eq(buyerBalanceBefore),
+      "buyer balance should be unchanged after revert"
+    );
+    assert(
+      sellerBalanceAfter.eq(sellerBalanceBefore),
+      "seller balance should be unchanged after revert"
     );
 
     const ownerA = await manager.ownerOf(tokenIdA);


### PR DESCRIPTION
### Motivation
- Ensure the marketplace purchase flow remains protected against reentrancy and add a regression that will fail if that protection is removed.  
- Keep changes minimal and non-invasive since `purchaseNFT` was already guarded by `ReentrancyGuard` in the existing contract.

### Description
- Added balance-invariant assertions to the existing reentrancy regression test at `test/purchaseNFT.reentrancy.truffle.js` to assert buyer and seller ERC-20 balances are unchanged when a nested/reentrant `purchaseNFT` attempt reverts.  
- Updated the security documentation at `docs/Security.md` to explicitly state why `purchaseNFT` is guarded (it performs an external ERC-20 `transferFrom` before the ERC-721 transfer).  
- No production contract logic was changed because `contracts/AGIJobManager.sol` already imports `ReentrancyGuard` and declares `purchaseNFT` as `nonReentrant`.

### Testing
- Ran the repository test suite with `npm test` (which runs `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js`) and observed the compiled contracts and full test run.  
- All automated tests passed: `96 passing` (the test run completed successfully and the new assertions were exercised).  
- No test failures remain; the change is limited to test assertions and a brief doc update.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d5819a638833384ace5a1b574d3c7)