### PR TITLE
Harden marketplace purchase flow with CEI and ERC‑721 safe transfers

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ npx truffle migrate --network development
 - **Eligibility gating**: Merkle roots and ENS dependencies are immutable post-deploy; misconfiguration requires redeployment.
 - **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
 - **Marketplace reentrancy guard**: `purchaseNFT` is protected by `nonReentrant` because it crosses an external ERC‑20 `transferFrom` boundary; removing this protection requires a redeploy even though the ABI is unchanged.
+- **Marketplace safe transfer**: `purchaseNFT` uses ERC‑721 safe transfer semantics; contract buyers must implement `onERC721Received` or the purchase will revert.
 - **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
 - **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline unless off‑chain policies intervene.
 - **Dispute strings**: `resolveDispute` accepts any string, but only the exact `agent win` / `employer win` values trigger settlement; other strings just clear the dispute flag.

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -755,9 +755,13 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
     function purchaseNFT(uint256 tokenId) external nonReentrant {
         Listing storage listing = listings[tokenId];
         if (!listing.isActive) revert InvalidState();
-        _tFrom(msg.sender, listing.seller, listing.price);
-        _transfer(listing.seller, msg.sender, tokenId);
+        if (listing.seller == address(0)) revert InvalidState();
+        if (listing.seller == msg.sender) revert NotAuthorized();
+        if (listing.price == 0) revert InvalidParameters();
+        if (ownerOf(tokenId) != listing.seller) revert InvalidState();
         listing.isActive = false;
+        _tFrom(msg.sender, listing.seller, listing.price);
+        _safeTransfer(listing.seller, msg.sender, tokenId, "");
         emit NFTPurchased(tokenId, msg.sender, listing.price);
     }
 

--- a/contracts/test/MarketplaceReceiverMocks.sol
+++ b/contracts/test/MarketplaceReceiverMocks.sol
@@ -1,0 +1,38 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.17;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+
+interface IAGIJobManagerMarketplace {
+    function purchaseNFT(uint256 tokenId) external;
+}
+
+contract NonReceiverBuyer {
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+
+    function purchase(address manager, uint256 tokenId) external {
+        IAGIJobManagerMarketplace(manager).purchaseNFT(tokenId);
+    }
+}
+
+contract ERC721ReceiverBuyer is IERC721Receiver {
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+
+    function purchase(address manager, uint256 tokenId) external {
+        IAGIJobManagerMarketplace(manager).purchaseNFT(tokenId);
+    }
+
+    function onERC721Received(
+        address,
+        address,
+        uint256,
+        bytes calldata
+    ) external pure override returns (bytes4) {
+        return IERC721Receiver.onERC721Received.selector;
+    }
+}

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -150,7 +150,7 @@ If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for obs
 ## NFT issuance and marketplace
 - **Minting**: completion mints a job NFT to the employer, with `tokenURI = baseIpfsUrl + '/' + job.ipfsHash`.
 - **Listings**: NFT owners can list tokens without escrow; listings live in the `listings` mapping.
-- **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT.
+- **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT using ERC‑721 safe transfer semantics; contract buyers must implement `onERC721Received`.
 
 ## Reward pool contributions
 `contributeToRewardPool` allows any address to transfer ERC‑20 into the contract. These funds increase the contract’s balance and are withdrawable by the owner via `withdrawAGI` while paused.

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -30,7 +30,7 @@ See [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md) for details.
 `ReentrancyGuard` is applied to:
 - `createJob`, `applyForJob`, `validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `cancelJob`, `withdrawAGI`, `contributeToRewardPool`, `purchaseNFT`.
 
-Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and `_transfer` (ERC‑721) rather than `safeTransferFrom`. Marketplace purchases are guarded because `purchaseNFT` crosses an external ERC‑20 `transferFrom` boundary before transferring the ERC‑721.
+Functions without `nonReentrant` include `requestJobCompletion`, `listNFT`, and `delistNFT`. `purchaseNFT` uses `transferFrom` (ERC‑20) and ERC‑721 safe transfer semantics, so contract buyers must implement `onERC721Received`. Marketplace purchases are guarded because `purchaseNFT` crosses an external ERC‑20 `transferFrom` boundary before transferring the ERC‑721.
 
 ## Known limitations and assumptions
 - **Root immutability**: there are no on‑chain setters for root nodes or Merkle roots after deployment. Misconfiguration requires redeployment.

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -450,12 +450,12 @@ contract("AGIJobManager scenario coverage", (accounts) => {
 
     await token.mint(employer, price, { from: owner });
     await token.approve(manager.address, price, { from: employer });
-    await manager.purchaseNFT(tokenId, { from: employer });
+    await expectCustomError(manager.purchaseNFT.call(tokenId, { from: employer }), "NotAuthorized");
 
     const listing = await manager.listings(tokenId);
-    assert.strictEqual(listing.isActive, false, "listing should clear after self-purchase");
+    assert.strictEqual(listing.isActive, true, "listing should remain active after self-purchase attempt");
     const ownerOfToken = await manager.ownerOf(tokenId);
-    assert.equal(ownerOfToken, employer, "self-purchase keeps NFT ownership unchanged");
+    assert.equal(ownerOfToken, employer, "self-purchase attempt keeps NFT ownership unchanged");
   });
 
   it("prevents validators from approving and disapproving the same job", async () => {


### PR DESCRIPTION
### Motivation
- Prevent NFT loss and reentrancy risks in the marketplace purchase path by enforcing ERC‑721 receiver semantics and checks‑effects‑interactions ordering in `purchaseNFT`.
- Ensure contract buyers must implement `onERC721Received`, so purchases to contracts without the hook revert instead of silently losing NFTs.
- Add minimal tests and docs to lock in the behavior and avoid regressions.

### Description
- Reworked `purchaseNFT` to validate inputs, set `listing.isActive = false` (effects) before external calls, then perform interactions; kept `nonReentrant` for defense‑in‑depth and CEI ordering.
- Replaced raw ERC‑721 `_transfer` with `_safeTransfer(listing.seller, msg.sender, tokenId, "")` so contract buyers must implement `onERC721Received`.
- Added additional preconditions in `purchaseNFT`: check `listing.seller != address(0)`, `listing.seller != msg.sender`, `listing.price != 0`, and `ownerOf(tokenId) == listing.seller`.
- Added `contracts/test/MarketplaceReceiverMocks.sol` with `NonReceiverBuyer` and `ERC721ReceiverBuyer` and updated tests in `test/nftMarketplace.test.js` and `test/scenarioLifecycle.marketplace.test.js` to exercise receiver/non‑receiver behavior and to assert self‑purchase is rejected.
- Updated documentation (`README.md`, `docs/AGIJobManager.md`, `docs/Security.md`) to note that `purchaseNFT` uses ERC‑721 safe transfer semantics and that contract buyers must implement `onERC721Received`.

### Testing
- Installed dependencies and compiled: `npm install` and `npm run build` (Truffle compile) completed successfully.
- Ran full test suite: `npm test`; compilation succeeded and tests passed.
- Automated test results: full suite passed (reported `178 passing`) and ABI smoke tests passed; new tests for receiver behavior passed.
- New/modified automated tests added: `reverts when buyer contract lacks ERC721 receiver hooks` and `allows purchase by ERC721 receiver contract` (in `test/nftMarketplace.test.js`) and a self‑purchase assertion fix in `test/scenarioLifecycle.marketplace.test.js`, all verified green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ed60194908333be5647058fb61f38)