### PR TITLE
Add ops parameter safety checklist and invariant checker

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,6 +183,7 @@ Start here:
 - **Non‑technical user guides**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/ParameterSafety.md`](docs/ParameterSafety.md)
+- [`docs/ops/parameter-safety.md`](docs/ops/parameter-safety.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
 - [`docs/Testing.md`](docs/Testing.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -51,6 +51,7 @@ This documentation set targets engineers, integrators, operators, and auditors *
 - **NFT Marketplace**: [`roles/NFT_MARKETPLACE.md`](roles/NFT_MARKETPLACE.md)
 
 ## Operations and validation
+- **Parameter safety & stuck-funds checklist (ops)**: [`ops/parameter-safety.md`](ops/parameter-safety.md)
 - **Regression tests summary**: [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md)
 - **FAQ**: [`FAQ.md`](FAQ.md)
 

--- a/scripts/ops/validate-params.js
+++ b/scripts/ops/validate-params.js
@@ -1,0 +1,199 @@
+const assert = require("assert");
+
+const CHECK = {
+  PASS: "PASS",
+  FAIL: "FAIL",
+  WARN: "WARN",
+};
+
+function evaluateInvariants({
+  requiredValidatorApprovals,
+  requiredValidatorDisapprovals,
+  maxValidators,
+  validationRewardPercentage,
+  maxJobPayout,
+  jobDurationLimit,
+  maxAgentPayoutPercentage,
+  agiToken,
+  ens,
+  nameWrapper,
+}) {
+  const results = [];
+  const approvals = Number(requiredValidatorApprovals);
+  const disapprovals = Number(requiredValidatorDisapprovals);
+  const maxValidatorsNum = Number(maxValidators);
+  const validationRewardNum = Number(validationRewardPercentage);
+  const maxAgentPayoutNum = Number(maxAgentPayoutPercentage);
+
+  results.push({
+    key: "agiToken",
+    status: agiToken && agiToken !== "0x0000000000000000000000000000000000000000" ? CHECK.PASS : CHECK.FAIL,
+    message: "agiToken address must be non-zero",
+  });
+  results.push({
+    key: "ens",
+    status: ens && ens !== "0x0000000000000000000000000000000000000000" ? CHECK.PASS : CHECK.WARN,
+    message: "ENS address should be set for on-chain ownership checks",
+  });
+  results.push({
+    key: "nameWrapper",
+    status: nameWrapper && nameWrapper !== "0x0000000000000000000000000000000000000000" ? CHECK.PASS : CHECK.WARN,
+    message: "NameWrapper address should be set for wrapped ENS ownership checks",
+  });
+  results.push({
+    key: "validatorThresholds",
+    status:
+      approvals <= maxValidatorsNum &&
+      disapprovals <= maxValidatorsNum &&
+      approvals + disapprovals <= maxValidatorsNum
+        ? CHECK.PASS
+        : CHECK.FAIL,
+    message: "Validator thresholds must respect MAX_VALIDATORS_PER_JOB",
+  });
+  results.push({
+    key: "validatorApprovalsNonZero",
+    status: approvals > 0 ? CHECK.PASS : CHECK.WARN,
+    message: "requiredValidatorApprovals is zero (single approval completes jobs)",
+  });
+  results.push({
+    key: "validatorDisapprovalsNonZero",
+    status: disapprovals > 0 ? CHECK.PASS : CHECK.WARN,
+    message: "requiredValidatorDisapprovals is zero (single disapproval triggers dispute)",
+  });
+  results.push({
+    key: "validationRewardPercentage",
+    status: validationRewardNum > 0 && validationRewardNum <= 100 ? CHECK.PASS : CHECK.FAIL,
+    message: "validationRewardPercentage must be in 1..100",
+  });
+  results.push({
+    key: "maxJobPayout",
+    status: BigInt(maxJobPayout) > 0n ? CHECK.PASS : CHECK.FAIL,
+    message: "maxJobPayout must be > 0",
+  });
+  results.push({
+    key: "jobDurationLimit",
+    status: BigInt(jobDurationLimit) > 0n ? CHECK.PASS : CHECK.FAIL,
+    message: "jobDurationLimit must be > 0",
+  });
+  results.push({
+    key: "combinedPayouts",
+    status: validationRewardNum + maxAgentPayoutNum <= 100 ? CHECK.PASS : CHECK.FAIL,
+    message: "validationRewardPercentage + maxAgentPayoutPercentage must be <= 100",
+  });
+
+  return results;
+}
+
+function formatResult(result) {
+  const icon = result.status === CHECK.PASS ? "✅" : result.status === CHECK.WARN ? "⚠️" : "❌";
+  return `${icon} ${result.key}: ${result.message}`;
+}
+
+function parseArgs(argv) {
+  const args = { fromBlock: 0 };
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--address" || arg === "-a") {
+      args.address = argv[i + 1];
+      i += 1;
+    } else if (arg === "--from-block") {
+      args.fromBlock = Number(argv[i + 1]);
+      i += 1;
+    }
+  }
+  return args;
+}
+
+async function loadMaxAgentPayoutPercentage(contract, fromBlock) {
+  const events = await contract.getPastEvents("AGITypeUpdated", {
+    fromBlock,
+    toBlock: "latest",
+  });
+  const payoutByNft = new Map();
+  for (const event of events) {
+    payoutByNft.set(event.returnValues.nftAddress.toLowerCase(), Number(event.returnValues.payoutPercentage));
+  }
+  let maxPayout = 0;
+  for (const value of payoutByNft.values()) {
+    if (value > maxPayout) {
+      maxPayout = value;
+    }
+  }
+  return maxPayout;
+}
+
+module.exports = async function validateParams(callback) {
+  try {
+    assert(global.artifacts, "This script must be run via truffle exec");
+    const { address, fromBlock } = parseArgs(process.argv);
+    if (!address) {
+      throw new Error("Missing --address <AGIJobManagerAddress>");
+    }
+
+    const AGIJobManager = artifacts.require("AGIJobManager");
+    const instance = await AGIJobManager.at(address);
+
+    const [
+      owner,
+      paused,
+      agiToken,
+      ens,
+      nameWrapper,
+      requiredValidatorApprovals,
+      requiredValidatorDisapprovals,
+      validationRewardPercentage,
+      maxJobPayout,
+      jobDurationLimit,
+      maxValidators,
+    ] = await Promise.all([
+      instance.owner(),
+      instance.paused(),
+      instance.agiToken(),
+      instance.ens(),
+      instance.nameWrapper(),
+      instance.requiredValidatorApprovals(),
+      instance.requiredValidatorDisapprovals(),
+      instance.validationRewardPercentage(),
+      instance.maxJobPayout(),
+      instance.jobDurationLimit(),
+      instance.MAX_VALIDATORS_PER_JOB(),
+    ]);
+
+    const maxAgentPayoutPercentage = await loadMaxAgentPayoutPercentage(instance, fromBlock);
+
+    const results = evaluateInvariants({
+      requiredValidatorApprovals,
+      requiredValidatorDisapprovals,
+      maxValidators,
+      validationRewardPercentage,
+      maxJobPayout,
+      jobDurationLimit,
+      maxAgentPayoutPercentage,
+      agiToken,
+      ens,
+      nameWrapper,
+    });
+
+    console.log("AGIJobManager parameter check:");
+    console.log(`- contract: ${address}`);
+    console.log(`- owner: ${owner}`);
+    console.log(`- paused: ${paused}`);
+    console.log(`- maxAgentPayoutPercentage (from events): ${maxAgentPayoutPercentage}`);
+    for (const result of results) {
+      console.log(formatResult(result));
+    }
+
+    const failed = results.filter((result) => result.status === CHECK.FAIL);
+    if (failed.length > 0) {
+      process.exitCode = 1;
+    }
+
+    callback();
+  } catch (error) {
+    callback(error);
+  }
+};
+
+module.exports.evaluateInvariants = evaluateInvariants;
+module.exports.formatResult = formatResult;
+module.exports.CHECK = CHECK;

--- a/test/validate-params-script.test.js
+++ b/test/validate-params-script.test.js
@@ -1,0 +1,22 @@
+const assert = require("assert");
+const { evaluateInvariants, CHECK } = require("../scripts/ops/validate-params");
+
+describe("validate-params invariant evaluator", () => {
+  it("flags invalid combined payout percentage", () => {
+    const results = evaluateInvariants({
+      requiredValidatorApprovals: 2,
+      requiredValidatorDisapprovals: 2,
+      maxValidators: 50,
+      validationRewardPercentage: 20,
+      maxJobPayout: 1,
+      jobDurationLimit: 1,
+      maxAgentPayoutPercentage: 90,
+      agiToken: "0x0000000000000000000000000000000000000001",
+      ens: "0x0000000000000000000000000000000000000001",
+      nameWrapper: "0x0000000000000000000000000000000000000001",
+    });
+
+    const combined = results.find((result) => result.key === "combinedPayouts");
+    assert.strictEqual(combined.status, CHECK.FAIL);
+  });
+});


### PR DESCRIPTION
### Motivation

- Provide operators a production-grade, versioned “parameter safety & stuck funds” analysis and runbook tied directly to `contracts/AGIJobManager.sol` to prevent misconfiguration and to document recovery paths. 
- Surface every parameter/lever that can affect job settlement, disputes, marketplace flows or escrow and make it easy to validate those invariants pre/post-deploy. 
- Offer a small deterministic helper that can be executed against a deployed instance to fail-fast when critical invariants are violated.

### Description

- Added an operations checklist and analysis at `docs/ops/parameter-safety.md` that enumerates parameters, their uses, recommended safe ranges, stuck-funds scenarios, a recovery playbook, pre/post-deploy verification reads, common revert explanations, and operational assumptions. 
- Added a small Truffle `exec` helper `scripts/ops/validate-params.js` that reads contract state (and `AGITypeUpdated` events) and prints pass/warn/fail checks, exiting non-zero when any invariant fails. 
- Added a minimal unit test `test/validate-params-script.test.js` that exercises the invariant evaluator logic locally (no network required). 
- Linked the new ops checklist from `README.md` and `docs/README.md` so the guidance is discoverable from the main docs index; no contract or secret changes were made.

### Testing

- Ran `npm run build` (Truffle compile) and it completed successfully with artifacts written to `build/contracts`. 
- Ran the repository test suite via `npm test`, which executed contract tests and the new invariant evaluator unit test, with all tests passing (existing suite plus added test reported as passing). 
- The new script is designed to be used as `truffle exec scripts/ops/validate-params.js --network <network> --address <AGIJobManagerAddress>` and will set a non-zero exit code if any invariant check fails for use in CI or release checklists.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e1a1f37c88333aa15fa3b809d2b89)