### PR TITLE
Enforce non-empty completion metadata for job settlement

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -365,6 +365,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
 
     function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external {
         Job storage job = _job(_jobId);
+        if (bytes(_jobCompletionURI).length == 0) revert InvalidParameters();
         require(!paused() || job.disputed, "Pausable: paused");
         if (msg.sender != job.assignedAgent) revert NotAuthorized();
         if (job.completed || job.expired) revert InvalidState();
@@ -779,6 +780,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
 
     function _mintJobNft(Job storage job) internal {
         uint256 tokenId = nextTokenId++;
+        if (bytes(job.ipfsHash).length == 0) revert InvalidParameters();
         string memory metadataURI = bytes(job.jobCompletionURI).length > 0 ? job.jobCompletionURI : job.ipfsHash;
         if (bytes(metadataURI).length == 0) revert InvalidParameters();
         string memory tokenURI = _formatTokenURI(metadataURI);

--- a/contracts/test/TestableAGIJobManager.sol
+++ b/contracts/test/TestableAGIJobManager.sol
@@ -29,4 +29,15 @@ contract TestableAGIJobManager is AGIJobManager {
     function setValidationRewardPercentageUnsafe(uint256 _percentage) external onlyOwner {
         validationRewardPercentage = _percentage;
     }
+
+    function setJobMetadata(uint256 jobId, string calldata completionURI, string calldata ipfsHash) external onlyOwner {
+        Job storage job = jobs[jobId];
+        job.jobCompletionURI = completionURI;
+        job.ipfsHash = ipfsHash;
+    }
+
+    function mintJobNftUnsafe(uint256 jobId) external {
+        Job storage job = jobs[jobId];
+        _mintJobNft(job);
+    }
 }

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -121,6 +121,7 @@ stateDiagram-v2
 - **ERC‑20 compatibility**: token transfers accept ERC‑20s that return `bool` or return no data. Calls that revert, return `false`, or return malformed data revert with `TransferFailed`. Escrow deposits enforce exact amount received, so fee‑on‑transfer, rebasing, or other balance‑mutating tokens are not supported.
 
 ## Validation and dispute flow
+- `requestJobCompletion` requires a **non‑empty completion metadata URI** that becomes the job NFT `tokenURI` on settlement. Pass a full URI (`ipfs://<cid>` or `https://...`) or a CID that will be combined with `baseIpfsUrl` (e.g., `bafy...`). The URI should resolve to ERC‑721 metadata JSON for the completion artifact.
 - `validateJob` increments approval count, records validator participation, and auto‑completes when approvals reach the required threshold. It requires `completionRequested`.
 - `disapproveJob` increments disapproval count, records participation, and flips `disputed` when disapprovals reach the required threshold; it requires `completionRequested`.
 - Each job records at most `MAX_VALIDATORS_PER_JOB` unique validators; once the cap is reached, additional `validateJob`/`disapproveJob` calls revert.


### PR DESCRIPTION
### Motivation
- Prevent jobs from being settled or NFTs minted with empty or invalid completion metadata, which could create NFTs with empty `tokenURI` or allow settlement without a recorded completion pointer.
- Add minimal, defensive guards that preserve existing state-machine and storage layout while failing fast on invalid input.

### Description
- Added a strict non-empty check in `requestJobCompletion(uint256,string)` that reverts with the existing `InvalidParameters` error before any state changes when the completion URI/hash is empty.  
- Added a defensive guard in `_mintJobNft(Job storage)` that reverts with `InvalidParameters` if `job.ipfsHash` is empty so minting cannot produce an empty `tokenURI`.  
- Added test-only helpers to `TestableAGIJobManager` (`setJobMetadata` and `mintJobNftUnsafe`) to allow exercising the defensive mint guard in tests without changing core logic.  
- Documented in `docs/AGIJobManager.md` that the completion pointer passed to `requestJobCompletion` is required and must resolve to ERC‑721 metadata JSON, and gave guidance on passing either a full URI or a CID.

### Testing
- Ran `npm run build` and the project compiled successfully with Truffle/solc.  
- Ran the full test suite with `npm test` and all automated tests passed; test run reported `189 passing`.  
- Added a targeted test `reverts minting a job NFT when completion metadata is empty (defensive)` that asserts `_mintJobNft` reverts with `InvalidParameters`, and it passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fb9e6be2c833396ada9976143f6d3)