### PR TITLE
Block completion resubmission without fresh review window

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ stateDiagram-v2
 
     Assigned --> Completed: validateJob (approval threshold)
     CompletionRequested --> Completed: validateJob (approval threshold)
+    CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
 
     Assigned --> Disputed: disapproveJob (disapproval threshold)
     CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
@@ -56,6 +57,9 @@ stateDiagram-v2
     Disputed --> Completed: resolveDispute("agent win")
     Disputed --> Completed: resolveDispute("employer win")
     Disputed --> Assigned: resolveDispute(other)
+    Disputed --> Completed: resolveStaleDispute (owner, paused, timeout)
+
+    Assigned --> Expired: expireJob (timeout, no completion request)
 
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -24,6 +24,9 @@ npx ganache -p 8545
 npx truffle compile
 ```
 
+By default the Truffle config enables `viaIR` to avoid stack-depth limits in the contract bytecode generator.
+If you need to disable it for comparison, set `SOLC_VIA_IR=false` in your environment.
+
 ## Run the full test suite
 
 ```bash

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -146,6 +146,10 @@ connected wallet matches `owner()`. Every admin action:
   - `jobDurationLimit` (seconds)
   - `premiumReputationThreshold`
 
+### Liveness timeout actions (not in UI yet)
+- `expireJob` (anyone) and `finalizeJob` (agent/employer) are **not** exposed in the UI; use Truffle console or scripts.
+- `resolveStaleDispute` (owner-only, paused) is **not** exposed in the UI; use a controlled admin workflow.
+
 > Moderators only have on-chain powers for `resolveDispute`. The UI does **not** expose moderator-only actions in the admin panel.
 
 ## Admin operations (CLI / Truffle)

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -195,6 +195,25 @@
         {
           "indexed": false,
           "internalType": "uint256",
+          "name": "oldPeriod",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newPeriod",
+          "type": "uint256"
+        }
+      ],
+      "name": "CompletionReviewPeriodUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
           "name": "jobId",
           "type": "uint256"
         },
@@ -212,6 +231,50 @@
         }
       ],
       "name": "DisputeResolved",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldPeriod",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newPeriod",
+          "type": "uint256"
+        }
+      ],
+      "name": "DisputeReviewPeriodUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "resolver",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "employerWins",
+          "type": "bool"
+        }
+      ],
+      "name": "DisputeTimeoutResolved",
       "type": "event"
     },
     {
@@ -363,6 +426,62 @@
         }
       ],
       "name": "JobDisputed",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "employer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "agent",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "payout",
+          "type": "uint256"
+        }
+      ],
+      "name": "JobExpired",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "agent",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "payout",
+          "type": "uint256"
+        }
+      ],
+      "name": "JobFinalized",
       "type": "event"
     },
     {
@@ -653,6 +772,19 @@
     },
     {
       "inputs": [],
+      "name": "MAX_REVIEW_PERIOD",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "MAX_VALIDATORS_PER_JOB",
       "outputs": [
         {
@@ -894,12 +1026,38 @@
     },
     {
       "inputs": [],
+      "name": "completionReviewPeriod",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "contactEmail",
       "outputs": [
         {
           "internalType": "string",
           "name": "",
           "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "disputeReviewPeriod",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -1048,6 +1206,21 @@
           "internalType": "string",
           "name": "details",
           "type": "string"
+        },
+        {
+          "internalType": "uint256",
+          "name": "completionRequestedAt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "disputedAt",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "expired",
+          "type": "bool"
         }
       ],
       "stateMutability": "view",
@@ -1663,6 +1836,24 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
+          "name": "_jobId",
+          "type": "uint256"
+        },
+        {
+          "internalType": "bool",
+          "name": "employerWins",
+          "type": "bool"
+        }
+      ],
+      "name": "resolveStaleDispute",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "address",
           "name": "_agent",
           "type": "address"
@@ -1829,6 +2020,32 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
+          "name": "_period",
+          "type": "uint256"
+        }
+      ],
+      "name": "setCompletionReviewPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_period",
+          "type": "uint256"
+        }
+      ],
+      "name": "setDisputeReviewPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "string",
           "name": "_hash",
           "type": "string"
@@ -1942,6 +2159,32 @@
         }
       ],
       "name": "cancelJob",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_jobId",
+          "type": "uint256"
+        }
+      ],
+      "name": "expireJob",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_jobId",
+          "type": "uint256"
+        }
+      ],
+      "name": "finalizeJob",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -1,0 +1,194 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockERC721 = artifacts.require("MockERC721");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { rootNode } = require("./helpers/ens");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+contract("AGIJobManager liveness timeouts", (accounts) => {
+  const [owner, employer, agent, validator, moderator, other] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      rootNode("club-root"),
+      rootNode("agent-root"),
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.setCompletionReviewPeriod(100, { from: owner });
+    await manager.setDisputeReviewPeriod(100, { from: owner });
+  });
+
+  async function createJob(payout, duration = 1000) {
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, duration, "details", { from: employer });
+    const jobId = tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+    return jobId;
+  }
+
+  it("expires jobs after the deadline when completion was never requested", async () => {
+    const payout = toBN(toWei("10"));
+    await token.mint(employer, payout, { from: owner });
+
+    const jobId = await createJob(payout, 100);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await advanceTime(120);
+
+    const employerBefore = await token.balanceOf(employer);
+    await manager.expireJob(jobId, { from: other });
+    const employerAfter = await token.balanceOf(employer);
+    assert.equal(employerAfter.toString(), employerBefore.add(payout).toString(), "employer should be refunded");
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.expired, true, "job should be marked expired");
+    assert.strictEqual(job.completed, false, "job should not be marked completed");
+
+    await expectCustomError(manager.expireJob.call(jobId, { from: other }), "InvalidState");
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidState"
+    );
+    await expectCustomError(
+      manager.requestJobCompletion.call(jobId, "ipfs-complete", { from: agent }),
+      "InvalidState"
+    );
+  });
+
+  it("finalizes completion after the review window when validators are silent", async () => {
+    const payout = toBN(toWei("25"));
+    await token.mint(employer, payout, { from: owner });
+
+    const jobId = await createJob(payout, 1000);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+
+    await advanceTime(120);
+
+    const agentBefore = await token.balanceOf(agent);
+    await manager.finalizeJob(jobId, { from: agent });
+    const agentAfter = await token.balanceOf(agent);
+
+    const expected = payout.muln(90).divn(100);
+    assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid after finalization");
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should be completed");
+    assert.strictEqual(job.disputed, false, "job should not be disputed");
+
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
+  });
+
+  it("blocks finalize when validators have already acted", async () => {
+    const payout = toBN(toWei("5"));
+    await token.mint(employer, payout, { from: owner });
+
+    const jobId = await createJob(payout, 1000);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+
+    await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await advanceTime(120);
+
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
+  });
+
+  it("rejects expiry after completion was requested and blocks finalize when disputed", async () => {
+    const payout = toBN(toWei("7"));
+    await token.mint(employer, payout, { from: owner });
+
+    const jobId = await createJob(payout, 100);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+
+    await advanceTime(120);
+    await expectCustomError(manager.expireJob.call(jobId, { from: other }), "InvalidState");
+
+    await manager.disputeJob(jobId, { from: employer });
+    await advanceTime(120);
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
+  });
+
+  it("allows the owner to resolve stale disputes only after the dispute review period", async () => {
+    const payout = toBN(toWei("9"));
+    await token.mint(employer, payout, { from: owner });
+
+    const jobId = await createJob(payout, 1000);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+
+    await manager.pause({ from: owner });
+    await advanceTime(120);
+
+    const employerBefore = await token.balanceOf(employer);
+    await manager.resolveStaleDispute(jobId, true, { from: owner });
+    const employerAfter = await token.balanceOf(employer);
+
+    assert.equal(employerAfter.sub(employerBefore).toString(), payout.toString(), "employer should be refunded");
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should be completed after timeout resolution");
+    assert.strictEqual(job.disputed, false, "job should no longer be disputed");
+  });
+});

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -51,7 +51,7 @@ const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = (process.env.SOLC_VERSION || '0.8.33').trim();
 const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 200));
-const solcViaIR = (process.env.SOLC_VIA_IR || '').toLowerCase() === 'true';
+const solcViaIR = (process.env.SOLC_VIA_IR || 'true').toLowerCase() === 'true';
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 
 const testProvider = ganache.provider({


### PR DESCRIPTION
### Motivation
- Prevent agents from bypassing the `completionReviewPeriod` by repeatedly calling `requestJobCompletion` and updating the IPFS hash after the initial request, which could allow a materially different submission to be finalized without a fresh review period for validators.

### Description
- Added a guard in `requestJobCompletion` to revert if `job.completionRequested` is already set and ensure `job.completionRequestedAt` is set on the (first) request so the review window is always based on the initial submission timestamp.

### Testing
- Ran the full test suite with `npm test` (Truffle compile + tests); all tests passed (155 passing), including the new liveness timeout scenarios for `expireJob`, `finalizeJob`, and stale dispute recovery.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e423279548333b052305dc7f0f186)