### PR TITLE
Harden dispute state machine and freeze validator voting

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ stateDiagram-v2
     CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
 
     CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
-    Assigned --> Disputed: disputeJob (manual)
     CompletionRequested --> Disputed: disputeJob (manual)
 
     Disputed --> Completed: resolveDispute("agent win")
@@ -62,7 +61,7 @@ stateDiagram-v2
     Created --> Cancelled: cancelJob (employer)
     Created --> Cancelled: delistJob (owner)
 ```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed or while paused for dispute recovery.
+*Note:* Disputes can only be initiated after completion is requested; validators can only act after the agent submits completion metadata, and once a job is disputed validator voting is frozen until dispute resolution. Settlement while disputed happens only via moderator resolution or owner stale‑dispute resolution (when paused). `resolveDispute` with a non‑canonical resolution string leaves the dispute active and returns the job to its prior in‑progress state (CompletionRequested).
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -318,6 +318,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await requestCompletion(0);
       await manager.disputeJob(0, { from: employer });
 
       const employerBalanceBefore = await token.balanceOf(employer);
@@ -461,6 +462,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
     it("allows only employer or agent to dispute", async () => {
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await requestCompletion(0);
       await expectCustomError(manager.disputeJob.call(0, { from: outsider }), "NotAuthorized");
       await manager.disputeJob(0, { from: agent });
       await expectCustomError(manager.disputeJob.call(0, { from: agent }), "InvalidState");

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -546,6 +546,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("6"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await manager.disputeJob(jobId, { from: employer });
       await expectCustomError(manager.disputeJob(jobId, { from: agent }), "InvalidState");
@@ -618,6 +619,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("9"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-dispute", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
 
       await expectCustomError(manager.resolveDispute(jobId, "agent win", { from: other }), "NotModerator");

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -1,0 +1,159 @@
+const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { rootNode } = require("./helpers/ens");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager dispute hardening", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      rootNode("club-root"),
+      rootNode("agent-root"),
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 92, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+  });
+
+  async function createAssignedJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
+    const jobId = tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    return jobId;
+  }
+
+  async function requestCompletion(jobId, uri = "ipfs-complete") {
+    await manager.requestJobCompletion(jobId, uri, { from: agent });
+  }
+
+  it("freezes validator voting once disputed", async () => {
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+
+    const payout = toBN(toWei("10"));
+    const jobId = await createAssignedJob(payout);
+    await requestCompletion(jobId);
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.disputed, true, "job should be disputed after threshold");
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-b", EMPTY_PROOF, { from: validatorB }),
+      "InvalidState"
+    );
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator-b", EMPTY_PROOF, { from: validatorB }),
+      "InvalidState"
+    );
+  });
+
+  it("prevents validator completion once disputed", async () => {
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+
+    const payout = toBN(toWei("11"));
+    const jobId = await createAssignedJob(payout);
+    await requestCompletion(jobId);
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-b", EMPTY_PROOF, { from: validatorB }),
+      "InvalidState"
+    );
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, false, "job should not complete while disputed");
+  });
+
+  it("only allows disputes after completion request", async () => {
+    const payout = toBN(toWei("12"));
+    const jobId = await createAssignedJob(payout);
+
+    await expectCustomError(manager.disputeJob.call(jobId, { from: employer }), "InvalidState");
+    await expectCustomError(manager.disputeJob.call(jobId, { from: agent }), "InvalidState");
+
+    await requestCompletion(jobId, "ipfs-complete");
+    await manager.disputeJob(jobId, { from: employer });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.disputed, true, "job should be disputed after completion request");
+  });
+
+  it("allows owner stale dispute resolution to complete agent wins", async () => {
+    await manager.setDisputeReviewPeriod(1, { from: owner });
+
+    const payout = toBN(toWei("13"));
+    const jobId = await createAssignedJob(payout);
+    await requestCompletion(jobId);
+    await manager.disputeJob(jobId, { from: employer });
+
+    await time.increase(2);
+    await manager.pause({ from: owner });
+
+    await manager.resolveStaleDispute(jobId, false, { from: owner });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should complete on stale dispute resolution");
+    assert.strictEqual(job.disputed, false, "dispute should clear after resolution");
+
+    const agentBalance = await token.balanceOf(agent);
+    const expectedPayout = payout.muln(92).divn(100);
+    assert.equal(agentBalance.toString(), expectedPayout.toString(), "agent should be paid on agent win");
+    assert.equal((await manager.lockedEscrow()).toString(), "0", "escrow should be released");
+    assert.equal((await manager.nextTokenId()).toNumber(), 1, "job NFT should be minted");
+  });
+
+  it("allows owner stale dispute resolution to refund employers", async () => {
+    await manager.setDisputeReviewPeriod(1, { from: owner });
+
+    const payout = toBN(toWei("14"));
+    const jobId = await createAssignedJob(payout);
+    await requestCompletion(jobId);
+    await manager.disputeJob(jobId, { from: employer });
+
+    await time.increase(2);
+    await manager.pause({ from: owner });
+
+    const employerBefore = await token.balanceOf(employer);
+    await manager.resolveStaleDispute(jobId, true, { from: owner });
+    const employerAfter = await token.balanceOf(employer);
+
+    assert.equal(employerAfter.sub(employerBefore).toString(), payout.toString(), "employer should be refunded");
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, true, "job should close on employer-win stale resolution");
+    assert.strictEqual(job.disputed, false, "dispute should clear after employer win");
+    assert.equal((await token.balanceOf(manager.address)).toString(), "0", "escrow should be released");
+  });
+});

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -112,6 +112,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
 
     const disputeJobId = await createJob(payout);
     await manager.applyForJob(disputeJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(disputeJobId, "ipfs-dispute", { from: agent });
     await manager.disputeJob(disputeJobId, { from: employer });
     await manager.resolveDispute(disputeJobId, "employer win", { from: moderator });
     assert.equal((await manager.lockedEscrow()).toString(), "0");

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -224,6 +224,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
 
     const jobId = await createJob(payout, 1000);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-stale", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     await manager.pause({ from: owner });

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -113,9 +113,9 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     await current.addModerator(moderator, { from: owner });
     await current.setRequiredValidatorApprovals(1, { from: owner });
     await token.mint(current.address, payout, { from: owner });
-    await current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator });
-    assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint once after validation");
-    await expectRevert(current.resolveDispute(currentJobId, "agent win", { from: moderator }));
+    await expectRevert(current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator }));
+    await current.resolveDispute(currentJobId, "agent win", { from: moderator });
+    assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint once after dispute resolution");
     assert.equal((await current.nextTokenId()).toNumber(), 1, "current should not mint twice");
   });
 
@@ -196,6 +196,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const original = await deployManager(AGIJobManagerOriginal, token.address, agent, validator, owner);
     await original.addAGIType(nft.address, 92, { from: owner });
     const originalJobId = await createAssignedJob(original, token, employer, agent, payout);
+    await original.requestJobCompletion(originalJobId, "ipfs-complete", { from: agent });
     await original.disputeJob(originalJobId, { from: employer });
     await original.addModerator(moderator, { from: owner });
     await original.setRequiredValidatorApprovals(1, { from: owner });
@@ -207,6 +208,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
+    await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
     await current.disputeJob(currentJobId, { from: employer });
     await current.addModerator(moderator, { from: owner });
     await current.setRequiredValidatorApprovals(1, { from: owner });

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -251,6 +251,7 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await token.mint(employer, payoutTwo, { from: owner });
     const jobIdTwo = await createJob(payoutTwo, "ipfs-employer-win");
     await manager.applyForJob(jobIdTwo, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobIdTwo, "ipfs-employer-complete", { from: agent });
 
     await manager.disputeJob(jobIdTwo, { from: employer });
     await expectCustomError(manager.resolveDispute.call(jobIdTwo, "agent win", { from: other }), "NotModerator");

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -252,6 +252,7 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     const { jobId } = await createJobWithApproval(payout);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-dispute", { from: agent });
 
     const disputeTx = await manager.disputeJob(jobId, { from: employer });
     assert.ok(disputeTx.logs.find((log) => log.event === "JobDisputed"), "JobDisputed should emit");
@@ -275,7 +276,7 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     );
   });
 
-  it("keeps disputes active on NO_ACTION and allows later completion", async () => {
+  it("keeps disputes active on NO_ACTION and freezes validator voting", async () => {
     const payout = toBN(toWei("20"));
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(1, { from: owner });
@@ -292,12 +293,15 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     assert.strictEqual(midJob.completed, false, "job should remain in progress");
     assert.strictEqual(midJob.completionRequested, true, "completion request should be preserved");
 
-    await manager.validateJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-b", EMPTY_PROOF, { from: validatorB }),
+      "InvalidState"
+    );
     const finalJob = await manager.jobs(jobId);
-    assert.strictEqual(finalJob.completed, true, "job should complete after follow-up validation");
+    assert.strictEqual(finalJob.completed, false, "job should remain unresolved while disputed");
   });
 
-  it("preserves escrow on NO_ACTION dispute resolution until later completion", async () => {
+  it("preserves escrow on NO_ACTION dispute resolution and blocks validator completion", async () => {
     const payout = toBN(toWei("25"));
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(1, { from: owner });
@@ -335,13 +339,10 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     assert.equal(balancesAfter.validatorB.toString(), balancesBefore.validatorB.toString(), "validator B should not be paid yet");
     assert.equal(balancesAfter.contract.toString(), payout.toString(), "escrow should remain locked");
 
-    await manager.validateJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
-    const balancesFinal = {
-      agent: await token.balanceOf(agent),
-      contract: await token.balanceOf(manager.address),
-    };
-    assert.ok(balancesFinal.agent.gt(balancesAfter.agent), "agent should be paid on final completion");
-    assert.equal(balancesFinal.contract.toString(), "0", "escrow should clear after completion");
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-b", EMPTY_PROOF, { from: validatorB }),
+      "InvalidState"
+    );
   });
 
   it("pauses state-changing actions and resumes after unpause", async () => {


### PR DESCRIPTION
### Motivation
- Prevent validator voting or validator-driven completion from progressing a job once it has been marked `disputed` to avoid disputed jobs being completed by validator votes.
- Disallow disputes that are used as a post-deadline griefing lever by restricting dispute initiation to the completion-review lane (i.e., only after a completion request exists).
- Ensure owner stale-dispute recovery clears the `disputed` flag before attempting completion to avoid race/ordering deadlocks.
- Keep changes minimal and preserve public/external APIs and expected lifecycle semantics.

### Description
- Contracts: `contracts/AGIJobManager.sol`:
  - Added early guards to `validateJob` and `disapproveJob` to revert when `job.disputed` is set (`revert InvalidState()`).
  - Added defense-in-depth check in `_completeJob` to revert if `job.disputed` is true.
  - Restricted `disputeJob` so it only succeeds when `job.completionRequested` is true, preventing post-deadline dispute wedging.
  - Modified `resolveStaleDispute` to clear `job.disputed` and `job.disputedAt` before calling `_completeJob()` when `employerWins == false`, and keep the whole operation atomic.
  - Kept existing moderator resolution paths unchanged (they already clear `disputed` before completion).
- Tests: added `test/disputeHardening.test.js` and updated multiple existing tests (`test/*`) to reflect and exercise the hardened rules (freezing votes, preventing validator completion while disputed, gating disputes on completion requests, and verifying `resolveStaleDispute` behavior). Test files updated include `AGIJobManager.*`, `escrowAccounting.test.js`, `livenessTimeouts.test.js`, `regressions.better-only.js`, `scenario*` suites, `securityRegression.test.js`, and `validatorCap.test.js`.
- Docs: updated `README.md` state-machine note to document the policy that disputes are allowed only after completion is requested and that validator voting is frozen while a job is disputed.

### Testing
- Commands run: `npm install`, `npm run build`, `npm test`, and `npm run lint` were executed in the repository root.
- Test results: the full test suite passed after changes; the test run concluded with all suites passing (test report: 194 passing). The new `test/disputeHardening.test.js` and the updated validator-cap/dispute scenarios ran and passed.
- Linting: `npm run lint` completed (no blocking solhint errors from the modified files).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc07a74808333a973ba2fa63e64b2)