### PR TITLE
Update docs to reflect jobSpec/jobCompletion metadata workflow and tokenURI semantics

### DIFF
--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -36,7 +36,7 @@ Refer to the ABI‑derived access map in [`Interface.md`](Interface.md).
 
 ### Job
 Each job is a struct containing:
-- `id`, `employer`, `ipfsHash`, `payout`, `duration`, `assignedAgent`, `assignedAt`, `details`.
+- `id`, `employer`, `jobSpecURI`, `jobCompletionURI`, legacy `ipfsHash`, `payout`, `duration`, `assignedAgent`, `assignedAt`, `details`.
 - State flags: `completed`, `completionRequested`, `disputed`, `expired`.
 - Timestamps: `completionRequestedAt`, `disputedAt`.
 - Validation: `validatorApprovals`, `validatorDisapprovals`, per‑validator `approvals` and `disapprovals`, plus the `validators` list.
@@ -149,7 +149,7 @@ Agents and validators must either:
 If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for observability and continues evaluation.
 
 ## NFT issuance and marketplace
-- **Minting**: completion mints a job NFT to the employer, with `tokenURI = baseIpfsUrl + '/' + job.ipfsHash`.
+- **Minting**: completion mints a job NFT to the employer, with `tokenURI` pointing to the job completion metadata. The contract uses `jobCompletionURI` when set and falls back to the legacy `ipfsHash` for older jobs. Full URIs (e.g., `ipfs://...` or `https://...`) are accepted; otherwise `baseIpfsUrl` is prepended.
 - **Listings**: NFT owners can list tokens without escrow; listings live in the `listings` mapping.
 - **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT using ERC‑721 safe transfer semantics; contract buyers must implement `onERC721Received`.
 

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -34,7 +34,7 @@
 | `getApproved(uint256 tokenId)` | view | address |
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
-| `jobs(uint256)` | view | uint256, address, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool, uint8, bool |
+| `jobs(uint256)` | view | uint256, address, string, string, string, uint256, uint256, address, uint256, bool, bool, uint256, uint256, bool, string, uint256, uint256, bool, uint8, bool |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
 | `lockedEscrow()` | view | uint256 |
 | `maxJobPayout()` | view | uint256 |
@@ -65,9 +65,9 @@
 | `validatorMerkleRoot()` | view | bytes32 |
 | `pause()` | nonpayable | — |
 | `unpause()` | nonpayable | — |
-| `createJob(string _ipfsHash, uint256 _payout, uint256 _duration, string _details)` | nonpayable | — |
+| `createJob(string _jobSpecURI, uint256 _payout, uint256 _duration, string _details)` | nonpayable | — |
 | `applyForJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
-| `requestJobCompletion(uint256 _jobId, string _ipfsHash)` | nonpayable | — |
+| `requestJobCompletion(uint256 _jobId, string _jobCompletionURI)` | nonpayable | — |
 | `validateJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
 | `disapproveJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
 | `disputeJob(uint256 _jobId)` | nonpayable | — |
@@ -133,8 +133,8 @@
 | `JobApplied(uint256 jobId, address agent)` | uint256 jobId, address agent |
 | `JobCancelled(uint256 jobId)` | uint256 jobId |
 | `JobCompleted(uint256 jobId, address agent, uint256 reputationPoints)` | uint256 jobId, address agent, uint256 reputationPoints |
-| `JobCompletionRequested(uint256 jobId, address agent)` | uint256 jobId, address agent |
-| `JobCreated(uint256 jobId, string ipfsHash, uint256 payout, uint256 duration, string details)` | uint256 jobId, string ipfsHash, uint256 payout, uint256 duration, string details |
+| `JobCompletionRequested(uint256 jobId, address agent, string jobCompletionURI)` | uint256 jobId, address agent, string jobCompletionURI |
+| `JobCreated(uint256 jobId, string jobSpecURI, uint256 payout, uint256 duration, string details)` | uint256 jobId, string jobSpecURI, uint256 payout, uint256 duration, string details |
 | `JobDisapproved(uint256 jobId, address validator)` | uint256 jobId, address validator |
 | `JobDisputed(uint256 jobId, address disputant)` | uint256 jobId, address disputant |
 | `JobExpired(uint256 jobId, address employer, address agent, uint256 payout)` | uint256 jobId, address employer, address agent, uint256 payout |

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -22,14 +22,14 @@ The following `public` state variables have auto‑generated getter functions:
 - `agiTypes(index)`
 
 ## Core workflow
-### `createJob(string ipfsHash, uint256 payout, uint256 duration, string details)`
+### `createJob(string jobSpecURI, uint256 payout, uint256 duration, string details)`
 Escrows `payout` tokens and creates a job. Emits `JobCreated`.
 
 ### `applyForJob(uint256 jobId, string subdomain, bytes32[] proof)`
 Assigns the agent if identity checks pass. The agent payout tier is **snapshotted at assignment time** and stored on the job. Agents without a payout tier (0%) cannot apply; `additionalAgents` only bypass identity checks. Emits `JobApplied`.
 
-### `requestJobCompletion(uint256 jobId, string ipfsHash)`
-Marks completion requested and updates the job’s `ipfsHash`. Emits `JobCompletionRequested`.
+### `requestJobCompletion(uint256 jobId, string jobCompletionURI)`
+Marks completion requested and updates the job’s `jobCompletionURI`. Emits `JobCompletionRequested`.
 
 ### `validateJob(uint256 jobId, string subdomain, bytes32[] proof)`
 Validator approval. Emits `JobValidated`. When approvals reach threshold, completes the job.
@@ -78,7 +78,7 @@ Explicit allowlists for roles, bypassing ENS/Merkle checks.
 Changes the ERC‑20 token used for payouts.
 
 ### `setBaseIpfsUrl(string)`
-Base prefix for minted NFT tokenURIs.
+Base prefix for minted NFT tokenURIs when a job URI is a bare CID.
 
 ### `setRequiredValidatorApprovals(uint256)`
 ### `setRequiredValidatorDisapprovals(uint256)`

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -29,15 +29,15 @@ sequenceDiagram
   participant ValidatorB
   participant Contract
 
-  Employer->>Contract: createJob(ipfsHash,payout,duration,details)
+  Employer->>Contract: createJob(jobSpecURI,payout,duration,details)
   Agent->>Contract: applyForJob(jobId, subdomain, proof)
-  Agent->>Contract: requestJobCompletion(jobId, ipfsHash)
+  Agent->>Contract: requestJobCompletion(jobId, jobCompletionURI)
   ValidatorA->>Contract: validateJob(jobId, subdomain, proof)
   ValidatorB->>Contract: validateJob(jobId, subdomain, proof)
   Contract-->>Agent: AGI payout (transfer)
   Contract-->>ValidatorA: validation reward
   Contract-->>ValidatorB: validation reward
-  Contract-->>Employer: NFT minted (tokenURI=base/ipfsHash)
+  Contract-->>Employer: NFT minted (tokenURI=jobCompletionURI)
 ```
 
 ### Dispute path (disapproval or manual dispute → moderator resolution)
@@ -120,11 +120,11 @@ await nameWrapper.setOwner(subnode(clubRoot, "validator-a"), validatorA);
 await nameWrapper.setOwner(subnode(clubRoot, "validator-b"), validatorB);
 
 // Create & complete job
-const jobTx = await manager.createJob("ipfs-job", web3.utils.toWei("100"), 3600, "details", { from: employer });
+const jobTx = await manager.createJob("ipfs-job-spec", web3.utils.toWei("100"), 3600, "details", { from: employer });
 const jobId = jobTx.logs[0].args.jobId.toNumber();
 
 await manager.applyForJob(jobId, "agent", [], { from: agent });
-await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+await manager.requestJobCompletion(jobId, "ipfs-completion", { from: agent });
 
 await manager.setRequiredValidatorApprovals(2, { from: owner });
 await manager.validateJob(jobId, "validator-a", [], { from: validatorA });
@@ -157,8 +157,8 @@ This path uses the Etherscan **Write Contract** UI. You will need the contract a
 > **Screenshot placeholder:** (Add screenshot of Etherscan “Write Contract” tab with wallet connected.)
 
 **Employer**
-1. `createJob(ipfsHash, payout, duration, details)`
-   - `ipfsHash`: CID or hash only (no “ipfs://” prefix)
+1. `createJob(jobSpecURI, payout, duration, details)`
+   - `jobSpecURI`: ERC‑721 metadata URI (full `ipfs://...` or `https://...` recommended)
    - `payout`: integer in token wei (18 decimals)
    - `duration`: seconds
    - `details`: short plain text
@@ -169,7 +169,7 @@ This path uses the Etherscan **Write Contract** UI. You will need the contract a
 1. `applyForJob(jobId, subdomain, proof)`
    - `subdomain`: your ENS/NameWrapper subdomain label (ex: `alice`)
    - `proof`: Merkle proof array if using allowlist, else `[]`
-2. `requestJobCompletion(jobId, ipfsHash)` after work is done.
+2. `requestJobCompletion(jobId, jobCompletionURI)` after work is done.
 
 **Validator**
 1. `validateJob(jobId, subdomain, proof)` to approve.
@@ -177,7 +177,7 @@ This path uses the Etherscan **Write Contract** UI. You will need the contract a
 
 **Moderator**
 1. `resolveDisputeWithCode(jobId, resolutionCode, reason)`
-   - Use exactly `"agent win"` or `"employer win"` to trigger payouts/refunds.
+   - Use `1` for agent win, `2` for employer win, `0` to log a note and keep the dispute active.
 
 **NFT Marketplace**
 1. `listNFT(tokenId, price)`
@@ -191,7 +191,7 @@ Every step emits events and changes state/balances.
 | --- | --- | --- | --- |
 | `createJob` | `JobCreated` | employer → contract escrow | new job stored |
 | `applyForJob` | `JobApplied` | none | `assignedAgent`, `assignedAt` |
-| `requestJobCompletion` | `JobCompletionRequested` | none | `completionRequested`, `ipfsHash` |
+| `requestJobCompletion` | `JobCompletionRequested` | none | `completionRequested`, `jobCompletionURI` |
 | `validateJob` | `JobValidated` | none (until threshold) | `validatorApprovals`, validator maps |
 | `disapproveJob` | `JobDisapproved`, maybe `JobDisputed` | none | `validatorDisapprovals`, `disputed` |
 | `resolveDisputeWithCode(AGENT_WIN)` | `DisputeResolvedWithCode`, `DisputeResolved`, `JobCompleted`, `NFTIssued` | contract → agent/validators | `completed`, reputation updates |

--- a/docs/case-studies/LEGACY_AGI_JOB_12_VS_NEW.md
+++ b/docs/case-studies/LEGACY_AGI_JOB_12_VS_NEW.md
@@ -234,7 +234,7 @@ In the test:
 6) Assertions:
    - `JobCompleted` + `NFTIssued`
    - NFT minted to employer
-   - `tokenURI = baseIpfsUrl + "/" + ipfsHash`
+   - `tokenURI = jobCompletionURI` (full URI or `baseIpfsUrl + "/" + cid`)
    - AGI token balances updated as expected
 
 **Better‑only assertions in the replay test**

--- a/docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md
+++ b/docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md
@@ -83,8 +83,8 @@ These steps assume you are using a block explorer like Etherscan and have the co
    - Go to the ERC‑20 contract → **Write Contract** → `approve(spender, amount)`
    - Use a **small, exact amount** (avoid unlimited approvals).
 3. **Create a job**
-   - Call `createJob(ipfsHash, payout, duration, details)`
-   - `ipfsHash`: just the hash/CID (no `ipfs://` prefix)
+   - Call `createJob(jobSpecURI, payout, duration, details)`
+   - `jobSpecURI`: ERC‑721 metadata URI (full `ipfs://...` or `https://...` recommended)
    - `payout`: token amount in **wei** (18 decimals)
    - `duration`: seconds
 4. **Track your jobId** from the `JobCreated` event.
@@ -213,7 +213,7 @@ sequenceDiagram
 
   Employer->>Contract: createJob(...)
   Agent->>Contract: applyForJob(jobId, subdomain, proof)
-  Agent->>Contract: requestJobCompletion(jobId, ipfsHash)
+  Agent->>Contract: requestJobCompletion(jobId, jobCompletionURI)
   Validator->>Contract: validateJob(jobId, subdomain, proof)
   Contract-->>Agent: payout
   Contract-->>Employer: NFT receipt

--- a/docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md
+++ b/docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md
@@ -29,11 +29,11 @@ If you are not using a Merkle allowlist, pass `[]` for `proof`.
 
 ### Employer
 1. `approve(AGIJobManager, amount)` on the ERC‑20 token.
-2. `createJob(ipfsHash, payout, duration, details)`.
+2. `createJob(jobSpecURI, payout, duration, details)`.
 
 ### Agent
 1. `applyForJob(jobId, "helper", proof)`.
-2. `requestJobCompletion(jobId, ipfsHash)`.
+2. `requestJobCompletion(jobId, jobCompletionURI)`.
 
 ### Validator
 1. `validateJob(jobId, "alice", proof)`.

--- a/docs/roles/AGENT.md
+++ b/docs/roles/AGENT.md
@@ -23,12 +23,12 @@ Call `applyForJob(jobId, subdomain, proof)`.
 - State: `assignedAgent` set to your address
 
 ### 3) Request completion
-Call `requestJobCompletion(jobId, ipfsHash)` before the job duration expires.
-- `ipfsHash` should point to your final deliverable.
+Generate/upload the **job completion metadata** JSON and call `requestJobCompletion(jobId, jobCompletionURI)` before the job duration expires.
+- `jobCompletionURI` should point to the ERC‑721 metadata JSON (see [`docs/job-metadata.md`](../job-metadata.md)).
 
 **On‑chain results**
 - Event: `JobCompletionRequested`
-- State: job’s `ipfsHash` updated
+- State: job’s `jobCompletionURI` updated
 
 ### 4) Wait for validator approvals
 Once enough validators approve, the job completes automatically and you are paid.
@@ -50,6 +50,7 @@ Once enough validators approve, the job completes automatically and you are paid
 ### State fields to inspect
 - `jobs[jobId].assignedAt`
 - `jobs[jobId].completionRequested`
+- `jobs[jobId].jobCompletionURI`
 
 ### Events to index
 `JobApplied`, `JobCompletionRequested`, `JobCompleted`, `ReputationUpdated`, `OwnershipVerified`

--- a/docs/roles/EMPLOYER.md
+++ b/docs/roles/EMPLOYER.md
@@ -13,8 +13,8 @@ This guide is for job posters (employers). It shows how to safely create and man
 Use your wallet or Etherscan to approve **only the exact payout amount**.
 
 ### 2) Create a job
-Call `createJob(ipfsHash, payout, duration, details)`.
-- **ipfsHash**: CID/hash only (no `ipfs://`)
+Generate/upload the **job spec metadata** JSON and call `createJob(jobSpecURI, payout, duration, details)`.
+- **jobSpecURI**: ERC‑721 metadata URI (full `ipfs://...` or `https://...` is recommended)
 - **payout**: token amount (18 decimals)
 - **duration**: seconds (max `jobDurationLimit`)
 - **details**: short plain text
@@ -37,7 +37,7 @@ Call `disputeJob(jobId)` if you disagree with the completion or validation direc
 ### 6) Receive NFT receipt
 When a job completes, an NFT is minted to your wallet.
 - Event: `NFTIssued`
-- Token URI: `baseIpfsUrl + "/" + ipfsHash`
+- Token URI: points to the **job completion metadata** (`jobCompletionURI`, with `baseIpfsUrl` fallback)
 
 ## Common mistakes
 - **Insufficient allowance** → `TransferFailed`


### PR DESCRIPTION
### Motivation
- Align repository documentation with the recommended job metadata workflow so the UI and integrators treat `jobSpec` and `jobCompletion` as distinct, versioned ERC‑721 metadata artifacts. 
- Make the metadata upload/URI flow and minting expectations explicit so marketplaces and users know that the NFT `tokenURI` should point to completion metadata. 
- Keep code changes minimal and non-breaking by updating docs and user guides first (the contract already contains `jobSpecURI`/`jobCompletionURI` fields and guards). 

### Description
- Updated core spec and reference docs to use `jobSpecURI` and `jobCompletionURI` (including `docs/AGIJobManager.md`, `docs/Interface.md`, and `docs/REFERENCE.md`). 
- Revised user and role guides to describe form-driven spec generation, manual upload guidance, completion metadata expectations, and the fact that minted NFTs point to completion metadata (`docs/USERS.md`, `docs/roles/EMPLOYER.md`, `docs/roles/AGENT.md`). 
- Updated namespace/quickstart and case‑study docs to use the new URI inputs and to document the `JobCreated` / `JobCompletionRequested` event shapes and `NFTIssued` tokenURI behavior (`docs/namespace/*`, `docs/case-studies/*`). 
- Regenerated the ABI/interface doc (`node scripts/generate-interface-doc.js`) and committed the doc updates; no contract source logic or UI code was modified in this PR. 

### Testing
- Ran `npm run build` (Truffle compile) and compilation completed successfully. 
- Ran the full test suite with `npm test` (Truffle tests + node test runner) and observed all contract tests passing (`182 passing`). 
- Ran UI smoke checks with `npm run test:ui` and the UI indexer helpers tests passed (all UI smoke tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f88ba0ea883338c572af0de91ae1a)