### PR TITLE
Prevent withdrawals from draining escrowed AGI

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ flowchart LR
 
 | Role | Capabilities | Trust considerations |
 | --- | --- | --- |
-| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw escrowed ERC‑20. | Highly privileged. Compromise or misuse can override operational safety. |
+| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw surplus ERC‑20 (balance minus locked escrow). | Highly privileged. Compromise or misuse can override operational safety. |
 | **Moderator** | Resolve disputes via `resolveDispute`. | Central dispute authority; outcomes depend on moderator integrity. |
 | **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
 | **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -34,8 +34,9 @@
 | `getApproved(uint256 tokenId)` | view | address |
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
-| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool, uint8 |
+| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool, uint8, bool |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
+| `lockedEscrow()` | view | uint256 |
 | `maxJobPayout()` | view | uint256 |
 | `moderators(address)` | view | bool |
 | `name()` | view | string |
@@ -107,6 +108,7 @@
 | `removeAdditionalValidator(address validator)` | nonpayable | — |
 | `addAdditionalAgent(address agent)` | nonpayable | — |
 | `removeAdditionalAgent(address agent)` | nonpayable | — |
+| `withdrawableAGI()` | view | uint256 |
 | `withdrawAGI(uint256 amount)` | nonpayable | — |
 | `canAccessPremiumFeature(address user)` | view | bool |
 | `contributeToRewardPool(uint256 amount)` | nonpayable | — |
@@ -117,6 +119,7 @@
 | Event | Indexed fields |
 | --- | --- |
 | `AGITypeUpdated(address nftAddress, uint256 payoutPercentage)` | indexed address nftAddress, uint256 payoutPercentage |
+| `AGIWithdrawn(address to, uint256 amount, uint256 remainingWithdrawable)` | indexed address to, uint256 amount, uint256 remainingWithdrawable |
 | `AdditionalAgentPayoutPercentageUpdated(uint256 newPercentage)` | uint256 newPercentage |
 | `Approval(address owner, address approved, uint256 tokenId)` | indexed address owner, indexed address approved, indexed uint256 tokenId |
 | `ApprovalForAll(address owner, address operator, bool approved)` | indexed address owner, indexed address operator, bool approved |
@@ -156,6 +159,8 @@
 | --- | --- |
 | `Blacklisted()` | — |
 | `IneligibleAgentPayout()` | — |
+| `InsolventEscrowBalance()` | — |
+| `InsufficientWithdrawableBalance()` | — |
 | `InvalidAgentPayoutSnapshot()` | — |
 | `InvalidParameters()` | — |
 | `InvalidState()` | — |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -99,7 +99,7 @@ Sets max job duration allowed.
 Updates informational metadata fields.
 
 ### `withdrawAGI(uint256 amount)`
-Withdraws AGI tokens held by the contract. Emits transfer via ERC‑20.
+Withdraws surplus AGI tokens held by the contract. Reverts if `amount > withdrawableAGI()`.
 
 ### `contributeToRewardPool(uint256 amount)`
 Transfers tokens to the contract and emits `RewardPoolContribution`.
@@ -110,6 +110,12 @@ Adds or updates an AGIType NFT that boosts agent payout percentage. Emits `AGITy
 ## View helpers
 ### `getJobStatus(uint256 jobId)`
 Returns `(completed, completionRequested, ipfsHash)`.
+
+### `lockedEscrow()`
+Returns the total AGI reserved for unsettled job escrows.
+
+### `withdrawableAGI()`
+Returns the surplus AGI balance (`balance - lockedEscrow`). Reverts if balance is below `lockedEscrow`.
 
 ### `canAccessPremiumFeature(address user)`
 Returns true if reputation exceeds `premiumReputationThreshold`.
@@ -139,3 +145,5 @@ Key events to index:
 - `ValidatorSetTooLarge`
 - `IneligibleAgentPayout`
 - `InvalidAgentPayoutSnapshot`
+- `InsufficientWithdrawableBalance`
+- `InsolventEscrowBalance`

--- a/docs/roles/OWNER_OPERATOR.md
+++ b/docs/roles/OWNER_OPERATOR.md
@@ -7,7 +7,7 @@ This guide covers administrative operations and safety controls.
 - Adjust risk parameters (payout limits, duration limits, validation rewards).
 - Manage moderators.
 - Pause/unpause the contract in emergencies.
-- Withdraw escrowed AGI funds when appropriate.
+- Withdraw surplus AGI funds when appropriate.
 
 ## Administrative actions
 > **Screenshot placeholder:** Etherscan “Write Contract” tab showing `pause`/`unpause` actions.
@@ -40,7 +40,7 @@ This guide covers administrative operations and safety controls.
 - `updateAdditionalText1/2/3(string)`
 
 ### Financial operations
-- `withdrawAGI(amount)` withdraws ERC‑20 tokens held by the contract.
+- `withdrawAGI(amount)` withdraws surplus ERC‑20 and reverts if `amount > withdrawableAGI()`.
 
 ## Safety checklist
 - Use a multisig or hardware wallet for the owner address.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -63,6 +63,16 @@
     },
     {
       "inputs": [],
+      "name": "InsolventEscrowBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
+      "name": "InsufficientWithdrawableBalance",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "InvalidAgentPayoutSnapshot",
       "type": "error"
     },
@@ -128,6 +138,31 @@
         }
       ],
       "name": "AGITypeUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "remainingWithdrawable",
+          "type": "uint256"
+        }
+      ],
+      "name": "AGIWithdrawn",
       "type": "event"
     },
     {
@@ -1274,6 +1309,11 @@
           "internalType": "uint8",
           "name": "agentPayoutPct",
           "type": "uint8"
+        },
+        {
+          "internalType": "bool",
+          "name": "escrowReleased",
+          "type": "bool"
         }
       ],
       "stateMutability": "view",
@@ -1308,6 +1348,19 @@
           "internalType": "bool",
           "name": "isActive",
           "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lockedEscrow",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -2406,6 +2459,19 @@
       "name": "removeAdditionalAgent",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "withdrawableAGI",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/docs/user-guide/roles.md
+++ b/docs/user-guide/roles.md
@@ -123,7 +123,7 @@ This guide explains what each role can do, what you need before starting, and co
 - Manage moderators and allowlists (`addModerator`, `addAdditionalAgent/Validator`).
 - Blacklist/un‑blacklist agents or validators.
 - Update parameters (limits, reward percentage, metadata fields).
-- Withdraw escrowed AGI tokens (`withdrawAGI`).
+- Withdraw surplus AGI tokens (`withdrawAGI`, limited to `withdrawableAGI()`).
 - Delist jobs before assignment (`delistJob`).
 - Manage AGI Types for agent payout bonuses (`addAGIType`).
 

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -654,7 +654,10 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
     it("withdraws AGI with bounds checks", async () => {
       await token.mint(manager.address, payout);
       await expectCustomError(manager.withdrawAGI.call(0, { from: owner }), "InvalidParameters");
-      await expectCustomError(manager.withdrawAGI.call(payout.muln(2), { from: owner }), "InvalidParameters");
+      await expectCustomError(
+        manager.withdrawAGI.call(payout.muln(2), { from: owner }),
+        "InsufficientWithdrawableBalance"
+      );
 
       const ownerBalanceBefore = await token.balanceOf(owner);
       await manager.withdrawAGI(payout, { from: owner });

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -756,7 +756,10 @@ contract("AGIJobManager comprehensive", (accounts) => {
     it("withdraws AGI within bounds and respects pause", async () => {
       await token.mint(manager.address, web3.utils.toWei("50"), { from: owner });
       await expectCustomError(manager.withdrawAGI(0, { from: owner }), "InvalidParameters");
-      await expectCustomError(manager.withdrawAGI(web3.utils.toWei("100"), { from: owner }), "InvalidParameters");
+      await expectCustomError(
+        manager.withdrawAGI(web3.utils.toWei("100"), { from: owner }),
+        "InsufficientWithdrawableBalance"
+      );
 
       const ownerBalanceBefore = new BN(await token.balanceOf(owner));
       await manager.withdrawAGI(web3.utils.toWei("10"), { from: owner });

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -1,0 +1,111 @@
+const assert = require("assert");
+
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager escrow accounting", (accounts) => {
+  const [owner, employer, agent, validator, moderator] = accounts;
+  let token;
+  let ens;
+  let nameWrapper;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+  });
+
+  const createJob = async (payout, duration = 1000) => {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const receipt = await manager.createJob("ipfs", payout, duration, "details", { from: employer });
+    return receipt.logs[0].args.jobId.toNumber();
+  };
+
+  it("prevents withdrawing escrowed funds", async () => {
+    const payout = toBN(toWei("5"));
+    await createJob(payout);
+
+    const lockedEscrow = await manager.lockedEscrow();
+    assert.equal(lockedEscrow.toString(), payout.toString(), "locked escrow should track job payout");
+
+    const withdrawable = await manager.withdrawableAGI();
+    assert.equal(withdrawable.toString(), "0", "withdrawable should exclude escrow");
+
+    await expectCustomError(
+      manager.withdrawAGI.call(toBN(1), { from: owner }),
+      "InsufficientWithdrawableBalance"
+    );
+  });
+
+  it("allows withdrawing surplus only", async () => {
+    const payout = toBN(toWei("4"));
+    const surplus = toBN(toWei("2"));
+    await createJob(payout);
+    await token.mint(manager.address, surplus, { from: owner });
+
+    const withdrawable = await manager.withdrawableAGI();
+    assert.equal(withdrawable.toString(), surplus.toString(), "withdrawable should be surplus only");
+
+    await manager.withdrawAGI(surplus, { from: owner });
+
+    const remainingWithdrawable = await manager.withdrawableAGI();
+    assert.equal(remainingWithdrawable.toString(), "0", "surplus should be fully withdrawn");
+    const lockedEscrow = await manager.lockedEscrow();
+    assert.equal(lockedEscrow.toString(), payout.toString(), "escrow remains locked");
+  });
+
+  it("releases escrow on terminal transitions", async () => {
+    const payout = toBN(toWei("3"));
+
+    const cancelJobId = await createJob(payout);
+    assert.equal((await manager.lockedEscrow()).toString(), payout.toString());
+    await manager.cancelJob(cancelJobId, { from: employer });
+    assert.equal((await manager.lockedEscrow()).toString(), "0");
+
+    const completeJobId = await createJob(payout);
+    await manager.applyForJob(completeJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.validateJob(completeJobId, "", EMPTY_PROOF, { from: validator });
+    assert.equal((await manager.lockedEscrow()).toString(), "0");
+
+    const disputeJobId = await createJob(payout);
+    await manager.applyForJob(disputeJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(disputeJobId, { from: employer });
+    await manager.resolveDispute(disputeJobId, "employer win", { from: moderator });
+    assert.equal((await manager.lockedEscrow()).toString(), "0");
+
+    const expireJobId = await createJob(payout, 1);
+    await manager.applyForJob(expireJobId, "", EMPTY_PROOF, { from: agent });
+    await time.increase(2);
+    await manager.expireJob(expireJobId, { from: employer });
+    assert.equal((await manager.lockedEscrow()).toString(), "0");
+  });
+});


### PR DESCRIPTION
### Motivation
- Prevent the owner from accidentally withdrawing tokens that are reserved for active job escrows and other reserved obligations by adding explicit reserved-funds accounting. 
- Make `withdrawAGI` safe by restricting it to surplus-only withdrawals (contract balance minus reserved escrow) and surface a helper view to make operator checks explicit. 
- Ensure terminal job transitions always release reserved escrow so accounting does not underflow or double-count. 

### Description
- Added `uint256 public lockedEscrow` to track total job payout escrows and a per-job `bool escrowReleased` flag to avoid double-decrementing. 
- Implemented `function withdrawableAGI() public view returns (uint256)` which returns `balance - lockedEscrow` and reverts with `InsolventEscrowBalance` if the contract balance is below `lockedEscrow`. 
- Updated `withdrawAGI(uint256 amount)` to require `amount <= withdrawableAGI()` and emit `AGIWithdrawn` while preserving the public signature and `onlyOwner` guard, and added `InsufficientWithdrawableBalance` error. 
- Adjusted `createJob` to `lockedEscrow += _payout` and called an internal `_releaseEscrow(job)` (idempotent) from all terminal transitions (`_completeJob`, `_refundEmployer`, `cancelJob`/`delistJob`, `expireJob`) so escrow is decremented exactly once per job. 
- Added tests (`test/escrowAccounting.test.js`) covering: `withdrawableAGI()` behavior, surplus-only withdrawals, and `lockedEscrow` correctness across cancel/complete/dispute/expire paths, and updated existing tests to expect the new error semantics where applicable. 
- Updated docs and README entries (`docs/*`, `README.md`, `docs/Interface.md`, `docs/REFERENCE.md`, `docs/ParameterSafety.md`, `docs/ops/parameter-safety.md`, `docs/roles/OWNER_OPERATOR.md`, `docs/user-guide/roles.md`) to describe `lockedEscrow`, `withdrawableAGI()`, and the surplus-only withdrawal behavior. 

### Testing
- Ran `npm run build` (Truffle compile) successfully and regenerated interface ABI docs. 
- Ran the full test suite with `npm test` (Truffle + mocha); all tests passed: 176 passing (including new `escrowAccounting` tests). 
- Updated and re-ran existing tests that assert withdrawal bounds to match the new `InsufficientWithdrawableBalance` semantics, and verified no regressions in job lifecycle, payouts, or marketplace tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ebf1be0f8833394aad6b896eb8eb6)