### PR TITLE
test: cover escrow release on delist path

### DIFF
--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -89,6 +89,11 @@ contract("AGIJobManager escrow accounting", (accounts) => {
   it("releases escrow on terminal transitions", async () => {
     const payout = toBN(toWei("3"));
 
+    const delistJobId = await createJob(payout);
+    assert.equal((await manager.lockedEscrow()).toString(), payout.toString());
+    await manager.delistJob(delistJobId, { from: owner });
+    assert.equal((await manager.lockedEscrow()).toString(), "0");
+
     const cancelJobId = await createJob(payout);
     assert.equal((await manager.lockedEscrow()).toString(), payout.toString());
     await manager.cancelJob(cancelJobId, { from: employer });


### PR DESCRIPTION
### Motivation
- Ensure owner `delistJob` releases job escrow (decrements `lockedEscrow`) so surplus accounting and withdraw guards remain correct.

### Description
- Add a small test in `test/escrowAccounting.test.js` that creates a job, calls `delistJob` as the owner, and asserts that `lockedEscrow` returns to zero.

### Testing
- Ran `npm test` (which executes the Truffle test suite); all tests passed locally including the new case (`176 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ecac1e49883339e2f56b2b8c655eb)