### PR TITLE
Require completion request before validator settlement; allow agents to request completion during disputes

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution can still complete a job even if completion was never requested.
+*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may request completion even while a job is disputed.
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -109,7 +109,7 @@ stateDiagram-v2
     Created --> Cancelled: delistJob (owner)
 ```
 
-**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution can still complete a job even if completion was never requested. **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
+**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution now requires a prior completion request so settlement always carries completion metadata; agents may request completion even while a job is disputed. **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
 
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,7 +51,7 @@ This allows tests to pass `_verifyOwnership` without external dependencies.
 ## Scenario coverage (contract-level)
 The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the contract in deterministic flows that map to the lifecycle diagram in the README:
 - **Create → apply → validate → complete** with escrow funding, payouts, reputation updates, and NFT issuance.
-- **Assigned → validate → complete** without a completion request to cover the direct validator approval path.
+- **Assigned → completion request → validate → complete** to cover the validator approval path after submission.
 - **Cancel** before assignment with escrow refunds and job deletion semantics.
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
 - **Neutral dispute escrow** behavior (funds remain locked until validators complete the job after a non-canonical resolution).

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -300,6 +300,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     await manager.createJob("ipfs-dispute", payout, 1000, "details", { from: employer });
 
     await manager.applyForJob(jobId, subdomains.agent, EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     const beforeTokenId = await manager.nextTokenId();


### PR DESCRIPTION
### Motivation
- Ensure validators cannot approve or disapprove a job before the assigned agent submits completion metadata by requiring `completionRequested == true` for validator actions and final completion paths.
- Prevent `_completeJob` from finalizing a job without completion metadata so settlements always carry agent-provided metadata.
- Fix the edge case where an early dispute could permanently block an agent-win settlement by allowing the assigned agent to call `requestJobCompletion` even while the job is disputed so moderator `AGENT_WIN` resolutions can complete with metadata.

### Description
- Require completion metadata by removing the `allowMissingCompletionRequest` parameter and making `_completeJob(uint256)` always revert when `job.completionRequested` is false, and update all internal callers to the new signature (`validateJob`, `resolveDispute`, `resolveStaleDispute`, and `finalizeJob`).
- Allow agents to request completion while a job is disputed by removing the `job.disputed` check from `requestJobCompletion` so disputed jobs can accept completion metadata for later agent-win settlement.
- Add and update tests to cover the new guards and flows, including rejection of validator votes before completion is requested and a regression that demonstrates completion requests during disputes enable agent-win settlement; update `caseStudies.job12.replay.test.js` to request completion where required.
- Update documentation (`README.md`, `docs/AGIJobManager.md`, `docs/TESTING.md`) to reflect the new requirement that validators need a completion request and that agents may request completion during disputes.

### Testing
- Installed dependencies with `npm install` and compiled contracts as part of the test run.
- Ran the targeted regression suite with `npx truffle test --network test test/securityRegression.test.js`, and the suite completed successfully with `10 passing` tests.
- Compilation warnings were observed from dependencies and contract size, but compilation succeeded and the updated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa21da69c83338b467127b96f3daf)