### PR TITLE
Add direct-validator completion and vote-order invariants to scenario tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,6 +51,7 @@ This allows tests to pass `_verifyOwnership` without external dependencies.
 ## Scenario coverage (contract-level)
 The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the contract in deterministic flows that map to the lifecycle diagram in the README:
 - **Create → apply → validate → complete** with escrow funding, payouts, reputation updates, and NFT issuance.
+- **Assigned → validate → complete** without a completion request to cover the direct validator approval path.
 - **Cancel** before assignment with escrow refunds and job deletion semantics.
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
 - **Pause/unpause** behavior that blocks when-not-paused actions and resumes normal operation.


### PR DESCRIPTION
### Motivation
- Strengthen contract-level scenario coverage to exercise the direct validator approval path (Assigned → validate → complete) and guard against validator vote-order regressions (disapprove → approve). These protect economic/state-machine invariants described in the README lifecycle diagram.

### Description
- Added a deterministic scenario test that verifies a job can complete and mint its NFT solely from validator approvals without an explicit `requestJobCompletion` call (`test/scenarioLifecycle.marketplace.test.js`).
- Added a test asserting validators cannot later `validateJob` after they have `disapproveJob`ed the same job to prevent mixed voting (`test/scenarioLifecycle.marketplace.test.js`).
- Documented the direct validator-completion path in `docs/TESTING.md` so the scenario suite intent is explicit.
- Files changed: `test/scenarioLifecycle.marketplace.test.js`, `docs/TESTING.md`.

### Testing
- `npm ci` — failed on this environment due to platform mismatch for `fsevents@2.3.2` (macOS-only dependency), so CI should continue to use the repo's existing pipeline which uses `npm ci` on supported environments; local install used the next command instead. (Error: unsupported platform for fsevents@2.3.2: wanted {"os":"darwin"} (current: {"os":"linux"}).)
- `npm install` — succeeded (installed dev deps; audit warnings unrelated to these tests).
- `npm run build` — succeeded and compiled contracts with `solc 0.8.33` (artifacts written to `build/contracts`).
- `npm test` — full suite compiled and ran successfully in this environment (previous run showed 117 passing across suites before the final focused run).
- `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` — focused scenario suite passed: `12 passing` (the new tests included) and completed deterministically on the in-process Ganache (`test`) network.

Commands run (local results):
- `npm ci` (failed on this Linux host due to `fsevents` platform restriction)
- `npm install` (succeeded)
- `npm run build` (succeeded, contracts compiled)
- `npm test` (succeeded; full test suite previously passed)
- `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` (succeeded: `12 passing`)

All new tests are self-contained, deterministic against the in-process Ganache provider, and do not require external RPC keys.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e04c6b30083338ea8d5e41c54a5c0)