### PR TITLE
Add canonical JobStatus enum and UI support; avoid disabling on transient RPC errors

### DIFF
--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -10,6 +10,7 @@
 ## Functions
 | Signature | State mutability | Returns |
 | --- | --- | --- |
+| `MAX_REVIEW_PERIOD()` | view | uint256 |
 | `MAX_VALIDATORS_PER_JOB()` | view | uint256 |
 | `additionalAgents(address)` | view | bool |
 | `additionalText1()` | view | string |
@@ -25,12 +26,14 @@
 | `blacklistedAgents(address)` | view | bool |
 | `blacklistedValidators(address)` | view | bool |
 | `clubRootNode()` | view | bytes32 |
+| `completionReviewPeriod()` | view | uint256 |
 | `contactEmail()` | view | string |
+| `disputeReviewPeriod()` | view | uint256 |
 | `ens()` | view | address |
 | `getApproved(uint256 tokenId)` | view | address |
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
-| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string |
+| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
 | `maxJobPayout()` | view | uint256 |
 | `moderators(address)` | view | bool |
@@ -67,6 +70,7 @@
 | `disapproveJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
 | `disputeJob(uint256 _jobId)` | nonpayable | — |
 | `resolveDispute(uint256 _jobId, string resolution)` | nonpayable | — |
+| `resolveStaleDispute(uint256 _jobId, bool employerWins)` | nonpayable | — |
 | `blacklistAgent(address _agent, bool _status)` | nonpayable | — |
 | `blacklistValidator(address _validator, bool _status)` | nonpayable | — |
 | `delistJob(uint256 _jobId)` | nonpayable | — |
@@ -79,14 +83,20 @@
 | `setPremiumReputationThreshold(uint256 _threshold)` | nonpayable | — |
 | `setMaxJobPayout(uint256 _maxPayout)` | nonpayable | — |
 | `setJobDurationLimit(uint256 _limit)` | nonpayable | — |
+| `setCompletionReviewPeriod(uint256 _period)` | nonpayable | — |
+| `setDisputeReviewPeriod(uint256 _period)` | nonpayable | — |
 | `updateTermsAndConditionsIpfsHash(string _hash)` | nonpayable | — |
 | `updateContactEmail(string _email)` | nonpayable | — |
 | `updateAdditionalText1(string _text)` | nonpayable | — |
 | `updateAdditionalText2(string _text)` | nonpayable | — |
 | `updateAdditionalText3(string _text)` | nonpayable | — |
 | `getJobStatus(uint256 _jobId)` | view | bool, bool, string |
+| `jobStatus(uint256 jobId)` | view | uint8 |
+| `jobStatusString(uint256 jobId)` | view | string |
 | `setValidationRewardPercentage(uint256 _percentage)` | nonpayable | — |
 | `cancelJob(uint256 _jobId)` | nonpayable | — |
+| `expireJob(uint256 _jobId)` | nonpayable | — |
+| `finalizeJob(uint256 _jobId)` | nonpayable | — |
 | `listNFT(uint256 tokenId, uint256 price)` | nonpayable | — |
 | `purchaseNFT(uint256 tokenId)` | nonpayable | — |
 | `delistNFT(uint256 tokenId)` | nonpayable | — |
@@ -107,7 +117,10 @@
 | `Approval(address owner, address approved, uint256 tokenId)` | indexed address owner, indexed address approved, indexed uint256 tokenId |
 | `ApprovalForAll(address owner, address operator, bool approved)` | indexed address owner, indexed address operator, bool approved |
 | `BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId)` | uint256 _fromTokenId, uint256 _toTokenId |
+| `CompletionReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
 | `DisputeResolved(uint256 jobId, address resolver, string resolution)` | uint256 jobId, address resolver, string resolution |
+| `DisputeReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
+| `DisputeTimeoutResolved(uint256 jobId, address resolver, bool employerWins)` | uint256 jobId, address resolver, bool employerWins |
 | `JobApplied(uint256 jobId, address agent)` | uint256 jobId, address agent |
 | `JobCancelled(uint256 jobId)` | uint256 jobId |
 | `JobCompleted(uint256 jobId, address agent, uint256 reputationPoints)` | uint256 jobId, address agent, uint256 reputationPoints |
@@ -115,6 +128,8 @@
 | `JobCreated(uint256 jobId, string ipfsHash, uint256 payout, uint256 duration, string details)` | uint256 jobId, string ipfsHash, uint256 payout, uint256 duration, string details |
 | `JobDisapproved(uint256 jobId, address validator)` | uint256 jobId, address validator |
 | `JobDisputed(uint256 jobId, address disputant)` | uint256 jobId, address disputant |
+| `JobExpired(uint256 jobId, address employer, address agent, uint256 payout)` | uint256 jobId, address employer, address agent, uint256 payout |
+| `JobFinalized(uint256 jobId, address agent, address employer, bool agentPaid, uint256 payout)` | uint256 jobId, address agent, address employer, bool agentPaid, uint256 payout |
 | `JobValidated(uint256 jobId, address validator)` | uint256 jobId, address validator |
 | `MerkleRootUpdated(bytes32 newMerkleRoot)` | indexed bytes32 newMerkleRoot |
 | `MetadataUpdate(uint256 _tokenId)` | uint256 _tokenId |

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -60,6 +60,12 @@ and “Fallback ABI used” when opened via `file://`.
 
 If `truffle test` fails with an ABI mismatch, run `npm run ui:abi` and commit the updated ABI file.
 
+### Job status API support
+
+The UI prefers the on-chain `jobStatus(jobId)` / `jobStatusString(jobId)` helpers when available
+to display the canonical job lifecycle status. When connected to older deployments that do not
+expose these helpers, the UI falls back to its existing client-side derivation.
+
 ## Supported networks
 
 - **Ethereum mainnet** is the intended production network.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2153,6 +2153,44 @@
       "inputs": [
         {
           "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        }
+      ],
+      "name": "jobStatus",
+      "outputs": [
+        {
+          "internalType": "enum AGIJobManager.JobStatus",
+          "name": "",
+          "type": "uint8"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        }
+      ],
+      "name": "jobStatusString",
+      "outputs": [
+        {
+          "internalType": "string",
+          "name": "",
+          "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
           "name": "_percentage",
           "type": "uint256"
         }

--- a/docs/ui/abi/ui_required_interface.json
+++ b/docs/ui/abi/ui_required_interface.json
@@ -30,6 +30,8 @@
     "listings": 1,
     "ownerOf": 1,
     "tokenURI": 1,
+    "jobStatus": 1,
+    "jobStatusString": 1,
     "createJob": 4,
     "cancelJob": 1,
     "pause": 0,

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -834,6 +834,10 @@
       contractDeployed: null,
       contractOwner: null,
       contractPaused: null,
+      capabilities: {
+        jobStatus: null,
+        jobStatusString: null,
+      },
       marketAllowance: null,
       nftCache: {},
       ui: {
@@ -929,6 +933,8 @@
       "function ownerOf(uint256) view returns (address)",
       "function tokenURI(uint256) view returns (string)",
       "function getJobStatus(uint256) view returns (bool,bool,string)",
+      "function jobStatus(uint256) view returns (uint8)",
+      "function jobStatusString(uint256) view returns (string)",
       "function createJob(string,uint256,uint256,string)",
       "function cancelJob(uint256)",
       "function pause()",
@@ -1403,6 +1409,10 @@
         state.contractDeployed = null;
         state.marketAllowance = null;
         state.nftCache = {};
+        state.capabilities = {
+          jobStatus: null,
+          jobStatusString: null,
+        };
         state.index = {
           jobs: {},
           nfts: {},
@@ -1429,6 +1439,10 @@
       state.nameWrapper = null;
       state.marketAllowance = null;
       state.nftCache = {};
+      state.capabilities = {
+        jobStatus: null,
+        jobStatusString: null,
+      };
       state.readContract = new ethers.Contract(state.contractAddress, abi, state.provider);
       if (state.signer) {
         state.contract = new ethers.Contract(state.contractAddress, abi, state.signer);
@@ -2339,15 +2353,86 @@
       logEvent(`Indexed ${ordered.length} events from blocks ${fromBlock} to ${toBlock}.`);
     }
 
+    const jobStatusLabels = {
+      0: "DeletedOrCancelled",
+      1: "Open",
+      2: "InProgress",
+      3: "CompletionRequested",
+      4: "Disputed",
+      5: "Completed",
+      6: "Expired",
+    };
+
     function jobStatusFromIndex(entry) {
       if (!entry) return "Unknown";
-      if (entry.cancelled) return "Cancelled";
+      if (entry.cancelled) return "DeletedOrCancelled";
       if (entry.completed) return "Completed";
       if (entry.disputed) return "Disputed";
       if (entry.completionRequested) return "CompletionRequested";
       if (entry.applied) return "InProgress";
       if (entry.created) return "Open";
       return "Unknown";
+    }
+
+    function deriveJobStatus(job, indexEntry) {
+      const employer = job[1];
+      const assignedAgent = job[5];
+      const completed = job[7];
+      const completionRequested = job[8];
+      const disputed = job[11];
+      let status = jobStatusFromIndex(indexEntry);
+      if (employer === ethers.ZeroAddress) {
+        status = "DeletedOrCancelled";
+      } else if (completed) {
+        status = "Completed";
+      } else if (disputed) {
+        status = "Disputed";
+      } else if (assignedAgent === ethers.ZeroAddress) {
+        status = "Open";
+      } else if (completionRequested) {
+        status = "CompletionRequested";
+      } else if (assignedAgent !== ethers.ZeroAddress) {
+        status = "InProgress";
+      }
+      return status;
+    }
+
+    async function resolveJobStatus(jobId, job, indexEntry) {
+      const derived = deriveJobStatus(job, indexEntry);
+      if (!state.readContract) return derived;
+      const shouldDisableCapability = (error) => {
+        if (!error) return false;
+        const message = (error.shortMessage || error.message || "").toLowerCase();
+        if (message.includes("method not found")) return true;
+        if (message.includes("unknown function")) return true;
+        if (message.includes("function selector was not recognized")) return true;
+        if (error.code === "CALL_EXCEPTION" && error.data === "0x") return true;
+        return false;
+      };
+      if (state.capabilities.jobStatusString !== false) {
+        try {
+          const status = await state.readContract.jobStatusString(BigInt(jobId));
+          state.capabilities.jobStatusString = true;
+          return status;
+        } catch (error) {
+          if (state.capabilities.jobStatusString == null && shouldDisableCapability(error)) {
+            state.capabilities.jobStatusString = false;
+          }
+        }
+      }
+      if (state.capabilities.jobStatus !== false) {
+        try {
+          const statusValue = await state.readContract.jobStatus(BigInt(jobId));
+          state.capabilities.jobStatus = true;
+          const key = Number(statusValue);
+          return jobStatusLabels[key] || derived;
+        } catch (error) {
+          if (state.capabilities.jobStatus == null && shouldDisableCapability(error)) {
+            state.capabilities.jobStatus = false;
+          }
+        }
+      }
+      return derived;
     }
 
     function nftStatusFromIndex(entry) {
@@ -2395,7 +2480,7 @@
         if (filter === "completion_requested") return status === "CompletionRequested";
         if (filter === "disputed") return status === "Disputed";
         if (filter === "completed") return status === "Completed";
-        if (filter === "cancelled") return status === "Cancelled";
+        if (filter === "cancelled") return status === "DeletedOrCancelled";
         return true;
       });
     }
@@ -2743,10 +2828,12 @@
 
       const jobs = await asyncPool(6, jobIds, async (jobId) => {
         const job = await state.readContract.jobs(BigInt(jobId));
-        return { jobId, job };
+        const indexEntry = state.index.jobs[jobId];
+        const status = await resolveJobStatus(jobId, job, indexEntry);
+        return { jobId, job, status };
       });
 
-      for (const { jobId, job } of jobs) {
+      for (const { jobId, job, status } of jobs) {
         const employer = job[1];
         const assignedAgent = job[5];
         const completed = job[7];
@@ -2754,21 +2841,6 @@
         const approvals = job[9];
         const disapprovals = job[10];
         const disputed = job[11];
-        const indexEntry = state.index.jobs[jobId];
-        let status = jobStatusFromIndex(indexEntry);
-        if (employer === ethers.ZeroAddress) {
-          status = "Deleted";
-        } else if (completed) {
-          status = "Completed";
-        } else if (disputed) {
-          status = "Disputed";
-        } else if (completionRequested) {
-          status = "CompletionRequested";
-        } else if (assignedAgent !== ethers.ZeroAddress) {
-          status = "Assigned";
-        } else if (!indexEntry) {
-          status = "Open";
-        }
 
         const row = document.createElement("tr");
         const cells = [

--- a/test/jobStatus.test.js
+++ b/test/jobStatus.test.js
@@ -1,0 +1,102 @@
+const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toWei } = web3.utils;
+
+contract("AGIJobManager jobStatus", (accounts) => {
+  const [owner, employer, agent, moderator] = accounts;
+  let token;
+  let ens;
+  let nameWrapper;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+  });
+
+  it("reports canonical job status transitions", async () => {
+    const payout = toWei("5");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    let status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "1", "new job should be Open");
+    let statusString = await manager.jobStatusString(jobId);
+    assert.strictEqual(statusString, "Open", "jobStatusString should map Open");
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "2", "assigned job should be InProgress");
+
+    await manager.requestJobCompletion(jobId, "ipfs-completed", { from: agent });
+    status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "3", "completion request should set CompletionRequested");
+
+    await manager.disputeJob(jobId, { from: employer });
+    status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "4", "disputed job should be Disputed");
+
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "5", "resolved job should be Completed");
+  });
+
+  it("marks cancelled jobs and rejects out-of-range status", async () => {
+    const payout = toWei("2");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.cancelJob(jobId, { from: employer });
+    const status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "0", "cancelled job should be DeletedOrCancelled");
+
+    await expectCustomError(manager.jobStatus.call(999), "JobNotFound");
+  });
+
+  it("computes Expired when assigned jobs pass their duration", async () => {
+    const payout = toWei("1");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs-job", payout, 5, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await time.increase(6);
+
+    const status = await manager.jobStatus(jobId);
+    assert.strictEqual(status.toString(), "6", "expired jobs should return Expired");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide a stable, on-chain canonical job lifecycle so clients and indexers do not need to re-derive status and risk stale-index mislabeling.
- Expose human- and machine-friendly accessors so UIs can prefer the contract state when available.
- Avoid permanently disabling UI capability detection for `jobStatus`/`jobStatusString` due to transient RPC failures by distinguishing missing-method errors from transient errors.

### Description
- Add a stable `JobStatus` enum and helpers in the contract: `jobStatus(uint256)`, `jobStatusString(uint256)`, and internal `_jobStatus(uint256)` implementing a documented precedence order (files: `contracts/AGIJobManager.sol`, `docs/AGIJobManager.md`, `docs/Interface.md`).
- Update the exported ABI and UI-required interface to include `jobStatus` and `jobStatusString` (files: `docs/ui/abi/AGIJobManager.json`, `docs/ui/abi/ui_required_interface.json`).
- Update the UI to prefer on-chain status: add `jobStatusLabels`, `deriveJobStatus`, and `resolveJobStatus` which first attempts `jobStatusString`, then `jobStatus`, and falls back to client derivation; initialize and maintain `state.capabilities` for capability detection (file: `docs/ui/agijobmanager.html`).
- Improve capability detection logic so capability flags are only set to `false` when the caught error clearly indicates a missing method/selector, preventing permanent disabling on transient RPC errors (file: `docs/ui/agijobmanager.html`).
- Add unit tests that exercise the new canonical lifecycle transitions, cancellation, expiry, and out-of-range handling (file: `test/jobStatus.test.js`).

### Testing
- Added `test/jobStatus.test.js` which covers canonical transitions (Open → InProgress → CompletionRequested → Disputed → Completed), cancellation handling, expiry detection, and out-of-range `JobNotFound` behavior, but these tests were not executed in this rollout.
- No automated CI or test runs were performed during this change set (UI and contract changes only in repository).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e586b9c1883339f1d9e1a440dfc14)