### PR TITLE
Require completion request before validator actions and settlement

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,11 +45,9 @@ stateDiagram-v2
     Created --> Assigned: applyForJob
     Assigned --> CompletionRequested: requestJobCompletion
 
-    Assigned --> Completed: validateJob (approval threshold)
     CompletionRequested --> Completed: validateJob (approval threshold)
     CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
 
-    Assigned --> Disputed: disapproveJob (disapproval threshold)
     CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
     Assigned --> Disputed: disputeJob (manual)
     CompletionRequested --> Disputed: disputeJob (manual)
@@ -64,7 +62,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
-*Note:* `validateJob` does **not** require `completionRequested`; validators can approve/disapprove at any time while the job is assigned and not completed. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested).
+*Note:* Validators may only `validateJob` / `disapproveJob` after `requestJobCompletion` has been called, and settlement paths that complete a job require a completion request. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested).
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid
@@ -177,7 +175,7 @@ npx truffle migrate --network development
 - **Marketplace reentrancy guard**: `purchaseNFT` is protected by `nonReentrant` because it crosses an external ERC‑20 `transferFrom` boundary; removing this protection requires a redeploy even though the ABI is unchanged.
 - **Marketplace safe transfer**: `purchaseNFT` uses ERC‑721 safe transfer semantics; contract buyers must implement `onERC721Received` or the purchase will revert.
 - **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
-- **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline unless off‑chain policies intervene.
+- **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can only act after a completion request, so late approvals/disapprovals require a timely completion submission.
 - **Dispute resolution codes**: moderators should use `resolveDisputeWithCode(jobId, code, reason)` with `code = 0 (NO_ACTION)`, `1 (AGENT_WIN)`, or `2 (EMPLOYER_WIN)`. The `reason` is freeform and does not control settlement. The legacy string-based `resolveDispute` is deprecated; non‑canonical strings map to `NO_ACTION` and keep the dispute active.
 - **Agent payout snapshot**: the agent payout percentage is snapshotted at `applyForJob` and used at completion; later NFT transfers do **not** change payout for that job. Agents must have a nonzero AGI‑type payout tier at apply time (0% tiers cannot accept jobs), and `additionalAgents` only bypass identity checks (not payout eligibility).
 

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -381,6 +381,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         if (job.assignedAgent == address(0)) revert InvalidState();
         if (job.completed) revert InvalidState();
         if (job.expired) revert InvalidState();
+        if (!job.completionRequested) revert InvalidState();
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnership(msg.sender, subdomain, proof, clubRootNode))) revert NotAuthorized();
         if (job.approvals[msg.sender]) revert InvalidState();
@@ -400,6 +401,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         if (job.assignedAgent == address(0)) revert InvalidState();
         if (job.completed) revert InvalidState();
         if (job.expired) revert InvalidState();
+        if (!job.completionRequested) revert InvalidState();
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnership(msg.sender, subdomain, proof, clubRootNode))) revert NotAuthorized();
         if (job.disapprovals[msg.sender]) revert InvalidState();
@@ -714,6 +716,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         Job storage job = _job(_jobId);
         if (job.completed || job.expired) revert InvalidState();
         if (job.assignedAgent == address(0)) revert InvalidState();
+        if (!job.completionRequested) revert InvalidState();
 
         uint256 agentPayoutPercentage = job.agentPayoutPct;
         if (agentPayoutPercentage == 0) revert InvalidAgentPayoutSnapshot();

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -51,6 +51,7 @@ sequenceDiagram
 
   Employer->>Contract: createJob(...)
   Agent->>Contract: applyForJob(...)
+  Agent->>Contract: requestJobCompletion(jobId, jobCompletionURI)
   Validator->>Contract: disapproveJob(...)
   Contract-->>Contract: job.disputed = true
   Employer->>Contract: disputeJob(jobId)
@@ -172,8 +173,8 @@ This path uses the Etherscan **Write Contract** UI. You will need the contract a
 2. `requestJobCompletion(jobId, jobCompletionURI)` after work is done.
 
 **Validator**
-1. `validateJob(jobId, subdomain, proof)` to approve.
-2. `disapproveJob(jobId, subdomain, proof)` to reject (may trigger dispute).
+1. `validateJob(jobId, subdomain, proof)` to approve (only after completion is requested).
+2. `disapproveJob(jobId, subdomain, proof)` to reject (only after completion is requested; may trigger dispute).
 
 **Moderator**
 1. `resolveDisputeWithCode(jobId, resolutionCode, reason)`
@@ -192,8 +193,8 @@ Every step emits events and changes state/balances.
 | `createJob` | `JobCreated` | employer → contract escrow | new job stored |
 | `applyForJob` | `JobApplied` | none | `assignedAgent`, `assignedAt` |
 | `requestJobCompletion` | `JobCompletionRequested` | none | `completionRequested`, `jobCompletionURI` |
-| `validateJob` | `JobValidated` | none (until threshold) | `validatorApprovals`, validator maps |
-| `disapproveJob` | `JobDisapproved`, maybe `JobDisputed` | none | `validatorDisapprovals`, `disputed` |
+| `validateJob` | `JobValidated` | none (until threshold) | `validatorApprovals`, validator maps (requires completion request) |
+| `disapproveJob` | `JobDisapproved`, maybe `JobDisputed` | none | `validatorDisapprovals`, `disputed` (requires completion request) |
 | `resolveDisputeWithCode(AGENT_WIN)` | `DisputeResolvedWithCode`, `DisputeResolved`, `JobCompleted`, `NFTIssued` | contract → agent/validators | `completed`, reputation updates |
 | `resolveDisputeWithCode(EMPLOYER_WIN)` | `DisputeResolvedWithCode`, `DisputeResolved` | contract → employer refund | `completed` |
 | `listNFT` | `NFTListed` | none | listing active |

--- a/docs/roles/VALIDATOR.md
+++ b/docs/roles/VALIDATOR.md
@@ -11,14 +11,14 @@ You must satisfy **one** of these:
 ## Step‑by‑step (non‑technical)
 > **Screenshot placeholder:** Etherscan “Write Contract” tab showing `validateJob` inputs filled in.
 ### 1) Validate a job
-Call `validateJob(jobId, subdomain, proof)`.
+Call `validateJob(jobId, subdomain, proof)` **after** the agent has requested completion.
 
 **On‑chain results**
 - Event: `JobValidated`
 - State: validator approval count increments
 
 ### 2) Disapprove a job (if needed)
-Call `disapproveJob(jobId, subdomain, proof)`.
+Call `disapproveJob(jobId, subdomain, proof)` **after** the agent has requested completion.
 
 **On‑chain results**
 - Event: `JobDisapproved`
@@ -35,6 +35,7 @@ When a job completes:
 - Validators gain reputation points.
 
 ## Common mistakes
+- Voting before completion is requested → `InvalidState`
 - Voting twice → `InvalidState`
 - Not authorized (identity gate) → `NotAuthorized`
 - Blacklisted → `Blacklisted`

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -4138,6 +4138,13 @@
         const label = ids("validateSubdomain").value.trim();
         if (!label) throw new Error("Label is required.");
         const proof = parseProof(ids("validateProof").value);
+        if (state.readContract) {
+          const job = await state.readContract.jobs(jobId);
+          const completionRequested = job[10];
+          if (!completionRequested) {
+            throw new Error("Awaiting completion submission from agent.");
+          }
+        }
         await sendTx("validateJob", [jobId, label, proof], "Validate job");
       } catch (error) {
         showAlert(error.message);
@@ -4150,6 +4157,13 @@
         const label = ids("disapproveSubdomain").value.trim();
         if (!label) throw new Error("Label is required.");
         const proof = parseProof(ids("disapproveProof").value);
+        if (state.readContract) {
+          const job = await state.readContract.jobs(jobId);
+          const completionRequested = job[10];
+          if (!completionRequested) {
+            throw new Error("Awaiting completion submission from agent.");
+          }
+        }
         await sendTx("disapproveJob", [jobId, label, proof], "Disapprove job");
       } catch (error) {
         showAlert(error.message);

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -256,6 +256,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.validateJob(0, "validator", [], { from: validatorOne });
 
       await expectCustomError(
@@ -278,6 +279,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.validateJob(0, "validator", [], { from: validatorOne });
 
       const tokenIdAfterCompletion = await manager.nextTokenId();
@@ -323,6 +325,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.disputeJob(0, { from: agent });
 
       const agentBalanceBefore = await token.balanceOf(agent);
@@ -341,6 +344,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.addAdditionalAgent(agent, { from: owner });
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
     });
 
     it("blocks double voting and mixed approve/disapprove", async () => {
@@ -404,6 +408,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.setRequiredValidatorApprovals(1, { from: owner });
       await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
       await agiTypeNft.mint(agent);
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.validateJob(0, "validator", [], { from: validatorOne });
 
       await expectCustomError(
@@ -448,6 +453,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.setRequiredValidatorDisapprovals(2, { from: owner });
 
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.disapproveJob(0, "validator", [], { from: validatorOne });
       const receipt = await manager.disapproveJob(0, "validator", [], { from: validatorTwo });
       expectEvent(receipt, "JobDisputed", { jobId: new BN(0), disputant: validatorTwo });
@@ -462,6 +468,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await agiTypeNft.mint(agent);
 
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.disputeJob(0, { from: employer });
       await expectCustomError(
         manager.resolveDisputeWithCode.call(0, 1, "agent win", { from: outsider }),
@@ -493,6 +500,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await agiTypeNft.mint(agent);
 
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.validateJob(0, "validator", [], { from: validatorOne });
       await expectCustomError(manager.disputeJob.call(0, { from: employer }), "InvalidState");
     });
@@ -547,6 +555,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await failingToken.setFailTransfers(true);
       await altManager.addModerator(moderator, { from: owner });
+      await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await altManager.disputeJob(0, { from: agent });
       await expectCustomError(
         altManager.resolveDispute.call(0, "agent win", { from: moderator }),
@@ -578,6 +587,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await failingToken.approve(altManager.address, payout, { from: employer });
       await altManager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer });
       await altManager.applyForJob(0, "agent", [], { from: agent });
+      await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
 
       await failingToken.setFailTransfers(true);
       await expectCustomError(
@@ -612,6 +622,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await altManager.applyForJob(0, "agent", [], { from: agent });
       await altManager.addAdditionalValidator(validatorOne, { from: owner });
       await altManager.setRequiredValidatorApprovals(1, { from: owner });
+      await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await altManager.validateJob(0, "validator", [], { from: validatorOne });
 
       const tokenId = (await altManager.nextTokenId()).subn(1);
@@ -726,6 +737,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await manager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await manager.validateJob(0, "validator", [], { from: validatorOne });
     });
 
@@ -813,6 +825,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await createJob(employer, payout, duration, "QmResolver");
       await setResolverOwnership(ens, resolver, clubRoot, "validator", validatorOne);
       await manager.applyForJob(1, "agent", agentTree.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(1, updatedIpfs, { from: agent });
       await manager.validateJob(1, "validator", [], { from: validatorOne });
     });
   });

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -200,6 +200,19 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await expectRevert.unspecified(manager.delistJob(99, { from: owner }));
     });
 
+    it("blocks validator actions before completion is requested", async () => {
+      const payout = web3.utils.toWei("12");
+      const jobId = await createJob({ manager, token, employer, payout });
+      await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+
+      await expectRevert.unspecified(
+        manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator })
+      );
+      await expectRevert.unspecified(
+        manager.disapproveJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator })
+      );
+    });
+
     it("prevents double completion and follow-on payouts", async () => {
       const payout = web3.utils.toWei("50");
       const jobId = await createJob({ manager, token, employer, payout });
@@ -208,6 +221,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.addAGIType(agiType.address, 92, { from: owner });
 
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
 
       await expectRevert.unspecified(
@@ -224,6 +238,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.addAGIType(agiType.address, 92, { from: owner });
 
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
       await manager.addModerator(moderator, { from: owner });
 
@@ -239,6 +254,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await expectRevert.unspecified(manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent }));
       await manager.blacklistAgent(agent, false, { from: owner });
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await manager.blacklistValidator(validator, true, { from: owner });
       await expectRevert.unspecified(
@@ -267,6 +283,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       const payout = web3.utils.toWei("18");
       const jobId = await createJob({ manager, token, employer, payout });
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disapproveJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
       const job = await manager.jobs(jobId);
       assert.equal(job.disputed, true);
@@ -302,6 +319,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
 
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
       await manager.addModerator(moderator, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
 
       const agentBalanceBefore = web3.utils.toBN(await token.balanceOf(agent));
@@ -363,6 +381,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await agiType.mint(agent, { from: owner });
       await failingManager.addAGIType(agiType.address, 92, { from: owner });
       await failingManager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await failingManager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await failingToken.setFailTransfers(true, { from: owner });
       await expectRevert.unspecified(
@@ -396,6 +415,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await agiType.mint(agent, { from: owner });
       await failingManager.addAGIType(agiType.address, 92, { from: owner });
       await failingManager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await failingManager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await failingManager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
 
       const tokenId = (await failingManager.nextTokenId()).toNumber() - 1;
@@ -453,6 +473,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await agiType.mint(agent, { from: owner });
       await manager.addAGIType(agiType.address, 92, { from: owner });
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
 
       const tokenId = (await manager.nextTokenId()).toNumber() - 1;
@@ -474,6 +495,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       const jobId = await createJob({ manager, token, employer, payout });
 
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await expectRevert.unspecified(manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator }));
       await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
     });
@@ -486,6 +508,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.applyForJob(jobId, "alice", EMPTY_PROOF, { from: agent });
 
       await setResolverOwnership(ens, resolver, rootNode("club-root"), "validator", validator);
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
     });
   });

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -372,6 +372,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
 
       await manager.setRequiredValidatorApprovals(1, { from: owner });
       const agentBalanceBefore = new BN(await token.balanceOf(agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
       const agentBalanceAfter = new BN(await token.balanceOf(agent));
 
@@ -391,6 +392,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
 
       await manager.setRequiredValidatorApprovals(1, { from: owner });
       const agentBalanceBefore = new BN(await token.balanceOf(other));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: other });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
       const agentBalanceAfter = new BN(await token.balanceOf(other));
 
@@ -419,6 +421,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
 
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       await manager.addModerator(moderator, { from: owner });
@@ -441,6 +444,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       await expectCustomError(manager.disputeJob(jobId, { from: employer }), "InvalidState");
@@ -455,6 +459,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
 
       await manager.addModerator(moderator, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
 
       const agentBalanceBefore = new BN(await token.balanceOf(agent));
@@ -480,6 +485,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       );
 
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
       await expectCustomError(
@@ -509,6 +515,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("6"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await expectCustomError(
         manager.validateJob(jobId, "validator", buildProof(validatorTree, other), { from: other }),
@@ -522,6 +529,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("9"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await expectCustomError(manager.disputeJob(jobId, { from: other }), "NotAuthorized");
 
@@ -555,6 +563,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("30"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
 
       const agentBalanceBefore = new BN(await token.balanceOf(agent));
@@ -664,6 +673,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await nft.mint(agent, { from: owner });
       await managerFailing.applyForJob(jobId, "agent", buildProof(agentTree, agent), { from: agent });
       await managerFailing.setRequiredValidatorApprovals(1, { from: owner });
+      await managerFailing.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await failing.setFailTransfers(true, { from: owner });
       await expectCustomError(
@@ -696,6 +706,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await nft.mint(agent, { from: owner });
       await managerFailing.applyForJob(jobId, "agent", buildProof(agentTree, agent), { from: agent });
       await managerFailing.setRequiredValidatorApprovals(1, { from: owner });
+      await managerFailing.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await managerFailing.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const tokenId = (await managerFailing.nextTokenId()).subn(1);
@@ -823,6 +834,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const { jobId } = await createJob(manager, token, employer, payout, 1000, "ipfs-6");
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const tokenId = (await manager.nextTokenId()).subn(1);
@@ -839,6 +851,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await manager.addAGIType(nft.address, 92, { from: owner });
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const rep = await manager.reputation(agent);
@@ -856,6 +869,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const tokenId = (await manager.nextTokenId()).subn(1);
@@ -884,6 +898,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const { jobId } = await createJob(manager, token, employer, payout, 1000, "ipfs-2");
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const tokenId = (await manager.nextTokenId()).subn(1);
@@ -900,6 +915,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const { jobId } = await createJob(manager, token, employer, payout, 1000, "ipfs-3");
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", buildProof(validatorTree, validator1), { from: validator1 });
 
       const tokenId = (await manager.nextTokenId()).subn(1);
@@ -943,6 +959,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await manager.applyForJob(jobId, "agent", buildProof(agentTree, agent), { from: agent });
       await manager.setRequiredValidatorApprovals(1, { from: owner });
 
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, subdomain, [], { from: validator4 });
     });
 
@@ -956,6 +973,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
 
       await manager.applyForJob(jobId, "ignored", [], { from: other });
       await manager.setRequiredValidatorApprovals(1, { from: owner });
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: other });
       await manager.validateJob(jobId, "ignored", [], { from: other });
     });
   });

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -80,6 +80,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     const snapshotPct = await manager.getJobAgentPayoutPct(jobId);
     assert.strictEqual(snapshotPct.toNumber(), 75);
 
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await agiType.transferFrom(agent, other, tokenId, { from: agent });
     const agentBalanceBefore = await token.balanceOf(agent);
 
@@ -105,6 +106,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     const snapshotPct = await manager.getJobAgentPayoutPct(jobId);
     assert.strictEqual(snapshotPct.toNumber(), 25);
 
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await agiType75.mint(agent, { from: owner });
     const agentBalanceBefore = await token.balanceOf(agent);
 
@@ -141,6 +143,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     const snapshotPct = await manager.getJobAgentPayoutPct(jobId);
     assert.strictEqual(snapshotPct.toNumber(), 60);
 
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await agiType.transferFrom(agent, other, tokenId, { from: agent });
     const agentBalanceBefore = await token.balanceOf(agent);
 

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -119,6 +119,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await expectCustomError(
       manager.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
@@ -156,6 +157,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
 
     const agentBalance = await token.balanceOf(agent);

--- a/test/erc20Compatibility.noReturn.test.js
+++ b/test/erc20Compatibility.noReturn.test.js
@@ -69,6 +69,7 @@ contract("AGIJobManager ERC20 compatibility", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "", [], { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     const validateTx = await manager.validateJob(jobId, "", [], { from: validator });
     const nftIssued = validateTx.logs.find((log) => log.event === "NFTIssued");
     const tokenId = nftIssued.args.tokenId.toNumber();

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -70,6 +70,7 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
 
     const jobId2 = await createJob();
     await manager.applyForJob(jobId2, 'agent', EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId2, 'ipfs-complete', { from: agent });
     await manager.disapproveJob(jobId2, 'club', EMPTY_PROOF, { from: validator });
     await manager.resolveDispute(jobId2, 'employer win', { from: moderator });
 

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -106,6 +106,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
 
     const completeJobId = await createJob(payout);
     await manager.applyForJob(completeJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(completeJobId, "ipfs-complete", { from: agent });
     await manager.validateJob(completeJobId, "", EMPTY_PROOF, { from: validator });
     assert.equal((await manager.lockedEscrow()).toString(), "0");
 

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -77,6 +77,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
     const jobId = await createJob();
     await setNameWrapperOwnership(nameWrapper, agentRoot, "helper", agent);
     await manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await setResolverOwnership(ens, resolver, clubRoot, "alice", validator);
 
@@ -116,6 +117,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
     await manager.addAdditionalValidator(validator, { from: owner });
 
     await manager.applyForJob(jobId, "helper", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     const tx = await manager.validateJob(jobId, "alice", EMPTY_PROOF, { from: validator });
 
     const validatedEvent = tx.logs.find((log) => log.event === "JobValidated");

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -57,6 +57,7 @@ async function createJob(manager, token, employer, payout) {
 async function createAssignedJob(manager, token, employer, agent, payout) {
   const jobId = await createJob(manager, token, employer, payout);
   await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+  await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
   return jobId;
 }
 

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -190,6 +190,7 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await manager.blacklistAgent(agent, false, { from: owner });
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await manager.blacklistValidator(validatorA, true, { from: owner });
     await expectCustomError(

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -170,24 +170,25 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     assert.equal((await token.balanceOf(manager.address)).toString(), "0", "escrow should be cleared");
   });
 
-  it("completes without an explicit completion request when validators approve", async () => {
+  it("completes after an explicit completion request when validators approve", async () => {
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     const payout = toBN(toWei("18"));
     await token.mint(employer, payout, { from: owner });
 
-    const { jobId } = await createJobWithApproval(payout, "ipfs-no-request");
+    const { jobId } = await createJobWithApproval(payout, "ipfs-job");
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     const completionTx = await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
     assert.ok(completionTx.logs.find((log) => log.event === "JobCompleted"), "JobCompleted should emit");
 
     const job = await manager.jobs(jobId);
     assert.strictEqual(job.completed, true, "job should complete with validator approvals");
-    assert.strictEqual(job.completionRequested, false, "completionRequested should remain false without request");
+    assert.strictEqual(job.completionRequested, true, "completionRequested should remain true after request");
 
     const tokenId = completionTx.logs.find((log) => log.event === "NFTIssued").args.tokenId.toNumber();
     const tokenUri = await manager.tokenURI(tokenId);
-    assert.equal(tokenUri, "ipfs://base/ipfs-no-request", "token URI should use the job spec URI fallback");
+    assert.equal(tokenUri, "ipfs://base/ipfs-complete", "token URI should use completion metadata");
     assert.equal(await manager.ownerOf(tokenId), employer, "employer should receive the NFT");
     assert.equal((await token.balanceOf(manager.address)).toString(), "0", "escrow should clear after completion");
   });

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -116,6 +116,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-done", { from: agent });
 
     await manager.disputeJob(jobId, { from: employer });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
@@ -133,6 +134,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-done", { from: agent });
 
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
     await expectCustomError(
@@ -148,6 +150,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTxTwo = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobIdTwo = createTxTwo.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobIdTwo, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobIdTwo, "ipfs-done", { from: agent });
     await manager.setRequiredValidatorDisapprovals(1, { from: owner });
     await manager.disapproveJob(jobIdTwo, "validator", EMPTY_PROOF, { from: validator });
 

--- a/test/validatorCap.test.js
+++ b/test/validatorCap.test.js
@@ -89,6 +89,7 @@ contract("AGIJobManager validator cap", (accounts) => {
     const payout = toBN(toWei("10"));
     const jobId = await createJob(manager, token, employer, payout);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     const validators = Array.from({ length: cap + 1 }, () => web3.eth.accounts.create());
     for (const validator of validators) {
@@ -122,6 +123,7 @@ contract("AGIJobManager validator cap", (accounts) => {
     const payout = toBN(toWei("20"));
     const jobId = await createJob(manager, token, employer, payout);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     const validators = Array.from({ length: cap }, () => web3.eth.accounts.create());
     for (const validator of validators) {


### PR DESCRIPTION
### Motivation
- Prevent validators from approving/disapproving (and thus triggering settlement or disputes) before an agent submits completion metadata, avoiding premature payouts and NFT minting. 
- Ensure settlement via `_completeJob()` only occurs when a completion request exists so the minted NFT references completion metadata rather than the original job spec. 
- Keep changes minimal and focused on state-machine hardening without altering storage layout or access controls. 

### Description
- Add explicit completion-request guards: `if (!job.completionRequested) revert InvalidState();` to `validateJob`, `disapproveJob`, and `_completeJob` in `contracts/AGIJobManager.sol`. 
- Update test coverage to assert the new lifecycle rule, including a new negative test `blocks validator actions before completion is requested` and many test adjustments to call `requestJobCompletion(...)` where validators now must act. 
- Update UI and docs to reflect the lifecycle change: the dapp now blocks validator actions until `completionRequested` and shows a clear message, and README/USERS/VALIDATOR guides were updated to document the rule. 
- Keep all other business logic, access modifiers, and storage layout unchanged. 

### Testing
- Tests updated/added: added the pre-completion validator revert test in `test/AGIJobManager.exhaustive.test.js` and updated many existing tests to call `requestJobCompletion(...)` before validator actions (files modified include `test/*.test.js`, `test/*.truffle.test.js`, and `test/*.truffle.js`). 
- UI/doc smoke adjustments: `docs/ui/agijobmanager.html`, `README.md`, `docs/USERS.md`, and `docs/roles/VALIDATOR.md` updated to reflect and enforce the new guard. 
- No test suite was executed in this rollout environment; please run the full test suite locally/CI with `npm test` (or `npx truffle test`) to validate all changes — the patch intentionally updates tests to align with the new invariant and should pass once run in CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697f9374d3c08333b0482ab52c747e3d)