### PR TITLE
Add neutral-dispute escrow assertions to scenario tests

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -54,6 +54,7 @@ The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the 
 - **Assigned → validate → complete** without a completion request to cover the direct validator approval path.
 - **Cancel** before assignment with escrow refunds and job deletion semantics.
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
+- **Neutral dispute escrow** behavior (funds remain locked until validators complete the job after a non-canonical resolution).
 - **Pause/unpause** behavior that blocks when-not-paused actions and resumes normal operation.
 - **Marketplace** listing/purchase flows, self-purchase behavior, and invariant checks (no double-purchase, invalid listings, insufficient allowance).
 - **Economic assertions** including escrow conservation, marketplace payout transfers, and zero remaining contract balance after expected payouts.


### PR DESCRIPTION
### Motivation
- Strengthen contract-level scenario coverage for dispute behaviors by asserting escrow preservation on non-canonical (neutral) dispute resolutions and preventing follow-on actions after employer-win resolutions.
- Keep CI green and avoid production contract changes by adding deterministic tests and small documentation updates only.

### Description
- Added assertions to `test/scenarioLifecycle.marketplace.test.js` that verify employer-win disputes close the job and block later validator actions via a custom-error check for `InvalidState`.
- Added a new scenario test in `test/scenarioLifecycle.marketplace.test.js` that drives a neutral dispute resolution and asserts escrow remains locked until subsequent validator completion triggers payouts and NFT issuance.
- Documented the neutral-dispute escrow behavior in `docs/TESTING.md` so the scenarios map clearly to the lifecycle and marketplace flows.

### Testing
- `npm ci` failed on this environment due to platform-specific optional dependency (`fsevents@2.3.2`), error: `EBADPLATFORM` (macOS-only); this is non-blocking for CI which uses compatible runners.
- `npm install` completed successfully and populated project dependencies.
- `npm run build` (Truffle compile) completed successfully and produced artifacts (solc 0.8.33); compile warnings only.
- `npm test` (full suite) completed successfully; test run reported `149 passing`.
- Targeted run `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` completed successfully; test run reported `13 passing` including the new neutral-dispute and employer-win checks.

Files changed:
- `test/scenarioLifecycle.marketplace.test.js` — added neutral-dispute escrow scenario and employer-win validation guard.
- `docs/TESTING.md` — documented neutral-dispute escrow coverage.

Run locally:
- `npm install`
- `npm run build`
- `npx truffle test --network test test/scenarioLifecycle.marketplace.test.js` (expected: passing tests shown above)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e392453648333aa6a95c74f6bb2fc)