### PR TITLE
Avoid zero-approval finalize fast path

### DIFF
--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -147,7 +147,7 @@ connected wallet matches `owner()`. Every admin action:
   - `premiumReputationThreshold`
 
 ### Liveness timeout actions (not in UI yet)
-- `expireJob` (anyone) and `finalizeJob` (agent/employer) are **not** exposed in the UI; use Truffle console or scripts.
+- `expireJob` (anyone) and `finalizeJob` (anyone, deterministic fallback) are **not** exposed in the UI; use Truffle console or scripts.
 - `resolveStaleDispute` (owner-only, paused) is **not** exposed in the UI; use a controlled admin workflow.
 
 > Moderators only have on-chain powers for `resolveDispute`. The UI does **not** expose moderator-only actions in the admin panel.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -476,6 +476,18 @@
         },
         {
           "indexed": false,
+          "internalType": "address",
+          "name": "employer",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "agentPaid",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
           "internalType": "uint256",
           "name": "payout",
           "type": "uint256"


### PR DESCRIPTION
### Motivation
- Prevent paying the agent automatically when `requiredValidatorApprovals` is set to `0`, so validator disapprovals still influence the deterministic fallback outcome.
- Allow liveness settlement after the review window without relying on a specific caller so non-actionable jobs can deterministically resolve escrow.
- Make the finalize path deterministic: honor thresholds, treat silence as agent win, and decide by `approvals > disapprovals` otherwise (ties refund employer).

### Description
- Updated `finalizeJob` to only take the approval-threshold fast path when `requiredValidatorApprovals > 0`, preserving the approvals-vs-disapprovals fallback when approvals are configured as `0`.
- Removed the previous caller restriction on `finalizeJob` and added a disapproval guard that checks `requiredValidatorDisapprovals > 0` before blocking finalization.
- Implemented deterministic fallback settlement: silence => agent wins; otherwise `agentWins = validatorApprovals > validatorDisapprovals`; agent wins call `_completeJob`, otherwise `_refundEmployer`.
- Added internal helper ` _refundEmployer(Job storage)` to centralize employer refunds and job closing, updated `JobFinalized` event payload (now `(jobId, agent, employer, agentPaid, payout)`), and synced ABI and docs to match behavior.
- Expanded `test/livenessTimeouts.test.js` to cover the new finalize semantics (review timing, caller flexibility, approvals/disapprovals outcomes) and updated docs describing deterministic fallback.

### Testing
- Ran `npm install` to install dependencies (warnings noted but completed). 
- Built and compiled contracts with `npm run build` and exported UI ABI with `npm run ui:abi`, both succeeded and ABI updated.
- Ran the full test suite with `npm test` (Truffle + tests + ABI smoke); all automated tests passed: `158 passing` and ABI smoke test passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e4d5e9ec083338481ebaf1169f795)