### PR TITLE
Strengthen scenario lifecycle and marketplace test assertions

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -55,6 +55,8 @@ The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the 
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
 - **Pause/unpause** behavior that blocks when-not-paused actions and resumes normal operation.
 - **Marketplace** listing/purchase flows, self-purchase behavior, and invariant checks (no double-purchase, invalid listings, insufficient allowance).
+- **Economic assertions** including escrow conservation, marketplace payout transfers, and zero remaining contract balance after expected payouts.
+- **Event assertions** for JobCreated/JobApplied/NFTPurchased to keep regressions visible at the log level.
 
 Run it locally with the standard test command:
 ```bash


### PR DESCRIPTION
### Motivation
- Increase contract-level, deterministic scenario coverage for job lifecycle and NFT marketplace flows to catch regressions at the economic and state-machine level.
- Verify escrow conservation, correct payout transfers, and event emissions so marketplace and dispute paths remain auditable and robust.

### Description
- Expanded `test/scenarioLifecycle.marketplace.test.js` helpers to return transaction receipts and added event assertions for `JobCreated` and `JobApplied` to make log-level regressions visible. 
- Added escrow and balance assertions before/after happy-path completion, dispute resolutions (agent/employer wins), and NFT purchases to ensure no retained funds or double-payouts. 
- Added marketplace purchase assertions that verify buyer/seller token deltas and that listings clear and ownership transfers as expected. 
- Documented the new economic and event assertions in `docs/TESTING.md`; all production contracts were left unchanged.

### Testing
- `npm install` was used to populate dependencies because `npm ci` fails on this environment due to a platform-only `fsevents` dependency; build and test commands were run on a local in-process chain. 
- `npm run build` (Truffle compile) completed successfully and produced artifacts. 
- The repository-level test suite was run earlier via `npm test` and reported success (existing suite run: 117 passing). 
- The modified scenario test was run directly with `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` and passed (10 passing), confirming the new assertions are deterministic and green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e00e2fb848333aedcefa6c0339406)