### PR TITLE
Enforce pause on NFT marketplace actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,6 +181,10 @@ npx truffle migrate --network development
 - **Dispute resolution codes**: moderators should use `resolveDisputeWithCode(jobId, code, reason)` with `code = 0 (NO_ACTION)`, `1 (AGENT_WIN)`, or `2 (EMPLOYER_WIN)`. The `reason` is freeform and does not control settlement. The legacy string-based `resolveDispute` is deprecated; non‑canonical strings map to `NO_ACTION` and keep the dispute active.
 - **Agent payout snapshot**: the agent payout percentage is snapshotted at `applyForJob` and used at completion; later NFT transfers do **not** change payout for that job. Agents must have a nonzero AGI‑type payout tier at apply time (0% tiers cannot accept jobs), and `additionalAgents` only bypass identity checks (not payout eligibility).
 
+## Pause behavior
+
+Pause is an incident-response safety control. When paused, all job lifecycle actions **and** marketplace actions (listNFT, delistNFT, purchaseNFT) are disabled; read-only/view functions continue to work. Resume operations by unpausing once the issue is resolved.
+
 See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known limitations.
 
 ## Documentation

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -772,14 +772,14 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit NFTIssued(tokenId, job.employer, tokenURI);
     }
 
-    function listNFT(uint256 tokenId, uint256 price) external {
+    function listNFT(uint256 tokenId, uint256 price) external whenNotPaused {
         if (ownerOf(tokenId) != msg.sender) revert NotAuthorized();
         if (price == 0) revert InvalidParameters();
         listings[tokenId] = Listing(tokenId, msg.sender, price, true);
         emit NFTListed(tokenId, msg.sender, price);
     }
 
-    function purchaseNFT(uint256 tokenId) external nonReentrant {
+    function purchaseNFT(uint256 tokenId) external whenNotPaused nonReentrant {
         Listing storage listing = listings[tokenId];
         if (!listing.isActive) revert InvalidState();
         address seller = listing.seller;
@@ -794,7 +794,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit NFTPurchased(tokenId, msg.sender, price);
     }
 
-    function delistNFT(uint256 tokenId) external {
+    function delistNFT(uint256 tokenId) external whenNotPaused {
         Listing storage listing = listings[tokenId];
         if (!listing.isActive || listing.seller != msg.sender) revert NotAuthorized();
         listing.isActive = false;

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -116,6 +116,7 @@ If the contract address has no code on the active chain, the UI shows a warning 
 - The UI only talks to your wallet provider (e.g., MetaMask). No keys or secrets are collected.
 - Always verify the contract address and chainId before signing transactions.
 - The UI runs a **staticCall preflight** for every state-changing action (including cancel and admin). If a call would revert, it surfaces the reason before you sign.
+- If the UI shows the contract is paused, wait for an unpause or switch to a different deployment before attempting marketplace or job actions.
 
 ## Employer lifecycle completeness: cancel job
 


### PR DESCRIPTION
### Motivation
- Close a pause-safety gap so marketplace value-moving actions are frozen during incident response, matching existing job lifecycle pause behavior. 
- Prevent any external ERC-20/ERC-721 interactions from being attempted while the contract is paused. 
- Keep changes minimal and ABI-stable while following existing checks-effects-interactions and access control patterns.

### Description
- Gate `listNFT`, `delistNFT`, and `purchaseNFT` with the `whenNotPaused` modifier so the marketplace respects contract pause state, with `purchaseNFT` keeping `nonReentrant` and ordering `whenNotPaused` at entry. 
- Retained existing checks-effects-interactions: listings are deactivated (`listing.isActive = false`) before external transfers and safe ERC-721 transfers remain unchanged. 
- Added a targeted Truffle test (`test/nftMarketplace.test.js`) that asserts marketplace actions revert while paused and succeed after `unpause`, with a helper `expectPausedRevert` that accepts OZ revert strings or custom error selectors. 
- Small docs updates: added a `Pause behavior` paragraph to `README.md` and a UI hint in `docs/ui/README.md` advising users to wait for unpause or switch deployments when the contract is paused.

### Testing
- Ran `npm install` (succeeded), then `npx truffle compile` (succeeded with warnings) and `npm run lint` (succeeded). 
- Ran `npx truffle test --network test` and the full test suite; all tests passed (`181 passing`). 
- Ran `npm test` and `npm run test:ui`; both completed successfully (UI smoke tests passed). 
- Note: running `npx truffle test` without `--network test` failed to connect to `http://127.0.0.1:8545` because no local node was running, which is an environment issue and not a code regression.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f71c481c0833399bfd4ad5a50bf94)