### PR TITLE
Add no-return ERC20 marketplace coverage and document token compatibility

### DIFF
--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -84,6 +84,7 @@ stateDiagram-v2
 - **Validator payout**: when validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
 - **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner.
 - **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with `employer win` refunds and finalizes the job.
+- **ERC-20 compatibility**: token transfers accept ERC‑20s that return `bool` or return no data. Calls that revert, return `false`, or return malformed data revert with `TransferFailed`. Escrow deposits enforce exact amount received, so fee‑on‑transfer, rebasing, or other balance‑mutating tokens are not supported.
 
 ## Validation and dispute flow
 - `validateJob` increments approval count, records validator participation, and auto‑completes when approvals reach the required threshold. It does **not** require `completionRequested`.


### PR DESCRIPTION
### Motivation
- Ensure AGIJobManager works with non‑standard ERC‑20s that return no data from `transfer`/`transferFrom` (USDT‑like) and cover the NFT marketplace purchase path in tests.
- Make the contract documentation explicit about supported token behaviors and the contract’s exact‑amount escrow constraint to prevent silent underfunding by fee‑on‑transfer tokens.

### Description
- Added a marketplace compatibility test to `test/erc20Compatibility.noReturn.test.js` which exercises creating a job, completing it, minting/listing the NFT, and `purchaseNFT` using `ERC20NoReturn` (a token whose `transfer`/`transferFrom` return no data).
- Updated `docs/AGIJobManager.md` to document ERC‑20 compatibility: the contract accepts tokens that return `bool` or return no data and reverts with `TransferFailed` on revert/`false`/malformed returns, and escrow deposits enforce exact amount received so fee‑on‑transfer/rebasing tokens are unsupported.
- No changes were required to `contracts/AGIJobManager.sol` because it already contains internal SafeERC20‑style helpers (`_callOptionalReturn`, `_safeERC20Transfer`, `_safeERC20TransferFrom`, `_safeERC20TransferFromExact`) that implement the desired semantics and exact‑amount escrow checks.

### Testing
- Commands run and results: `npm ci` (failed: `fsevents` unsupported platform on Linux), `npm ci --omit=optional` (failed for same reason), `npm ci --force` (completed, deps installed with warnings), `npx truffle compile` (succeeded), `npx truffle test` (initial attempt failed: no RPC at `http://127.0.0.1:8545`), `npx ganache -p 8545` (started local node), `npx truffle test` (succeeded; full suite ran and reported `99 passing`).
- Tests added: new marketplace coverage in `test/erc20Compatibility.noReturn.test.js` which passed under the local test run, and the existing `erc20Compatibility.noReturn` test continues to pass.
- Files changed: `test/erc20Compatibility.noReturn.test.js` (tests expanded), `docs/AGIJobManager.md` (ERC‑20 compatibility note).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d6d785004833391e8e5952732dbad)