### PR TITLE
Require paused withdrawals for surplus AGI (prevent draining reserved escrow)

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -828,7 +828,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         return bal - lockedEscrow;
     }
 
-    function withdrawAGI(uint256 amount) external onlyOwner nonReentrant {
+    function withdrawAGI(uint256 amount) external onlyOwner whenPaused nonReentrant {
         if (amount == 0) revert InvalidParameters();
         uint256 available = withdrawableAGI();
         if (amount > available) revert InsufficientWithdrawableBalance();

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -118,7 +118,7 @@ stateDiagram-v2
 - **Agent payout**: on assignment, the agent’s payout percentage is snapshotted and stored on the job. On completion, the agent receives `job.payout * snapshottedAgentPayoutPercentage / 100`. If the agent has no AGI‑type NFTs, `applyForJob` reverts unless the agent is explicitly allowlisted in `additionalAgents`, in which case the job records the configurable `additionalAgentPayoutPercentage`.
 - **Validator payout**: when validators voted, `validationRewardPercentage` of the payout is split equally across all validators who voted (approvals and disapprovals both append to the validator list).
 - **Locked escrow accounting**: `lockedEscrow` tracks total job payout escrow for unsettled jobs (currently job payouts only).
-- **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner via `withdrawAGI`, which is restricted to `withdrawableAGI()` (balance minus `lockedEscrow`).
+- **Residual funds**: any unallocated balance remains in the contract and is withdrawable by the owner via `withdrawAGI` while paused, which is restricted to `withdrawableAGI()` (balance minus `lockedEscrow`).
 - **Refunds**: `cancelJob` and `delistJob` refund the employer before assignment; `resolveDispute` with `employer win` refunds and finalizes the job.
 - **ERC-20 compatibility**: token transfers accept ERC‑20s that return `bool` or return no data. Calls that revert, return `false`, or return malformed data revert with `TransferFailed`. Escrow deposits enforce exact amount received, so fee‑on‑transfer, rebasing, or other balance‑mutating tokens are not supported.
 
@@ -153,7 +153,7 @@ If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for obs
 - **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT.
 
 ## Reward pool contributions
-`contributeToRewardPool` allows any address to transfer ERC‑20 into the contract. These funds increase the contract’s balance and are withdrawable by the owner via `withdrawAGI`.
+`contributeToRewardPool` allows any address to transfer ERC‑20 into the contract. These funds increase the contract’s balance and are withdrawable by the owner via `withdrawAGI` while paused.
 
 ## Events
 High-signal events to index:

--- a/docs/ParameterSafety.md
+++ b/docs/ParameterSafety.md
@@ -39,7 +39,7 @@ On completion (`_completeJob`), the contract executes the following calculations
 **Rounding behavior:** all divisions are integer divisions; any remainder stays in the contract. Specifically:
 - Any fractional remainder from `agentPayout` is retained by the contract.
 - Any remainder from `totalValidatorPayout / vCount` stays in the contract.
-- There is no “dust” redistribution. Remaining tokens are only recoverable by the owner via `withdrawAGI`, which is limited to `withdrawableAGI()` (balance minus `lockedEscrow`).
+- There is no “dust” redistribution. Remaining tokens are only recoverable by the owner via `withdrawAGI` while paused, which is limited to `withdrawableAGI()` (balance minus `lockedEscrow`).
 
 ### Safety constraints derived from settlement
 

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -99,7 +99,7 @@ Sets max job duration allowed.
 Updates informational metadata fields.
 
 ### `withdrawAGI(uint256 amount)`
-Withdraws surplus AGI tokens held by the contract. Reverts if `amount > withdrawableAGI()`.
+Withdraws surplus AGI tokens held by the contract while paused. Reverts if `amount > withdrawableAGI()`.
 
 ### `contributeToRewardPool(uint256 amount)`
 Transfers tokens to the contract and emits `RewardPoolContribution`.

--- a/docs/ops/parameter-safety.md
+++ b/docs/ops/parameter-safety.md
@@ -48,7 +48,7 @@ This document is a production-grade **operator checklist** for preventing and re
 | `clubRootNode`, `agentRootNode` (constructor) | ENS namehash | Eligibility gating. | Must match intended ENS hierarchy. | Wrong root nodes → `_verifyOwnership` fails → validators/agents cannot qualify. | Use `additional*` allowlist; redeploy if pervasive. |
 | `validatorMerkleRoot`, `agentMerkleRoot` (constructor) | Merkle root | Eligibility gating. | Must match allowlists; immutable after deploy. | Bad root means Merkle proofs always fail; gating relies solely on ENS or allowlist. | Use `additional*` allowlist or redeploy. |
 | `ens`, `nameWrapper` (constructor) | contract address | ENS/NameWrapper ownership checks. | Must be correct chain-specific addresses. | Wrong addresses → ownership checks fail; `_verifyOwnership` emits recovery events and returns false. | Use `additional*` allowlist or redeploy. |
-| `withdrawAGI` | token amount | Owner withdraws surplus (`withdrawableAGI()`). | Only withdraw when `withdrawableAGI()` is positive. | Withdrawal reverts if amount exceeds surplus. | Use `withdrawableAGI()` to size withdrawals; do not rely on raw balance. |
+| `withdrawAGI` | token amount | Owner withdraws surplus (`withdrawableAGI()`) while paused. | Only withdraw when paused and `withdrawableAGI()` is positive. | Withdrawal reverts if amount exceeds surplus. | Use `withdrawableAGI()` to size withdrawals; do not rely on raw balance. |
 | `baseIpfsUrl` (`setBaseIpfsUrl`) | string URL | Token URI for job NFTs. | Stable HTTP/IPFS base. | Wrong value breaks NFT metadata display (no settlement impact). | Update base URL; metadata reads fixed retroactively. |
 | `termsAndConditionsIpfsHash`, `contactEmail`, `additionalText1/2/3` | strings | UI/legal metadata only. | Non-empty strings recommended. | Mis-set affects UI/legal metadata only. | Update strings. |
 | `listNFT` price | token amount | Marketplace list price. | Must be > 0. | Zero price reverts listing; invalid price prevents sale. | Re-list with valid price. |
@@ -72,7 +72,7 @@ This document is a production-grade **operator checklist** for preventing and re
    - **Escape hatch:** lower thresholds, add validators via `addAdditionalValidator`, or moderator resolves disputes.
 
 4. **Owner attempts to withdraw escrow**
-   - **Prerequisite:** `withdrawAGI` called while jobs outstanding.
+   - **Prerequisite:** `withdrawAGI` called while jobs outstanding (and paused).
    - **Failure:** Withdrawal reverts with `InsufficientWithdrawableBalance`.
    - **Escape hatch:** use `withdrawableAGI()` to withdraw surplus only.
 

--- a/docs/roles/OWNER_OPERATOR.md
+++ b/docs/roles/OWNER_OPERATOR.md
@@ -40,7 +40,7 @@ This guide covers administrative operations and safety controls.
 - `updateAdditionalText1/2/3(string)`
 
 ### Financial operations
-- `withdrawAGI(amount)` withdraws surplus ERC‑20 and reverts if `amount > withdrawableAGI()`.
+- `withdrawAGI(amount)` withdraws surplus ERC‑20 while paused and reverts if `amount > withdrawableAGI()`.
 
 ## Safety checklist
 - Use a multisig or hardware wallet for the owner address.

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -653,6 +653,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
     it("withdraws AGI with bounds checks", async () => {
       await token.mint(manager.address, payout);
+      await expectRevert(manager.withdrawAGI(payout, { from: owner }), "Pausable: not paused");
+      await manager.pause({ from: owner });
       await expectCustomError(manager.withdrawAGI.call(0, { from: owner }), "InvalidParameters");
       await expectCustomError(
         manager.withdrawAGI.call(payout.muln(2), { from: owner }),

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -417,6 +417,8 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.contributeToRewardPool(web3.utils.toWei("5"), { from: employer });
       await expectRevert.unspecified(manager.withdrawAGI(0, { from: owner }));
       await expectRevert.unspecified(manager.withdrawAGI(web3.utils.toWei("100"), { from: owner }));
+      await expectRevert(manager.withdrawAGI(web3.utils.toWei("5"), { from: owner }), "Pausable: not paused");
+      await manager.pause({ from: owner });
       await manager.withdrawAGI(web3.utils.toWei("5"), { from: owner });
       const balance = await token.balanceOf(manager.address);
       assert.equal(balance.toString(), "0");

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -111,6 +111,8 @@ contract("AGIJobManager admin ops", (accounts) => {
     await token.mint(manager.address, surplus, { from: owner });
 
     const balanceBefore = await token.balanceOf(owner);
+    await expectRevert(manager.withdrawAGI(surplus, { from: owner }), "Pausable: not paused");
+    await manager.pause({ from: owner });
     await expectCustomError(
       manager.withdrawAGI.call(payout, { from: owner }),
       "InsufficientWithdrawableBalance"
@@ -138,6 +140,7 @@ contract("AGIJobManager admin ops", (accounts) => {
 
     await failing.transfer(managerFailing.address, toBN(toWei("2")), { from: owner });
     await failing.setFailTransfers(true, { from: owner });
+    await managerFailing.pause({ from: owner });
     await expectCustomError(
       managerFailing.withdrawAGI.call(toBN(toWei("1")), { from: owner }),
       "TransferFailed"


### PR DESCRIPTION
### Motivation
- Prevent the owner from accidentally withdrawing tokens that are reserved for active job escrows by enforcing a clear safety rail. 
- Preserve existing `lockedEscrow` / `withdrawableAGI()` accounting and make surplus recovery explicit and auditable. 

### Description
- Require `withdrawAGI` to be callable only when the contract is paused by adding the `whenPaused` guard to `withdrawAGI(uint256 amount)` in `contracts/AGIJobManager.sol`. 
- Keep the prior surplus check using `withdrawableAGI()` so withdrawals remain limited to `balance - lockedEscrow` and revert on insolvency. 
- Update tests to assert paused-only behavior and to pause the contract before performing successful surplus withdrawals (tests modified under `test/*` to reflect the new guard). 
- Update operator & reference docs (`docs/REFERENCE.md`, `docs/AGIJobManager.md`, `docs/ParameterSafety.md`, `docs/ops/parameter-safety.md`, `docs/roles/OWNER_OPERATOR.md`) to document that `withdrawAGI` requires the contract to be paused and that `withdrawableAGI()` is the sizing helper. 

### Testing
- Ran the repository test suite with `npm test` (which runs `truffle compile` and the mocha suites) after updating tests; compilation succeeded and all tests passed. 
- Test run summary: full test run completed with all tests passing (176 passing). 
- Notes: contracts compiled with `solc 0.8.33`; test run produced expected compile warnings only and no failing tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ec461b07c833391fad6d5066f796e)