### PR TITLE
Require completion request before validator settlement; allow agents to request completion during disputes (including when paused)

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution can still complete a job even if completion was never requested.
+*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed (and during a pause for disputed jobs).
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -363,11 +363,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit JobApplied(_jobId, msg.sender);
     }
 
-    function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external whenNotPaused {
+    function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external {
         Job storage job = _job(_jobId);
         if (msg.sender != job.assignedAgent) revert NotAuthorized();
-        if (job.completed || job.disputed || job.expired) revert InvalidState();
-        if (block.timestamp > job.assignedAt + job.duration) revert InvalidState();
+        if (paused() && !job.disputed) revert InvalidState();
+        if (job.completed || job.expired) revert InvalidState();
+        if (!job.disputed && block.timestamp > job.assignedAt + job.duration) revert InvalidState();
         if (job.completionRequested) revert InvalidState();
         _requireValidUri(_jobCompletionURI);
         job.jobCompletionURI = _jobCompletionURI;
@@ -393,7 +394,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         job.validators.push(msg.sender);
         validatorApprovedJobs[msg.sender].push(_jobId);
         emit JobValidated(_jobId, msg.sender);
-        if (job.validatorApprovals >= requiredValidatorApprovals) _completeJob(_jobId, false);
+        if (job.validatorApprovals >= requiredValidatorApprovals) _completeJob(_jobId);
     }
 
     function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
@@ -468,7 +469,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         job.disputedAt = 0;
 
         if (resolutionCode == uint8(DisputeResolutionCode.AGENT_WIN)) {
-            _completeJob(_jobId, true);
+            _completeJob(_jobId);
         } else if (resolutionCode == uint8(DisputeResolutionCode.EMPLOYER_WIN)) {
             _refundEmployer(job);
         } else {
@@ -492,7 +493,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         if (employerWins) {
             _refundEmployer(job);
         } else {
-            _completeJob(_jobId, true);
+            _completeJob(_jobId);
         }
 
         job.disputed = false;
@@ -691,7 +692,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         }
 
         if (requiredValidatorApprovals > 0 && job.validatorApprovals >= requiredValidatorApprovals) {
-            _completeJob(_jobId, false);
+            _completeJob(_jobId);
             emit JobFinalized(_jobId, job.assignedAgent, job.employer, true, job.payout);
             return;
         }
@@ -704,7 +705,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         }
 
         if (agentWins) {
-            _completeJob(_jobId, false);
+            _completeJob(_jobId);
         } else {
             _refundEmployer(job);
         }
@@ -712,11 +713,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         emit JobFinalized(_jobId, job.assignedAgent, job.employer, agentWins, job.payout);
     }
 
-    function _completeJob(uint256 _jobId, bool allowMissingCompletionRequest) internal {
+    function _completeJob(uint256 _jobId) internal {
         Job storage job = _job(_jobId);
         if (job.completed || job.expired) revert InvalidState();
         if (job.assignedAgent == address(0)) revert InvalidState();
-        if (!job.completionRequested && !allowMissingCompletionRequest) revert InvalidState();
+        if (!job.completionRequested) revert InvalidState();
 
         uint256 agentPayoutPercentage = job.agentPayoutPct;
         if (agentPayoutPercentage == 0) revert InvalidAgentPayoutSnapshot();

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -109,7 +109,7 @@ stateDiagram-v2
     Created --> Cancelled: delistJob (owner)
 ```
 
-**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution can still complete a job even if completion was never requested. **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
+**Finalized** means `completed = true`. An `employer win` finalizes the job *without* agent payout or NFT minting. `resolveDisputeWithCode(NO_ACTION)` only logs a reason and leaves the dispute active (in‑progress flags such as `completionRequested` remain set). Validators can call `validateJob`/`disapproveJob` only after `requestJobCompletion`. Agent‑win dispute resolution now requires a prior completion request so settlement always carries completion metadata, and agents may submit completion even if a dispute is already open (including after the nominal duration, and during a pause for disputed jobs). **Expired** means `expired = true` with the escrow refunded to the employer; expired jobs are terminal and cannot be completed later.
 
 ## Escrow and payout mechanics
 - **Escrow on creation**: `createJob` transfers the payout from employer to the contract via `transferFrom`.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -51,7 +51,7 @@ This allows tests to pass `_verifyOwnership` without external dependencies.
 ## Scenario coverage (contract-level)
 The scenario suite (`test/scenarioLifecycle.marketplace.test.js`) exercises the contract in deterministic flows that map to the lifecycle diagram in the README:
 - **Create → apply → validate → complete** with escrow funding, payouts, reputation updates, and NFT issuance.
-- **Assigned → validate → complete** without a completion request to cover the direct validator approval path.
+- **Assigned → completion request → validate → complete** to cover the validator approval path after submission.
 - **Cancel** before assignment with escrow refunds and job deletion semantics.
 - **Dispute** paths (thresholded disapprovals, manual disputes, moderator resolutions) covering agent win, employer win, and neutral outcomes.
 - **Neutral dispute escrow** behavior (funds remain locked until validators complete the job after a non-canonical resolution).

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -300,6 +300,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     await manager.createJob("ipfs-dispute", payout, 1000, "details", { from: employer });
 
     await manager.applyForJob(jobId, subdomains.agent, EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     const beforeTokenId = await manager.nextTokenId();

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -10,6 +10,7 @@ const FailingERC20 = artifacts.require("FailingERC20");
 
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
+const { time } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -116,6 +117,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await manager.disputeJob(jobId, { from: employer });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
@@ -123,6 +125,94 @@ contract("AGIJobManager security regressions", (accounts) => {
     const agentBalance = await token.balanceOf(agent);
     const expectedPayout = payout.muln(92).divn(100);
     assert.equal(agentBalance.toString(), expectedPayout.toString(), "agent payout should succeed without validators");
+  });
+
+  it("rejects validator approvals before completion is requested", async () => {
+    const payout = toBN(toWei("12"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidState"
+    );
+  });
+
+  it("rejects validator disapprovals before completion is requested", async () => {
+    const payout = toBN(toWei("12"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidState"
+    );
+  });
+
+  it("allows completion request during disputes so agent-win can resolve", async () => {
+    const payout = toBN(toWei("18"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-complete", { from: agent });
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "agent-win dispute should complete after completion request");
+    assert.strictEqual(job.completionRequested, true, "completion request should be recorded");
+  });
+
+  it("allows disputed completion requests after duration expiry for agent-win resolution", async () => {
+    const payout = toBN(toWei("19"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 1, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+
+    await time.increase(2);
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-late", { from: agent });
+    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "agent-win should settle after late completion request");
+    assert.strictEqual(job.completionRequested, true, "late completion request should be recorded");
+  });
+
+  it("allows disputed completion requests while paused for stale dispute agent-win", async () => {
+    const payout = toBN(toWei("21"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const createTx = await manager.createJob("ipfs", payout, 100, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+    await manager.setDisputeReviewPeriod(1, { from: owner });
+
+    await manager.pause({ from: owner });
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-paused", { from: agent });
+    await time.increase(2);
+    await manager.resolveStaleDispute(jobId, false, { from: owner });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "stale dispute agent-win should complete after paused request");
+    assert.strictEqual(job.completionRequested, true, "paused completion request should be recorded");
   });
 
   it("enforces vote rules and dispute thresholds", async () => {


### PR DESCRIPTION
### Motivation
- Ensure settlements always include agent-submitted completion metadata by preventing validators and auto-resolve paths from completing jobs when `completionRequested` is not set.
- Restore the ability for agents to submit completion metadata while a job is `disputed` (including after nominal duration and while the contract is paused) so moderator/owner recovery flows can settle in favor of the agent.

### Description
- Update `requestJobCompletion` in `contracts/AGIJobManager.sol` to remove the `whenNotPaused` modifier and allow completion submissions for disputed jobs, adding a guard `if (paused() && !job.disputed) revert InvalidState();` to keep normal pause semantics.
- Change `_completeJob` to always require `job.completionRequested` by removing the `allowMissingCompletionRequest` parameter and updating all internal callers (`validateJob`, `_resolveDispute` / `resolveDisputeWithCode`, `resolveStaleDispute`, `finalizeJob`) to the new signature `function _completeJob(uint256 _jobId)`.
- Update validation flows to prevent `validateJob`/`disapproveJob` before a completion request (`if (!job.completionRequested) revert InvalidState();`).
- Add and adjust tests in `test/securityRegression.test.js` and `test/caseStudies.job12.replay.test.js` to cover: rejecting validator actions before completion request, allowing completion during disputes, allowing late completion after duration expiry, allowing completion during pause for disputed jobs, and zero-validator agent-win cases.
- Update documentation in `README.md`, `docs/AGIJobManager.md`, and `docs/TESTING.md` to reflect the new lifecycle rules around completion requests, disputed submissions, and paused recovery behavior.

### Testing
- Ran `npx truffle test --network test test/securityRegression.test.js`, which compiled the contracts with `solc 0.8.33` and executed the suite with `12 passing` tests.
- The changes were exercised by the updated regression cases that assert validator gating before completion and that disputed completion submissions succeed while disputed/after expiry/while paused, and those assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fa21da69c83338b467127b96f3daf)