### PR TITLE
Add tests and docs for agent payout snapshot and additional-agent fallback

### DIFF
--- a/docs/ParameterSafety.md
+++ b/docs/ParameterSafety.md
@@ -22,7 +22,7 @@ The table below lists configurable parameters and relevant caps, including who c
 | `MAX_VALIDATORS_PER_JOB` (constant) | Immutable | Caps validators per job and enforces `requiredValidatorApprovals + requiredValidatorDisapprovals <= 50`. | `50` | Keep validator thresholds well below 50 to ensure reachable consensus and reasonable gas. | If validator thresholds approach 50, a single unexpected disapproval can make approvals unreachable; disputes may become the only path. |
 | `AGIType.payoutPercentage` (per NFT) | Owner (`addAGIType`) | Determines agent payout percentage via `getHighestPayoutPercentage`. | `1..100` | Choose a **max agent payout %** so that `maxAgentPayoutPercentage + validationRewardPercentage <= 100`. | If any agent holds an NFT with a payout percentage that, combined with `validationRewardPercentage`, exceeds 100, job completion will revert when validator payouts execute. |
 | `clubRootNode`, `agentRootNode`, `validatorMerkleRoot`, `agentMerkleRoot` | Immutable post‑deploy | Gate eligibility for validators/agents via ENS + Merkle proofs. | Set only in constructor (no setters). | Validate before deployment; keep canonical allowlists and ENS settings accurate. | Mis-set roots can prevent validators/agents from ever qualifying, blocking validation and making jobs uncompletable without manual additional allowlisting or redeploy. |
-| `additionalValidators`, `additionalAgents` | Owner (`addAdditionalValidator`, `addAdditionalAgent`) | Manual allowlist bypass for eligibility checks. | None. | Use as a recovery tool when allowlist/ENS config blocks participation. | Overuse weakens trust; underuse when root nodes are wrong can stall jobs. |
+| `additionalValidators`, `additionalAgents` | Owner (`addAdditionalValidator`, `addAdditionalAgent`) | Manual allowlist bypass for eligibility checks. | None. | Use as a recovery tool when allowlist/ENS config blocks participation. | Overuse weakens trust; underuse when root nodes are wrong can stall jobs. Additional agents without a payout tier will receive `additionalAgentPayoutPercentage` on assignment. |
 
 ## Settlement math safety
 
@@ -31,6 +31,7 @@ The table below lists configurable parameters and relevant caps, including who c
 On completion (`_completeJob`), the contract executes the following calculations:
 
 - **Agent payout**: `agentPayout = job.payout * agentPayoutPercentage / 100`
+  - `agentPayoutPercentage` is snapshotted at assignment (`applyForJob`) and stored in the job. Subsequent NFT transfers or new tier NFTs do **not** change the payout for that job.
 - **Validator pool**: `totalValidatorPayout = job.payout * validationRewardPercentage / 100`
 - **Per-validator payout**: `validatorPayout = totalValidatorPayout / vCount`
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -26,7 +26,7 @@ The following `public` state variables have auto‑generated getter functions:
 Escrows `payout` tokens and creates a job. Emits `JobCreated`.
 
 ### `applyForJob(uint256 jobId, string subdomain, bytes32[] proof)`
-Assigns the agent if identity checks pass. Emits `JobApplied`.
+Assigns the agent if identity checks pass. The agent payout tier is **snapshotted at assignment time** and stored on the job. Agents without a payout tier (0%) cannot apply unless they are explicitly allowlisted via `additionalAgents`, in which case the snapshot uses `additionalAgentPayoutPercentage`. Emits `JobApplied`.
 
 ### `requestJobCompletion(uint256 jobId, string ipfsHash)`
 Marks completion requested and updates the job’s `ipfsHash`. Emits `JobCompletionRequested`.
@@ -134,3 +134,8 @@ Key events to index:
 - `InvalidState`
 - `JobNotFound`
 - `TransferFailed`
+- `ValidatorLimitReached`
+- `InvalidValidatorThresholds`
+- `ValidatorSetTooLarge`
+- `IneligibleAgentPayout`
+- `InvalidAgentPayoutSnapshot`


### PR DESCRIPTION
### Motivation
- Prevent agents from ending up with a 0% payout due to live recomputation of NFT-derived tiers at settlement time by ensuring payout tiers are snapshotted at assignment and ineligible agents cannot accept jobs. 
- Make the contract behavior explicit and non-gameable by documenting the snapshot rule and the `additionalAgents` fallback payout policy so operators and integrators can rely on deterministic settlement math.

### Description
- Added an `agent payout snapshots` test block to `test/AGIJobManager.full.test.js` which covers rejecting ineligible agents (0% tier), verifying the payout percentage is snapshotted at `applyForJob` and honored at settlement even after NFT transfers, and validating the `additionalAgents` fallback payout path. 
- Updated `docs/REFERENCE.md` to document that the agent payout tier is snapshotted at assignment and that agents without a tier are rejected unless in `additionalAgents`, in which case `additionalAgentPayoutPercentage` is used. 
- Updated `docs/ParameterSafety.md` to note the snapshotting behavior and the `additionalAgents` fallback so operators understand that post-assignment NFT transfers do not affect a job's payout.

### Testing
- Attempted `npm run build` (runs `truffle compile`) which failed in this environment because `truffle` is not installed, so on-repo compilation could not be completed. 
- Attempted `npm test` (runs `truffle test`) which also failed for the same reason (`truffle: not found`) so the new tests were not executed here. 
- All changes were committed locally (`git commit` succeeded) and the modified files are `test/AGIJobManager.full.test.js`, `docs/REFERENCE.md`, and `docs/ParameterSafety.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697e8f87ddf083339d61e0b4b717883a)