### PR TITLE
Snapshot agent payout tiers at assignment and enforce nonzero payouts

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,6 +174,7 @@ npx truffle migrate --network development
 - **Eligibility gating**: Merkle roots and ENS dependencies are immutable post-deploy; misconfiguration requires redeployment.
 - **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
 - **Marketplace reentrancy guard**: `purchaseNFT` is protected by `nonReentrant` because it crosses an external ERC‑20 `transferFrom` boundary; removing this protection requires a redeploy even though the ABI is unchanged.
+- **Agent payout snapshotting**: the agent payout tier is snapshotted at `applyForJob`; buying/selling/transferring AGI‑type NFTs after assignment does **not** change payout for that job. Agents with a 0% tier cannot accept jobs unless they are explicitly allowlisted as `additionalAgents` with a nonzero default payout.
 - **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
 - **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline unless off‑chain policies intervene.
 - **Dispute strings**: `resolveDispute` accepts any string, but only the exact `agent win` / `employer win` values trigger settlement; other strings just clear the dispute flag.

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -114,7 +114,7 @@ stateDiagram-v2
 
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.
-- **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is the highest AGI type percentage owned by the agent (may be zero).
+- **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPercentage / 100`, where `agentPayoutPercentage` is **snapshotted at `applyForJob` time** from the agent’s highest AGI type percentage. Post‑assignment transfers do not affect that job’s payout. Agents with a 0% tier cannot apply unless they are `additionalAgents`, in which case the configured default payout percentage is used.
 - **Validator payout**: when validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
 - **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner.
 - **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with `employer win` refunds and finalizes the job.

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -12,6 +12,7 @@
 | --- | --- | --- |
 | `MAX_REVIEW_PERIOD()` | view | uint256 |
 | `MAX_VALIDATORS_PER_JOB()` | view | uint256 |
+| `additionalAgentPayoutPercentage()` | view | uint256 |
 | `additionalAgents(address)` | view | bool |
 | `additionalText1()` | view | string |
 | `additionalText2()` | view | string |
@@ -33,7 +34,7 @@
 | `getApproved(uint256 tokenId)` | view | address |
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
-| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool |
+| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool, uint8 |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
 | `maxJobPayout()` | view | uint256 |
 | `moderators(address)` | view | bool |
@@ -85,12 +86,14 @@
 | `setJobDurationLimit(uint256 _limit)` | nonpayable | — |
 | `setCompletionReviewPeriod(uint256 _period)` | nonpayable | — |
 | `setDisputeReviewPeriod(uint256 _period)` | nonpayable | — |
+| `setAdditionalAgentPayoutPercentage(uint256 _percentage)` | nonpayable | — |
 | `updateTermsAndConditionsIpfsHash(string _hash)` | nonpayable | — |
 | `updateContactEmail(string _email)` | nonpayable | — |
 | `updateAdditionalText1(string _text)` | nonpayable | — |
 | `updateAdditionalText2(string _text)` | nonpayable | — |
 | `updateAdditionalText3(string _text)` | nonpayable | — |
 | `getJobStatus(uint256 _jobId)` | view | bool, bool, string |
+| `getJobAgentPayoutPct(uint256 _jobId)` | view | uint256 |
 | `jobStatus(uint256 jobId)` | view | uint8 |
 | `jobStatusString(uint256 jobId)` | view | string |
 | `setValidationRewardPercentage(uint256 _percentage)` | nonpayable | — |
@@ -114,6 +117,7 @@
 | Event | Indexed fields |
 | --- | --- |
 | `AGITypeUpdated(address nftAddress, uint256 payoutPercentage)` | indexed address nftAddress, uint256 payoutPercentage |
+| `AdditionalAgentPayoutPercentageUpdated(uint256 newPercentage)` | uint256 newPercentage |
 | `Approval(address owner, address approved, uint256 tokenId)` | indexed address owner, indexed address approved, indexed uint256 tokenId |
 | `ApprovalForAll(address owner, address operator, bool approved)` | indexed address owner, indexed address operator, bool approved |
 | `BatchMetadataUpdate(uint256 _fromTokenId, uint256 _toTokenId)` | uint256 _fromTokenId, uint256 _toTokenId |
@@ -151,6 +155,8 @@
 | Error | Inputs |
 | --- | --- |
 | `Blacklisted()` | — |
+| `IneligibleAgentPayout()` | — |
+| `InvalidAgentPayoutSnapshot()` | — |
 | `InvalidParameters()` | — |
 | `InvalidState()` | — |
 | `InvalidValidatorThresholds()` | — |

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -58,6 +58,16 @@
     },
     {
       "inputs": [],
+      "name": "IneligibleAgentPayout",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InvalidAgentPayoutSnapshot",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "InvalidParameters",
       "type": "error"
     },
@@ -118,6 +128,19 @@
         }
       ],
       "name": "AGITypeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newPercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "AdditionalAgentPayoutPercentageUpdated",
       "type": "event"
     },
     {
@@ -809,6 +832,19 @@
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "additionalAgentPayoutPercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "address",
@@ -1233,6 +1269,11 @@
           "internalType": "bool",
           "name": "expired",
           "type": "bool"
+        },
+        {
+          "internalType": "uint8",
+          "name": "agentPayoutPct",
+          "type": "uint8"
         }
       ],
       "stateMutability": "view",
@@ -2058,6 +2099,19 @@
     {
       "inputs": [
         {
+          "internalType": "uint256",
+          "name": "_percentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAdditionalAgentPayoutPercentage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "string",
           "name": "_hash",
           "type": "string"
@@ -2144,6 +2198,25 @@
           "internalType": "string",
           "name": "",
           "type": "string"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_jobId",
+          "type": "uint256"
+        }
+      ],
+      "name": "getJobAgentPayoutPct",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -98,6 +98,9 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       agentTree.root
     );
 
+    await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
+    await agiTypeNft.mint(agent);
+
     await token.mint(employer, payout.muln(5));
     await token.mint(agent, payout);
     await token.mint(buyer, payout);

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -67,6 +67,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
   let agentMerkle;
   let validatorMerkle;
   let manager;
+  let agiType;
 
   beforeEach(async () => {
     token = await MockERC20.new({ from: owner });
@@ -87,6 +88,10 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       agentMerkleRoot: agentMerkle.root,
       owner,
     });
+
+    agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(1, { from: owner });

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -170,6 +170,9 @@ contract("AGIJobManager comprehensive", (accounts) => {
       { from: owner }
     );
 
+    await nft.mint(agent, { from: owner });
+    await manager.addAGIType(nft.address, 92, { from: owner });
+
     await token.mint(employer, web3.utils.toWei("500"), { from: owner });
     await token.mint(buyer, web3.utils.toWei("500"), { from: owner });
     await token.mint(other, web3.utils.toWei("500"), { from: owner });

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -8,6 +8,7 @@ const MockENS = artifacts.require("MockENS");
 const MockResolver = artifacts.require("MockResolver");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
 const FailingERC20 = artifacts.require("FailingERC20");
+const MockERC721 = artifacts.require("MockERC721");
 
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
@@ -25,6 +26,7 @@ contract("AGIJobManager admin ops", (accounts) => {
   let manager;
   let clubRoot;
   let agentRoot;
+  let agiType;
 
   beforeEach(async () => {
     token = await MockERC20.new({ from: owner });
@@ -46,6 +48,10 @@ contract("AGIJobManager admin ops", (accounts) => {
       ZERO_ROOT,
       { from: owner }
     );
+
+    agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -1,0 +1,140 @@
+const assert = require("assert");
+const { MerkleTree } = require("merkletreejs");
+const keccak256 = require("keccak256");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { rootNode } = require("./helpers/ens");
+const { expectCustomError } = require("./helpers/errors");
+
+const { toBN, toWei } = web3.utils;
+
+function leafFor(address) {
+  return Buffer.from(web3.utils.soliditySha3({ type: "address", value: address }).slice(2), "hex");
+}
+
+function buildMerkle(addresses) {
+  const leaves = addresses.map(leafFor);
+  const tree = new MerkleTree(leaves, keccak256, { sortPairs: true });
+  return {
+    root: tree.getHexRoot(),
+    proofFor: (addr) => tree.getHexProof(leafFor(addr)),
+  };
+}
+
+contract("AGIJobManager agent payout snapshots", (accounts) => {
+  const [owner, employer, agent, validator, other] = accounts;
+  let token;
+  let ens;
+  let nameWrapper;
+  let manager;
+  let agentMerkle;
+  let validatorMerkle;
+
+  const payout = toBN(toWei("100"));
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    agentMerkle = buildMerkle([agent]);
+    validatorMerkle = buildMerkle([validator]);
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      rootNode("club-root"),
+      rootNode("agent-root"),
+      validatorMerkle.root,
+      agentMerkle.root,
+      { from: owner }
+    );
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+  });
+
+  async function createJob() {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+    return tx.logs[0].args.jobId.toNumber();
+  }
+
+  it("rejects agents with a 0% payout tier", async () => {
+    const jobId = await createJob();
+
+    await expectCustomError(
+      manager.applyForJob.call(jobId, "agent", agentMerkle.proofFor(agent), { from: agent }),
+      "IneligibleAgentPayout"
+    );
+  });
+
+  it("uses the snapshot even if the agent sells their AGI-type after assignment", async () => {
+    const jobId = await createJob();
+    const agiTypeLow = await MockERC721.new({ from: owner });
+    const agiTypeHigh = await MockERC721.new({ from: owner });
+
+    await manager.addAGIType(agiTypeLow.address, 25, { from: owner });
+    await manager.addAGIType(agiTypeHigh.address, 75, { from: owner });
+
+    const mintTx = await agiTypeHigh.mint(agent, { from: owner });
+    const highTokenId = mintTx.logs.find((log) => log.event === \"Transfer\").args.tokenId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+
+    await agiTypeHigh.transferFrom(agent, other, highTokenId, { from: agent });
+
+    const balanceBefore = await token.balanceOf(agent);
+    await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
+    const balanceAfter = await token.balanceOf(agent);
+
+    const expectedPayout = payout.muln(75).divn(100);
+    assert.equal(balanceAfter.sub(balanceBefore).toString(), expectedPayout.toString());
+  });
+
+  it("ignores post-assignment upgrades to a higher AGI-type tier", async () => {
+    const jobId = await createJob();
+    const agiTypeLow = await MockERC721.new({ from: owner });
+    const agiTypeHigh = await MockERC721.new({ from: owner });
+
+    await manager.addAGIType(agiTypeLow.address, 25, { from: owner });
+    await manager.addAGIType(agiTypeHigh.address, 75, { from: owner });
+
+    await agiTypeLow.mint(agent, { from: owner });
+    await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+
+    await agiTypeHigh.mint(agent, { from: owner });
+
+    const balanceBefore = await token.balanceOf(agent);
+    await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
+    const balanceAfter = await token.balanceOf(agent);
+
+    const expectedPayout = payout.muln(25).divn(100);
+    assert.equal(balanceAfter.sub(balanceBefore).toString(), expectedPayout.toString());
+  });
+
+  it("pays additionalAgents using the configured nonzero default tier", async () => {
+    const jobId = await createJob();
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.setAdditionalAgentPayoutPercentage(50, { from: owner });
+
+    await manager.applyForJob(jobId, "agent", [], { from: agent });
+
+    const balanceBefore = await token.balanceOf(agent);
+    await manager.validateJob(jobId, "validator", [], { from: validator });
+    const balanceAfter = await token.balanceOf(agent);
+
+    const expectedPayout = payout.muln(50).divn(100);
+    assert.equal(balanceAfter.sub(balanceBefore).toString(), expectedPayout.toString());
+  });
+});

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -5,6 +5,7 @@ const MockERC20 = artifacts.require("MockERC20");
 const MockENS = artifacts.require("MockENS");
 const MockResolver = artifacts.require("MockResolver");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
 
 const { namehash, subnode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
 const { expectRevert } = require("@openzeppelin/test-helpers");
@@ -22,6 +23,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
   let manager;
   let clubRoot;
   let agentRoot;
+  let agiType;
 
   const payout = toBN(toWei("10"));
 
@@ -52,6 +54,10 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
       ZERO_ROOT,
       { from: owner }
     );
+
+    agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
   });

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -147,7 +147,11 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const token = await MockERC20.new({ from: owner });
     await token.mint(employer, payout.muln(4), { from: owner });
 
+    const nft = await MockERC721.new({ from: owner });
+    await nft.mint(agent, { from: owner });
+
     const original = await deployManager(AGIJobManagerOriginal, token.address, agent, validator, owner);
+    await original.addAGIType(nft.address, 92, { from: owner });
     const approveThenDisapproveId = await createAssignedJob(original, token, employer, agent, payout);
     await original.validateJob(approveThenDisapproveId, "validator", EMPTY_PROOF, { from: validator });
     await original.disapproveJob(approveThenDisapproveId, "validator", EMPTY_PROOF, { from: validator });
@@ -163,6 +167,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     assert.equal(disapproveThenApproveJob.validatorDisapprovals.toNumber(), 1, "original should track disapprovals");
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
+    await current.addAGIType(nft.address, 92, { from: owner });
     const currentApproveThenDisapproveId = await createAssignedJob(current, token, employer, agent, payout);
     await current.validateJob(currentApproveThenDisapproveId, "validator", EMPTY_PROOF, { from: validator });
     await expectRevert(

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -24,6 +24,7 @@ contract("AGIJobManager security regressions", (accounts) => {
   let manager;
   let clubRoot;
   let agentRoot;
+  let agiType;
 
   beforeEach(async () => {
     token = await MockERC20.new({ from: owner });
@@ -45,6 +46,10 @@ contract("AGIJobManager security regressions", (accounts) => {
       ZERO_ROOT,
       { from: owner }
     );
+
+    agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);


### PR DESCRIPTION
### Motivation
- Prevent on-completion recomputation of agent payout that allows an assigned agent to be paid 0% by buying/selling/losing AGI-type NFTs after assignment and to stop gameable payout manipulation.
- Make agent payout eligibility explicit at assignment-time and provide a safe override for allowlisted `additionalAgents`.

### Description
- Snapshot: added `uint8 agentPayoutPct` to `Job` (appended to struct) and record the agent payout percentage in `applyForJob` using `getHighestPayoutPercentage(msg.sender)` or a configured default for `additionalAgents`.
- Enforcement: added custom errors `IneligibleAgentPayout()` and `InvalidAgentPayoutSnapshot()` and make `applyForJob` revert if the agent would have a 0% payout tier and is not an `additionalAgent` with an override.
- Payouts: changed `_payAgent` to use the stored `job.agentPayoutPct` (and revert if it is 0) instead of recomputing holdings at completion time.
- Additional-agents override: added `additionalAgentPayoutPercentage` (default 50), `setAdditionalAgentPayoutPercentage(uint256)` (owner-only, bounds-checked), and `AdditionalAgentPayoutPercentageUpdated` event; `additionalAgents` who lack AGI types snapshot this configured nonzero percentage.
- Visibility and docs: added `getJobAgentPayoutPct(uint256)` view, updated README and `docs/AGIJobManager.md`, regenerated ABI and interface docs, and added an ABI event for the new setter/event.
- Tests: added `test/agentPayoutSnapshot.truffle.test.js` covering rejection of 0% agents, snapshot immutability (sell NFT after assignment), ignoring post-assignment upgrades, and `additionalAgents` default payout; adjusted existing tests to mint AGI-type NFTs or add AGI types where necessary to avoid unintended reverts.

### Testing
- Compiled contracts with `npx truffle@5.11.5 compile --all` and the compilation succeeded (artifacts written to `build/contracts`).
- Updated ABI and interface with `npm run ui:abi` and `npm run docs:interface`, and the exported ABI/update succeeded.
- Ran the UI smoke tests with `npm run test:ui` and they passed (indexer helpers smoke tests).
- Environment notes: `npm ci` failed in this environment due to `fsevents` being OS‑specific (macOS) which prevented a full `npm test` run (so the end-to-end `truffle test` suite was not executed here); lint (`npm run lint`) was not executed because dev dependencies were not installed.
- Test artifacts: the new truffle test `test/agentPayoutSnapshot.truffle.test.js` is included in the repository and exercises the new economics rules (intended to be picked up by CI/truffle test in normal CI environments).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e86f32738833382b578ab880d914f)