### PR TITLE
Require completion request before validator settlement; allow agents to request completion during disputes (including after duration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution can still complete a job even if completion was never requested.
+*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration.
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -366,8 +366,8 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
     function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external whenNotPaused {
         Job storage job = _job(_jobId);
         if (msg.sender != job.assignedAgent) revert NotAuthorized();
-        if (job.completed || job.disputed || job.expired) revert InvalidState();
-        if (block.timestamp > job.assignedAt + job.duration) revert InvalidState();
+        if (job.completed || job.expired) revert InvalidState();
+        if (!job.disputed && block.timestamp > job.assignedAt + job.duration) revert InvalidState();
         if (job.completionRequested) revert InvalidState();
         _requireValidUri(_jobCompletionURI);
         job.jobCompletionURI = _jobCompletionURI;
@@ -393,7 +393,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         job.validators.push(msg.sender);
         validatorApprovedJobs[msg.sender].push(_jobId);
         emit JobValidated(_jobId, msg.sender);
-        if (job.validatorApprovals >= requiredValidatorApprovals) _completeJob(_jobId, false);
+        if (job.validatorApprovals >= requiredValidatorApprovals) _completeJob(_jobId);
     }
 
     function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
@@ -468,7 +468,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         job.disputedAt = 0;
 
         if (resolutionCode == uint8(DisputeResolutionCode.AGENT_WIN)) {
-            _completeJob(_jobId, true);
+            _completeJob(_jobId);
         } else if (resolutionCode == uint8(DisputeResolutionCode.EMPLOYER_WIN)) {
             _refundEmployer(job);
         } else {
@@ -492,7 +492,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         if (employerWins) {
             _refundEmployer(job);
         } else {
-            _completeJob(_jobId, true);
+            _completeJob(_jobId);
         }
 
         job.disputed = false;
@@ -691,7 +691,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         }
 
         if (requiredValidatorApprovals > 0 && job.validatorApprovals >= requiredValidatorApprovals) {
-            _completeJob(_jobId, false);
+            _completeJob(_jobId);
             emit JobFinalized(_jobId, job.assignedAgent, job.employer, true, job.payout);
             return;
         }
@@ -704,7 +704,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         }
 
         if (agentWins) {
-            _completeJob(_jobId, false);
+            _completeJob(_jobId);
         } else {
             _refundEmployer(job);
         }
@@ -712,11 +712,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit JobFinalized(_jobId, job.assignedAgent, job.employer, agentWins, job.payout);
     }
 
-    function _completeJob(uint256 _jobId, bool allowMissingCompletionRequest) internal {
+    function _completeJob(uint256 _jobId) internal {
         Job storage job = _job(_jobId);
         if (job.completed || job.expired) revert InvalidState();
         if (job.assignedAgent == address(0)) revert InvalidState();
-        if (!job.completionRequested && !allowMissingCompletionRequest) revert InvalidState();
+        if (!job.completionRequested) revert InvalidState();
 
         uint256 agentPayoutPercentage = job.agentPayoutPct;
         if (agentPayoutPercentage == 0) revert InvalidAgentPayoutSnapshot();

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -109,7 +109,7 @@ stateDiagram-v2
     Created --> Cancelled: delistJob (owner)
 ```
 
-**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution can still complete a job even if completion was never requested. **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
+**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution now requires a prior completion request so settlement always carries completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration. **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
 
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,7 +51,7 @@ This allows tests to pass `_verifyOwnership` without external dependencies.
 ## Scenario coverage (contract-level)
 The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the contract in deterministic flows that map to the lifecycle diagram in the README:
 - **Create → apply → validate → complete** with escrow funding, payouts, reputation updates, and NFT issuance.
-- **Assigned → validate → complete** without a completion request to cover the direct validator approval path.
+- **Assigned → completion request → validate → complete** to cover the validator approval path after submission.
 - **Cancel** before assignment with escrow refunds and job deletion semantics.
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
 - **Neutral dispute escrow** behavior (funds remain locked until validators complete the job after a non-canonical resolution).

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -300,6 +300,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     await manager.createJob("ipfs-dispute", payout, 1000, "details", { from: employer });
 
     await manager.applyForJob(jobId, subdomains.agent, EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     const beforeTokenId = await manager.nextTokenId();

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -1,4 +1,5 @@
 const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
 
 const AGIJobManager = artifacts.require("AGIJobManager");
 const MockERC20 = artifacts.require("MockERC20");
@@ -116,6 +117,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await manager.disputeJob(jobId, { from: employer });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
@@ -123,6 +125,73 @@ contract("AGIJobManager security regressions", (accounts) => {
     const agentBalance = await token.balanceOf(agent);
     const expectedPayout = payout.muln(92).divn(100);
     assert.equal(agentBalance.toString(), expectedPayout.toString(), "agent payout should succeed without validators");
+  });
+
+  it("rejects validator approvals before completion is requested", async () => {
+    const payout = toBN(toWei("12"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidState"
+    );
+  });
+
+  it("rejects validator disapprovals before completion is requested", async () => {
+    const payout = toBN(toWei("12"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidState"
+    );
+  });
+
+  it("allows completion request during disputes so agent-win can resolve", async () => {
+    const payout = toBN(toWei("18"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-complete", { from: agent });
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "agent-win dispute should complete after completion request");
+    assert.strictEqual(job.completionRequested, true, "completion request should be recorded");
+  });
+
+  it("allows completion request after duration when disputed", async () => {
+    const payout = toBN(toWei("14"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 5, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+    await time.increase(6);
+
+    await manager.requestJobCompletion(jobId, "ipfs-late-complete", { from: agent });
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "agent-win dispute should complete after late completion request");
+    assert.strictEqual(job.completionRequested, true, "completion request should be recorded");
   });
 
   it("enforces vote rules and dispute thresholds", async () => {


### PR DESCRIPTION
### Motivation
- Ensure validators cannot approve or disapprove a job until the assigned agent has submitted completion metadata so settlements always carry completion info and premature payouts are prevented. 
- Avoid deadlocks for agent-win dispute resolutions when an employer opens a dispute after the job `duration` by allowing agents to submit completion metadata while a job is `disputed`, including after the nominal duration. 
- Keep the changes localized to state-machine guards, internal callers, tests, and docs without changing storage layout or access control.

### Description
- Enforced that `_completeJob` always requires `completionRequested` by removing the `allowMissingCompletionRequest` parameter and making `_completeJob(_jobId)` revert when `job.completionRequested` is false. 
- Allowed agents to call `requestJobCompletion` for disputed jobs (and permitted completion submissions after the nominal duration when `job.disputed == true`) by changing the duration/dispute checks in `requestJobCompletion`. 
- Updated internal callers to the new `_completeJob(_jobId)` signature (auto-complete in `validateJob`, moderator `AGENT_WIN` resolution, `resolveStaleDispute`, and `finalizeJob`) and adjusted a case study test that relied on the old behavior. 
- Updated test coverage and documentation by adding/regressing tests in `test/securityRegression.test.js` and `test/caseStudies.job12.replay.test.js`, and by updating `README.md`, `docs/AGIJobManager.md`, and `docs/TESTING.md` to document the lifecycle change.

### Testing
- Ran `npx truffle test --network test test/securityRegression.test.js` (after `npm install` to satisfy environment deps) which compiled contracts and executed the suite successfully with `11 passing`. 
- The test run included contract compilation (solc 0.8.33) and validated the new dispute-time and post-duration completion request paths and validator guard behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa21da69c83338b467127b96f3daf)