### PR TITLE
docs: document validator cap, clarify ERC‑20 semantics, regenerate interface docs

### DIFF
--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -10,6 +10,7 @@
 ## Functions
 | Signature | State mutability | Returns |
 | --- | --- | --- |
+| `MAX_VALIDATORS_PER_JOB()` | view | uint256 |
 | `additionalAgents(address)` | view | bool |
 | `additionalText1()` | view | string |
 | `additionalText2()` | view | string |
@@ -137,7 +138,10 @@
 | `Blacklisted()` | — |
 | `InvalidParameters()` | — |
 | `InvalidState()` | — |
+| `InvalidValidatorThresholds()` | — |
 | `JobNotFound()` | — |
 | `NotAuthorized()` | — |
 | `NotModerator()` | — |
 | `TransferFailed()` | — |
+| `ValidatorLimitReached()` | — |
+| `ValidatorSetTooLarge()` | — |

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -37,7 +37,7 @@ Marketplace purchases are guarded because `purchaseNFT` crosses an external ERC�
 ## Known limitations and assumptions
 - **Root immutability**: there are no on-chain setters for root nodes or Merkle roots after deployment. Misconfiguration requires redeployment.
 - **ENS dependency**: ownership checks rely on ENS registry, NameWrapper, and resolver behavior.
-- **ERC‑20 compatibility**: tokens must return a boolean for `transfer` and `transferFrom`.
+- **ERC‑20 compatibility**: transfers must either return `true` or return no data; calls that revert, return `false`, or return malformed data revert.
 - **Agent payout can be zero**: if no AGI type applies, the agent payout percentage is zero and residual funds remain in the contract.
 - **Validator payout sharing**: all validators who voted share equally; there is no weighting or slashing.
 - **Validator cap**: each job records at most `MAX_VALIDATORS_PER_JOB` unique validators to bound settlement gas. Owner-set thresholds must fit within this cap (each ≤ cap and approvals + disapprovals ≤ cap) to keep completion/dispute reachable without exceeding the loop bound.


### PR DESCRIPTION
### Motivation
- Make the contract documentation and ABI-derived interface fully consistent with on-chain invariants around validator capacity and related custom errors. 
- Clarify ERC‑20 transfer semantics in the security model to avoid ambiguity for integrators and auditors. 
- Keep docs factual and aligned with the compiled ABI and test suite so operators can rely on them for deployments and verification.

### Description
- Updated `docs/AGIJobManager.md` to document `MAX_VALIDATORS_PER_JOB`, the per-job validator cap, the owner-set threshold constraints, and the related custom errors (`InvalidValidatorThresholds`, `ValidatorLimitReached`, `ValidatorSetTooLarge`).
- Clarified ERC‑20 transfer compatibility in `docs/Security.md` to state that transfers must either return `true` or return no data and that calls which revert, return `false`, or return malformed data revert with `TransferFailed`.
- Regenerated and committed the ABI-derived `docs/Interface.md` so the published interface includes `MAX_VALIDATORS_PER_JOB()` and the current custom error set.
- Changes are documentation-only and do not modify any contract source files or runtime behavior; the contract `contracts/AGIJobManager.sol` was not edited in any way.

### Testing
- Ran `npm install` (dependencies installed; audit warnings reported), `npm run build` (ran `truffle compile` and compiled successfully with solc 0.8.33), and `npm test` (test suite passed: `119 passing`).
- Regenerated interface docs with `npm run docs:interface`, which wrote `docs/Interface.md` from `build/contracts/AGIJobManager.json`.
- CI workflow was detected at `.github/workflows/ci.yml`, so no CI badge was added to the README as no badge changes were part of this PR.

Files changed: `docs/AGIJobManager.md`, `docs/Security.md`, `docs/Interface.md`.

Commands run and results: `npm install` (completed; audit warnings), `npm run build` (compile succeeded), `npm test` (119 passing), `npm run docs:interface` (wrote `docs/Interface.md`).

Known gaps / next steps: verify README badge set is still accurate against project requirements if any additional badge additions are desired, and optionally regenerate any consumer-facing docs if downstream tooling relies on a different interface format.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e108f473883339f71afa06efb61be)