### PR TITLE
docs: clarify marketplace safe transfer requirement

### DIFF
--- a/docs/roles/NFT_MARKETPLACE.md
+++ b/docs/roles/NFT_MARKETPLACE.md
@@ -12,6 +12,9 @@ Call `listNFT(tokenId, price)` from the wallet that owns the NFT.
 ### 2) Purchase an NFT
 The buyer must approve the AGIJobManager contract to spend the purchase amount.
 Call `purchaseNFT(tokenId)` from the buyer wallet.
+Marketplace purchases use ERC-721 safe transfer semantics.
+If the buyer is a smart contract, it must implement `IERC721Receiver` /
+`onERC721Received` or the purchase will revert.
 
 ### 3) Delist an NFT
 If you change your mind before it sells, call `delistNFT(tokenId)` from the seller wallet.


### PR DESCRIPTION
### Motivation
- Make the marketplace behavior explicit so integrators know that `purchaseNFT` uses ERC‑721 safe transfer semantics and contract buyers must implement `IERC721Receiver`/`onERC721Received` or the purchase will revert.

### Description
- Add a short note to `docs/roles/NFT_MARKETPLACE.md` explaining that marketplace purchases use ERC‑721 safe transfers and that smart contract buyers must implement `IERC721Receiver`/`onERC721Received` to succeed.

### Testing
- Ran `npm ci` (failed with `fsevents` platform mismatch on Linux); ran `npm install` successfully; ran `npm run lint` successfully; ran `npm test` (Truffle test suite) and observed the full test run complete with `178 passing` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ee470a7fc83338d4ebd61a1fba032)