### PR TITLE
Enforce non-empty completion metadata for job settlement

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -365,6 +365,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
 
     function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external {
         Job storage job = _job(_jobId);
+        if (bytes(_jobCompletionURI).length == 0) revert InvalidParameters();
         require(!paused() || job.disputed, "Pausable: paused");
         if (msg.sender != job.assignedAgent) revert NotAuthorized();
         if (job.completed || job.expired) revert InvalidState();
@@ -778,6 +779,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
     }
 
     function _mintJobNft(Job storage job) internal {
+        if (bytes(job.ipfsHash).length == 0) revert InvalidParameters();
         uint256 tokenId = nextTokenId++;
         string memory metadataURI = bytes(job.jobCompletionURI).length > 0 ? job.jobCompletionURI : job.ipfsHash;
         if (bytes(metadataURI).length == 0) revert InvalidParameters();

--- a/contracts/test/TestableAGIJobManager.sol
+++ b/contracts/test/TestableAGIJobManager.sol
@@ -29,4 +29,13 @@ contract TestableAGIJobManager is AGIJobManager {
     function setValidationRewardPercentageUnsafe(uint256 _percentage) external onlyOwner {
         validationRewardPercentage = _percentage;
     }
+
+    function setJobIpfsHashUnsafe(uint256 jobId, string calldata ipfsHash) external onlyOwner {
+        jobs[jobId].ipfsHash = ipfsHash;
+    }
+
+    function mintJobNftUnsafe(uint256 jobId) external onlyOwner {
+        Job storage job = _job(jobId);
+        _mintJobNft(job);
+    }
 }

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -148,6 +148,7 @@ If ENS or NameWrapper calls fail, the contract emits `RecoveryInitiated` for obs
 
 ## NFT issuance and marketplace
 - **Minting**: completion mints a job NFT to the employer, with `tokenURI` pointing to the job completion metadata. The contract uses `jobCompletionURI` when set and falls back to the legacy `ipfsHash` for older jobs. Full URIs (e.g., `ipfs://...` or `https://...`) are accepted; otherwise `baseIpfsUrl` is prepended.
+- **Completion metadata required**: `requestJobCompletion(jobId, jobCompletionURI)` requires a non‑empty completion metadata URI. This URI must resolve to the ERC‑721 metadata JSON for the completion because it becomes the NFT’s `tokenURI` (for example, `ipfs://bafy...` or a CID such as `bafy...` when `baseIpfsUrl` is configured).
 - **Listings**: NFT owners can list tokens without escrow; listings live in the `listings` mapping.
 - **Purchases**: `purchaseNFT` transfers ERC‑20 from buyer to seller and transfers the NFT using ERC‑721 safe transfer semantics; contract buyers must implement `onERC721Received`.
 


### PR DESCRIPTION
### Motivation
- Prevent NFTs with empty or invalid `tokenURI` and stop settlement when a job has no recorded completion metadata.
- Ensure agents cannot request completion with an empty pointer and add a defensive backstop at mint time to catch any bypass paths.

### Description
- In `requestJobCompletion(uint256,string)` added an early check `if (bytes(_jobCompletionURI).length == 0) revert InvalidParameters();` to fail fast before any state changes. (file: `contracts/AGIJobManager.sol`).
- In `_mintJobNft(Job storage)` added `if (bytes(job.ipfsHash).length == 0) revert InvalidParameters();` so minting cannot proceed if the fallback/legacy hash is empty. (file: `contracts/AGIJobManager.sol`).
- Reused the existing `InvalidParameters` custom error for both checks to keep bytecode small and consistent with repo style. (file: `contracts/AGIJobManager.sol`).
- Added small test-only helpers to `TestableAGIJobManager`: `setJobIpfsHashUnsafe` and `mintJobNftUnsafe` to support a defensive unit test that exercises the mint guard. (file: `contracts/test/TestableAGIJobManager.sol`).
- Added a targeted test `defensively blocks minting when job metadata is empty` which sets a job's `ipfsHash` to empty and asserts `_mintJobNft` reverts with `InvalidParameters`. (file: `test/economicSafety.test.js`).
- Documented the new behavioral requirement in `docs/AGIJobManager.md`: `requestJobCompletion` requires a non-empty completion metadata URI and an example format is provided. (file: `docs/AGIJobManager.md`).

### Testing
- Added an automated unit test (`test/economicSafety.test.js` — `defensively blocks minting when job metadata is empty`) that asserts the defensive mint guard reverts with `InvalidParameters`; the test was added but not executed in this environment. (new test file updated).
- Attempted to run the project automation with `npm run build` and `npm test`, but both failed in this environment because `truffle` is not installed (`sh: 1: truffle: not found`); no test suite was executed here.
- Next steps to validate locally/CI: install dev dependencies and run `npm install` (or `npm ci`) then run `npm run build` and `npm test` to execute the full test suite and confirm CI passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb9e6be2c833396ada9976143f6d3)