### PR TITLE
Update mainnet deployment timestamp

### DIFF
--- a/docs/deployments/mainnet.json
+++ b/docs/deployments/mainnet.json
@@ -3,5 +3,5 @@
   "chainId": 1,
   "agiJobManager": "",
   "legacyV0": "0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477",
-  "updatedAt": "2026-01-30T00:07:31Z"
+  "updatedAt": "2026-01-31T17:03:23Z"
 }


### PR DESCRIPTION
### Motivation
- Refresh the canonical mainnet deployments record to reflect a recent review/update timestamp.

### Description
- Update `docs/deployments/mainnet.json` by setting the `updatedAt` field to the current ISO timestamp.

### Testing
- Ran `npm ci` and `npm ci --omit=optional`, both failed due to `fsevents` being platform-conditional (Darwin) which prevented a full install.
- Ran `npx truffle compile` and `npx truffle test`, both failed due to missing dev environment setup (`dotenv` not installed) because `npm ci` did not complete.
- Performed a local UI smoke check by serving `docs/` with `python3 -m http.server 8000` and confirmed `http://localhost:8000/ui/agijobmanager.html` returned HTTP 200.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e35485d6083339de188f1039bed53)