### PR TITLE
Add scenario lifecycle and marketplace tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -45,4 +45,18 @@ This allows tests to pass `_verifyOwnership` without external dependencies.
 - `test/securityRegression.test.js` — takeover prevention, vote rules, dispute behavior, transfer checks
 - `test/nftMarketplace.test.js` — list/purchase/delist flows
 - `test/adminOps.test.js` — pause, allowlists, blacklists, withdrawals
+- `test/scenarioLifecycle.marketplace.test.js` — scenario coverage for lifecycle, disputes, pause behavior, and marketplace invariants
 - Existing regression suites remain in `test/` for backward coverage.
+
+## Scenario coverage (contract-level)
+The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the contract in deterministic flows that map to the lifecycle diagram in the README:
+- **Create → apply → validate → complete** with escrow funding, payouts, reputation updates, and NFT issuance.
+- **Cancel** before assignment with escrow refunds and job deletion semantics.
+- **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
+- **Pause/unpause** behavior that blocks when-not-paused actions and resumes normal operation.
+- **Marketplace** listing/purchase flows, self-purchase behavior, and invariant checks (no double-purchase, invalid listings, insufficient allowance).
+
+Run it locally with the standard test command:
+```bash
+npx truffle test --network test test/scenarioLifecycle.marketplace.test.js
+```

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -1,0 +1,346 @@
+const assert = require("assert");
+const { expectRevert } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { rootNode } = require("./helpers/ens");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager scenario coverage", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB, moderator, buyer, other] = accounts;
+  let token;
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let manager;
+  let agiType;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    resolver = await MockResolver.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      rootNode("club-root"),
+      rootNode("agent-root"),
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+  });
+
+  async function createJobWithApproval(payout, ipfsHash = "ipfs-job") {
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob(ipfsHash, payout, 3600, "details", { from: employer });
+    return createTx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+  }
+
+  async function assignAndRequest(jobId, completionHash) {
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, completionHash, { from: agent });
+  }
+
+  it("completes the happy path with payouts, state updates, and NFT issuance", async () => {
+    const payout = toBN(toWei("100"));
+    await token.mint(employer, payout, { from: owner });
+    const balancesBefore = {
+      employer: await token.balanceOf(employer),
+      agent: await token.balanceOf(agent),
+      validatorA: await token.balanceOf(validatorA),
+      validatorB: await token.balanceOf(validatorB),
+      contract: await token.balanceOf(manager.address),
+    };
+
+    const jobId = await createJobWithApproval(payout);
+    await assignAndRequest(jobId, "ipfs-complete");
+
+    const applyJob = await manager.jobs(jobId);
+    assert.equal(applyJob.assignedAgent, agent, "assigned agent should be set");
+    assert.ok(toBN(applyJob.assignedAt).gt(toBN(0)), "assignedAt should be recorded");
+
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    const finalTx = await manager.validateJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+
+    const finalJob = await manager.jobs(jobId);
+    assert.strictEqual(finalJob.completed, true, "job should be completed");
+    assert.strictEqual(finalJob.completionRequested, true, "completionRequested should be true");
+
+    const jobCompleted = finalTx.logs.find((log) => log.event === "JobCompleted");
+    const nftIssued = finalTx.logs.find((log) => log.event === "NFTIssued");
+    assert.ok(jobCompleted, "JobCompleted event should be emitted");
+    assert.ok(nftIssued, "NFTIssued event should be emitted");
+
+    const tokenId = nftIssued.args.tokenId.toNumber();
+    const tokenUri = await manager.tokenURI(tokenId);
+    assert.equal(tokenUri, "ipfs://base/ipfs-complete", "token URI should match base + ipfs hash");
+
+    const nftOwner = await manager.ownerOf(tokenId);
+    assert.equal(nftOwner, employer, "employer should own the job NFT");
+
+    const agentExpected = payout.muln(92).divn(100);
+    const validatorExpected = payout.muln(8).divn(100).divn(2);
+    const agentBalance = await token.balanceOf(agent);
+    const validatorABalance = await token.balanceOf(validatorA);
+    const validatorBBalance = await token.balanceOf(validatorB);
+    assert.equal(agentBalance.toString(), agentExpected.toString(), "agent payout should match AGI type share");
+    assert.equal(validatorABalance.toString(), validatorExpected.toString(), "validator A reward mismatch");
+    assert.equal(validatorBBalance.toString(), validatorExpected.toString(), "validator B reward mismatch");
+
+    const balancesAfter = {
+      employer: await token.balanceOf(employer),
+      agent: await token.balanceOf(agent),
+      validatorA: await token.balanceOf(validatorA),
+      validatorB: await token.balanceOf(validatorB),
+      contract: await token.balanceOf(manager.address),
+    };
+
+    const employerDelta = balancesAfter.employer.sub(balancesBefore.employer);
+    const agentDelta = balancesAfter.agent.sub(balancesBefore.agent);
+    const validatorADelta = balancesAfter.validatorA.sub(balancesBefore.validatorA);
+    const validatorBDelta = balancesAfter.validatorB.sub(balancesBefore.validatorB);
+    const contractDelta = balancesAfter.contract.sub(balancesBefore.contract);
+
+    const totalDelta = employerDelta.add(agentDelta).add(validatorADelta).add(validatorBDelta).add(contractDelta);
+    assert.equal(totalDelta.toString(), "0", "token deltas should conserve payout accounting");
+
+    const agentReputation = await manager.reputation(agent);
+    const validatorReputation = await manager.reputation(validatorA);
+    assert.ok(agentReputation.gt(toBN(0)), "agent reputation should increase");
+    assert.ok(validatorReputation.gt(toBN(0)), "validator reputation should increase");
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }),
+      "InvalidState"
+    );
+  });
+
+  it("allows employer to cancel before assignment and refunds escrow", async () => {
+    const payout = toBN(toWei("12"));
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+
+    const cancelTx = await manager.cancelJob(jobId, { from: employer });
+    assert.ok(cancelTx.logs.find((log) => log.event === "JobCancelled"), "JobCancelled event should emit");
+
+    const job = await manager.jobs(jobId);
+    assert.equal(job.employer, "0x0000000000000000000000000000000000000000", "job should be deleted");
+
+    const employerBalance = await token.balanceOf(employer);
+    assert.equal(employerBalance.toString(), payout.toString(), "employer should be refunded escrow");
+  });
+
+  it("prevents cancellation after assignment or completion", async () => {
+    const payout = toBN(toWei("10"));
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(manager.cancelJob.call(jobId, { from: employer }), "InvalidState");
+
+    await manager.requestJobCompletion(jobId, "ipfs", { from: agent });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+
+    await expectCustomError(manager.cancelJob.call(jobId, { from: employer }), "InvalidState");
+  });
+
+  it("disputes via disapprovals and resolves agent win with payouts", async () => {
+    const payout = toBN(toWei("50"));
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await assignAndRequest(jobId, "ipfs-disputed");
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    const disputeTx = await manager.disapproveJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+    assert.ok(disputeTx.logs.find((log) => log.event === "JobDisputed"), "JobDisputed should emit");
+
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should complete after agent win");
+    assert.strictEqual(job.disputed, false, "disputed flag should clear");
+
+    const tokenId = (await manager.nextTokenId()).toNumber() - 1;
+    const ownerOfToken = await manager.ownerOf(tokenId);
+    assert.equal(ownerOfToken, employer, "employer should receive the NFT on agent win");
+  });
+
+  it("resolves employer-win disputes with refund and no NFT issuance", async () => {
+    const payout = toBN(toWei("30"));
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await manager.disputeJob(jobId, { from: employer });
+    await manager.resolveDispute(jobId, "employer win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should be closed after employer win");
+    assert.strictEqual(job.disputed, false, "disputed flag should clear");
+
+    const employerBalance = await token.balanceOf(employer);
+    assert.equal(employerBalance.toString(), payout.toString(), "employer should be refunded");
+
+    assert.equal((await manager.nextTokenId()).toNumber(), 0, "no NFT should be minted");
+    await expectRevert(manager.ownerOf(0), "ERC721: invalid token ID");
+  });
+
+  it("clears disputed flag on non-canonical resolution and returns to in-progress", async () => {
+    const payout = toBN(toWei("20"));
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await assignAndRequest(jobId, "ipfs-neutral");
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await manager.resolveDispute(jobId, "needs more work", { from: moderator });
+
+    const midJob = await manager.jobs(jobId);
+    assert.strictEqual(midJob.disputed, false, "disputed flag should clear");
+    assert.strictEqual(midJob.completed, false, "job should remain in progress");
+
+    await manager.validateJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+    const finalJob = await manager.jobs(jobId);
+    assert.strictEqual(finalJob.completed, true, "job should complete after follow-up validation");
+  });
+
+  it("pauses state-changing actions and resumes after unpause", async () => {
+    const payout = toBN(toWei("8"));
+    await token.mint(employer, payout, { from: owner });
+
+    await manager.pause({ from: owner });
+
+    await expectRevert(
+      manager.createJob("ipfs-job", payout, 3600, "details", { from: employer }),
+      "Pausable: paused"
+    );
+
+    await manager.unpause({ from: owner });
+    const jobId = await createJobWithApproval(payout, "ipfs-job");
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await manager.pause({ from: owner });
+    await expectRevert(
+      manager.requestJobCompletion(jobId, "ipfs-paused", { from: agent }),
+      "Pausable: paused"
+    );
+    await expectRevert(
+      manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }),
+      "Pausable: paused"
+    );
+    await expectRevert(
+      manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }),
+      "Pausable: paused"
+    );
+    await expectRevert(manager.disputeJob(jobId, { from: employer }), "Pausable: paused");
+    await expectRevert(manager.contributeToRewardPool(payout, { from: employer }), "Pausable: paused");
+
+    await manager.unpause({ from: owner });
+    await manager.requestJobCompletion(jobId, "ipfs-resumed", { from: agent });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should complete after unpause");
+  });
+
+  it("lists and purchases NFTs with marketplace invariants", async () => {
+    const payout = toBN(toWei("40"));
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await assignAndRequest(jobId, "ipfs-market");
+    const mintTx = await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    const tokenId = mintTx.logs.find((log) => log.event === "NFTIssued").args.tokenId.toNumber();
+
+    const price = toBN(toWei("5"));
+    await manager.listNFT(tokenId, price, { from: employer });
+    const listing = await manager.listings(tokenId);
+    assert.strictEqual(listing.isActive, true, "listing should be active");
+    assert.equal(listing.seller, employer, "seller should be employer");
+    assert.equal(listing.price.toString(), price.toString(), "listing price should match");
+
+    await token.mint(buyer, price, { from: owner });
+    await token.approve(manager.address, price, { from: buyer });
+    await manager.purchaseNFT(tokenId, { from: buyer });
+
+    const newOwner = await manager.ownerOf(tokenId);
+    assert.equal(newOwner, buyer, "buyer should own NFT after purchase");
+
+    const postListing = await manager.listings(tokenId);
+    assert.strictEqual(postListing.isActive, false, "listing should be inactive after purchase");
+
+    await expectCustomError(manager.purchaseNFT.call(tokenId, { from: buyer }), "InvalidState");
+  });
+
+  it("blocks invalid marketplace actions and documents self-purchase behavior", async () => {
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    const payout = toBN(toWei("20"));
+
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await assignAndRequest(jobId, "ipfs-market-2");
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+
+    const tokenId = (await manager.nextTokenId()).toNumber() - 1;
+    await expectCustomError(manager.listNFT.call(tokenId, toBN(toWei("4")), { from: other }), "NotAuthorized");
+
+    const price = toBN(toWei("4"));
+    await manager.listNFT(tokenId, price, { from: employer });
+
+    await expectCustomError(manager.purchaseNFT.call(tokenId + 1, { from: buyer }), "InvalidState");
+
+    await token.mint(buyer, price, { from: owner });
+    await expectCustomError(manager.purchaseNFT.call(tokenId, { from: buyer }), "TransferFailed");
+
+    await token.mint(employer, price, { from: owner });
+    await token.approve(manager.address, price, { from: employer });
+    await manager.purchaseNFT(tokenId, { from: employer });
+
+    const listing = await manager.listings(tokenId);
+    assert.strictEqual(listing.isActive, false, "listing should clear after self-purchase");
+    const ownerOfToken = await manager.ownerOf(tokenId);
+    assert.equal(ownerOfToken, employer, "self-purchase keeps NFT ownership unchanged");
+  });
+
+  it("prevents validators from approving and disapproving the same job", async () => {
+    const payout = toBN(toWei("15"));
+    await token.mint(employer, payout, { from: owner });
+    const jobId = await createJobWithApproval(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }),
+      "InvalidState"
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Strengthen contract-level, deterministic scenario coverage for job lifecycle, dispute resolution, pause semantics, and the NFT marketplace to catch regressions in economic behavior and state transitions.
- Keep changes minimal and non-invasive by adding tests and mocks rather than modifying production contracts.

### Description
- Add a new Truffle test suite `test/scenarioLifecycle.marketplace.test.js` that covers: happy-path create→apply→validate→complete (escrow, payouts, reputation, NFT issuance), cancel-before-assignment refunds, dispute flows (disapproval thresholds, manual disputes, moderator resolutions for agent/employer/neutral outcomes), pause/unpause protections, and marketplace listing/purchase invariants including self-purchase behavior and negative cases.
- Reuse existing test helpers (`test/helpers/ens.js`, `test/helpers/errors.js`) and existing test mocks (`MockERC20`, `MockERC721`, `MockENS`, `MockResolver`, `MockNameWrapper`) to ensure deterministic ownership/allowlist behavior without external RPCs.
- Use the repo’s lightweight custom error helper (`expectCustomError`) to assert custom Solidity error selectors in negative tests.
- Document the new scenario suite in `docs/TESTING.md` with a short mapping to the README lifecycle diagram and the command to run the scenario test.

### Testing
- `npm install` completed (warnings only) and `npm run build` compiled contracts successfully with `solc: 0.8.33`.
- Full test suite via the project test task produced a passing run locally: `npm test` / Truffle test showed the existing suite passing (reported 107 passing tests).
- New scenario file run directly: `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` completed successfully with `10 passing` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697d88d77640833396e04278aad0287b)