### PR TITLE
Enforce MAX_VALIDATORS_PER_JOB cap and validate thresholds

### DIFF
--- a/docs/Security.md
+++ b/docs/Security.md
@@ -40,6 +40,7 @@ Marketplace purchases are guarded because `purchaseNFT` crosses an external ERC�
 - **ERC‑20 compatibility**: tokens must return a boolean for `transfer` and `transferFrom`.
 - **Agent payout can be zero**: if no AGI type applies, the agent payout percentage is zero and residual funds remain in the contract.
 - **Validator payout sharing**: all validators who voted share equally; there is no weighting or slashing.
+- **Validator cap**: each job records at most `MAX_VALIDATORS_PER_JOB` unique validators to bound settlement gas. Owner-set thresholds must fit within this cap (each ≤ cap and approvals + disapprovals ≤ cap) to keep completion/dispute reachable without exceeding the loop bound.
 - **Owner-controlled parameters**: thresholds and limits can be changed post-deployment by the owner.
 - **Time enforcement gap**: only `requestJobCompletion` enforces job duration; validators can still approve/disapprove after the deadline unless off‑chain policy prevents it.
 

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -68,6 +68,11 @@
     },
     {
       "inputs": [],
+      "name": "InvalidValidatorThresholds",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "JobNotFound",
       "type": "error"
     },
@@ -84,6 +89,16 @@
     {
       "inputs": [],
       "name": "TransferFailed",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ValidatorLimitReached",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "ValidatorSetTooLarge",
       "type": "error"
     },
     {
@@ -635,6 +650,19 @@
       ],
       "name": "Unpaused",
       "type": "event"
+    },
+    {
+      "inputs": [],
+      "name": "MAX_VALIDATORS_PER_JOB",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
     },
     {
       "inputs": [

--- a/test/validatorCap.test.js
+++ b/test/validatorCap.test.js
@@ -1,0 +1,146 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function sendSigned(manager, account, data, gas = 500000) {
+  const gasPrice = await web3.eth.getGasPrice();
+  const nonce = await web3.eth.getTransactionCount(account.address);
+  const signed = await web3.eth.accounts.signTransaction(
+    {
+      to: manager.address,
+      data,
+      gas,
+      gasPrice,
+      nonce,
+    },
+    account.privateKey
+  );
+  return web3.eth.sendSignedTransaction(signed.rawTransaction);
+}
+
+async function createJob(manager, token, employer, payout) {
+  await token.mint(employer, payout);
+  await token.approve(manager.address, payout, { from: employer });
+  const receipt = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+  return receipt.logs[0].args.jobId.toNumber();
+}
+
+contract("AGIJobManager validator cap", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  let token;
+  let ens;
+  let nameWrapper;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+  });
+
+  it("rejects validator thresholds that exceed the cap", async () => {
+    const cap = (await manager.MAX_VALIDATORS_PER_JOB()).toNumber();
+
+    await expectCustomError(
+      manager.setRequiredValidatorApprovals.call(cap + 1, { from: owner }),
+      "InvalidValidatorThresholds"
+    );
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await expectCustomError(
+      manager.setRequiredValidatorDisapprovals.call(cap, { from: owner }),
+      "InvalidValidatorThresholds"
+    );
+  });
+
+  it("reverts when the validator cap is reached", async () => {
+    const cap = (await manager.MAX_VALIDATORS_PER_JOB()).toNumber();
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(cap - 1, { from: owner });
+
+    const payout = toBN(toWei("10"));
+    const jobId = await createJob(manager, token, employer, payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    const validators = Array.from({ length: cap + 1 }, () => web3.eth.accounts.create());
+    for (const validator of validators) {
+      await web3.eth.sendTransaction({
+        from: owner,
+        to: validator.address,
+        value: toWei("1"),
+      });
+      await manager.addAdditionalValidator(validator.address, { from: owner });
+    }
+
+    const disapproveData = manager.contract.methods
+      .disapproveJob(jobId, "validator", EMPTY_PROOF)
+      .encodeABI();
+
+    for (let i = 0; i < cap; i += 1) {
+      await sendSigned(manager, validators[i], disapproveData);
+    }
+
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator", EMPTY_PROOF, { from: validators[cap].address }),
+      "ValidatorLimitReached"
+    );
+  });
+
+  it("completes successfully at the validator cap", async () => {
+    const cap = (await manager.MAX_VALIDATORS_PER_JOB()).toNumber();
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(cap - 1, { from: owner });
+
+    const payout = toBN(toWei("20"));
+    const jobId = await createJob(manager, token, employer, payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    const validators = Array.from({ length: cap }, () => web3.eth.accounts.create());
+    for (const validator of validators) {
+      await web3.eth.sendTransaction({
+        from: owner,
+        to: validator.address,
+        value: toWei("1"),
+      });
+      await manager.addAdditionalValidator(validator.address, { from: owner });
+    }
+
+    const disapproveData = manager.contract.methods
+      .disapproveJob(jobId, "validator", EMPTY_PROOF)
+      .encodeABI();
+    for (let i = 0; i < cap - 1; i += 1) {
+      await sendSigned(manager, validators[i], disapproveData);
+    }
+
+    const validateData = manager.contract.methods
+      .validateJob(jobId, "validator", EMPTY_PROOF)
+      .encodeABI();
+    await sendSigned(manager, validators[cap - 1], validateData, 2500000);
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should complete at the cap");
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent unbounded loops over the per-job validator list during settlement which can cause mainnet gas/DoS failures. 
- Make the validator-count limit explicit and enforceable so owner-configured thresholds cannot create unreachable or gas-exhausting settlement paths. 
- Apply a minimal, production-safe mitigation (hard cap + invariant checks) without changing public APIs beyond adding small custom errors.

### Description
- Add a conservative hard cap `MAX_VALIDATORS_PER_JOB = 50` and three custom errors `InvalidValidatorThresholds`, `ValidatorLimitReached`, and `ValidatorSetTooLarge` to `contracts/AGIJobManager.sol` to keep settlement loops provably bounded. 
- Enforce the cap when recording unique validator votes by calling `_enforceValidatorCapacity(job.validators.length)` in `validateJob` and `disapproveJob`, and validate owner-set thresholds via `_validateValidatorThresholds` (called from constructor and the two setter functions). 
- Add a defensive invariant in `_completeJob` that reverts with `ValidatorSetTooLarge` if `validators.length` exceeds the cap, preventing silent partial payouts and aiding diagnosability. 
- Update documentation to mention the validator cap and threshold rules (`docs/Security.md`), refresh the exported UI ABI to include new errors and the `MAX_VALIDATORS_PER_JOB` getter, and add `test/validatorCap.test.js` with coverage for threshold validation, cap enforcement, and completion-at-cap behavior.

### Testing
- Ran `npm run test` (which executes `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js`), and the full suite passed (102 passing). 
- Ran `npx truffle compile` and compilation succeeded with artifacts written (solc 0.8.33). 
- Exported UI ABI via `npm run ui:abi` to refresh `docs/ui/abi/AGIJobManager.json` which now includes the new errors and `MAX_VALIDATORS_PER_JOB`. 
- The new `test/validatorCap.test.js` was executed as part of the suite and validated: (a) setters reject thresholds that violate the cap, (b) additional votes revert when the cap is reached, and (c) a job can complete successfully when the validator count is at the cap.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d7611340c83338c15853d71fc17b1)