### PR TITLE
Harden dispute state machine: freeze validator voting and restrict dispute lane

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,6 @@ stateDiagram-v2
     CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
 
     CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
-    Assigned --> Disputed: disputeJob (manual)
     CompletionRequested --> Disputed: disputeJob (manual)
 
     Disputed --> Completed: resolveDispute("agent win")
@@ -63,6 +62,11 @@ stateDiagram-v2
     Created --> Cancelled: delistJob (owner)
 ```
 *Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed or while paused for dispute recovery.
+
+**Dispute lane policy**
+- Disputes can only be initiated after completion is requested (`completionRequested == true`).
+- Once disputed, validator voting is frozen; approvals/disapprovals no longer progress settlement.
+- Settlement while disputed happens only via moderator resolution or owner stale‑dispute resolution (when paused).
 
 ### Full‑stack trust layer (signaling → enforcement)
 ```mermaid

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -318,6 +318,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await createJob();
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await requestCompletion(0);
       await manager.disputeJob(0, { from: employer });
 
       const employerBalanceBefore = await token.balanceOf(employer);
@@ -461,6 +462,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
     it("allows only employer or agent to dispute", async () => {
       await manager.applyForJob(0, "agent", [], { from: agent });
+      await requestCompletion(0);
       await expectCustomError(manager.disputeJob.call(0, { from: outsider }), "NotAuthorized");
       await manager.disputeJob(0, { from: agent });
       await expectCustomError(manager.disputeJob.call(0, { from: agent }), "InvalidState");

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -546,6 +546,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("6"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
       await manager.disputeJob(jobId, { from: employer });
       await expectCustomError(manager.disputeJob(jobId, { from: agent }), "InvalidState");
@@ -618,6 +619,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       const payout = new BN(web3.utils.toWei("9"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000);
       await assignJob(manager, jobId, agent, buildProof(agentTree, agent));
+      await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.disputeJob(jobId, { from: employer });
 
       await expectCustomError(manager.resolveDispute(jobId, "agent win", { from: other }), "NotModerator");

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -1,0 +1,185 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+contract("AGIJobManager dispute hardening", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB, validatorC] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.addAdditionalValidator(validatorC, { from: owner });
+
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.setDisputeReviewPeriod(100, { from: owner });
+  });
+
+  async function createJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
+    return tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+  }
+
+  async function setupCompletion(payout) {
+    const jobId = await createJob(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-completed", { from: agent });
+    return jobId;
+  }
+
+  it("freezes validator voting once disputed", async () => {
+    const payout = toBN(toWei("10"));
+    const jobId = await setupCompletion(payout);
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await manager.disapproveJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.disputed, true, "job should be disputed");
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-c", EMPTY_PROOF, { from: validatorC }),
+      "InvalidState"
+    );
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator-c", EMPTY_PROOF, { from: validatorC }),
+      "InvalidState"
+    );
+  });
+
+  it("prevents validator completion after a dispute", async () => {
+    const payout = toBN(toWei("12"));
+    const jobId = await setupCompletion(payout);
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await manager.disapproveJob(jobId, "validator-b", EMPTY_PROOF, { from: validatorB });
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator-c", EMPTY_PROOF, { from: validatorC }),
+      "InvalidState"
+    );
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.completed, false, "job should not be completed");
+  });
+
+  it("allows disputes only after completion is requested", async () => {
+    const payout = toBN(toWei("8"));
+    const jobId = await createJob(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await expectCustomError(manager.disputeJob.call(jobId, { from: employer }), "InvalidState");
+    await expectCustomError(manager.disputeJob.call(jobId, { from: agent }), "InvalidState");
+
+    await manager.requestJobCompletion(jobId, "ipfs-completed", { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+
+    const job = await manager.jobs(jobId);
+    assert.strictEqual(job.disputed, true, "job should be disputed after completion request");
+  });
+
+  it("resolves stale disputes through the owner recovery path", async () => {
+    const payout = toBN(toWei("15"));
+    const jobId = await setupCompletion(payout);
+
+    await manager.disputeJob(jobId, { from: employer });
+    await advanceTime(120);
+    await manager.pause({ from: owner });
+
+    const agentBefore = await token.balanceOf(agent);
+    await manager.resolveStaleDispute(jobId, false, { from: owner });
+    const agentAfter = await token.balanceOf(agent);
+
+    const expected = payout.muln(90).divn(100);
+    assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid");
+
+    const resolvedJob = await manager.jobs(jobId);
+    assert.strictEqual(resolvedJob.completed, true, "job should be completed");
+    assert.strictEqual(resolvedJob.disputed, false, "dispute should be cleared");
+
+    await manager.unpause({ from: owner });
+
+    const payoutRefund = toBN(toWei("9"));
+    const refundJobId = await setupCompletion(payoutRefund);
+    await manager.disputeJob(refundJobId, { from: employer });
+    await advanceTime(120);
+    await manager.pause({ from: owner });
+
+    const employerBefore = await token.balanceOf(employer);
+    await manager.resolveStaleDispute(refundJobId, true, { from: owner });
+    const employerAfter = await token.balanceOf(employer);
+
+    assert.equal(
+      employerAfter.sub(employerBefore).toString(),
+      payoutRefund.toString(),
+      "employer should be refunded"
+    );
+  });
+});

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -112,6 +112,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
 
     const disputeJobId = await createJob(payout);
     await manager.applyForJob(disputeJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(disputeJobId, "ipfs-dispute", { from: agent });
     await manager.disputeJob(disputeJobId, { from: employer });
     await manager.resolveDispute(disputeJobId, "employer win", { from: moderator });
     assert.equal((await manager.lockedEscrow()).toString(), "0");

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -224,6 +224,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
 
     const jobId = await createJob(payout, 1000);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     await manager.pause({ from: owner });

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -113,10 +113,10 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     await current.addModerator(moderator, { from: owner });
     await current.setRequiredValidatorApprovals(1, { from: owner });
     await token.mint(current.address, payout, { from: owner });
-    await current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator });
-    assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint once after validation");
-    await expectRevert(current.resolveDispute(currentJobId, "agent win", { from: moderator }));
-    assert.equal((await current.nextTokenId()).toNumber(), 1, "current should not mint twice");
+    await expectRevert(current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator }));
+    assert.equal((await current.nextTokenId()).toNumber(), 0, "current should not mint while disputed");
+    await current.resolveDispute(currentJobId, "agent win", { from: moderator });
+    assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint once via dispute resolution");
   });
 
   it("avoids div-by-zero on agent-win disputes in current", async () => {
@@ -196,6 +196,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const original = await deployManager(AGIJobManagerOriginal, token.address, agent, validator, owner);
     await original.addAGIType(nft.address, 92, { from: owner });
     const originalJobId = await createAssignedJob(original, token, employer, agent, payout);
+    await original.requestJobCompletion(originalJobId, "ipfs-complete", { from: agent });
     await original.disputeJob(originalJobId, { from: employer });
     await original.addModerator(moderator, { from: owner });
     await original.setRequiredValidatorApprovals(1, { from: owner });
@@ -207,6 +208,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
+    await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
     await current.disputeJob(currentJobId, { from: employer });
     await current.addModerator(moderator, { from: owner });
     await current.setRequiredValidatorApprovals(1, { from: owner });

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -251,6 +251,7 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await token.mint(employer, payoutTwo, { from: owner });
     const jobIdTwo = await createJob(payoutTwo, "ipfs-employer-win");
     await manager.applyForJob(jobIdTwo, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobIdTwo, "ipfs-employer-win-complete", { from: agent });
 
     await manager.disputeJob(jobIdTwo, { from: employer });
     await expectCustomError(manager.resolveDispute.call(jobIdTwo, "agent win", { from: other }), "NotModerator");

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -97,6 +97,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTxTwo = await manager.createJob("ipfs", payoutTwo, 1000, "details", { from: employer });
     const jobIdTwo = createTxTwo.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobIdTwo, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobIdTwo, "ipfs-done-two", { from: agent });
     await manager.disputeJob(jobIdTwo, { from: employer });
     await manager.resolveDispute(jobIdTwo, "employer win", { from: moderator });
     await expectCustomError(
@@ -157,7 +158,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     );
   });
 
-  it("allows completion request during disputes so agent-win can resolve", async () => {
+  it("settles agent-win disputes after completion is requested", async () => {
     const payout = toBN(toWei("18"));
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
@@ -165,9 +166,9 @@ contract("AGIJobManager security regressions", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
-    await manager.requestJobCompletion(jobId, "ipfs-disputed-complete", { from: agent });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
 
     const job = await manager.jobs(jobId);
@@ -175,7 +176,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     assert.strictEqual(job.completionRequested, true, "completion request should be recorded");
   });
 
-  it("allows disputed completion requests after duration expiry for agent-win resolution", async () => {
+  it("allows disputes after duration expiry when completion was requested", async () => {
     const payout = toBN(toWei("19"));
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
@@ -183,10 +184,10 @@ contract("AGIJobManager security regressions", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
-    await manager.disputeJob(jobId, { from: employer });
+    await manager.requestJobCompletion(jobId, "ipfs-disputed-late", { from: agent });
 
     await time.increase(2);
-    await manager.requestJobCompletion(jobId, "ipfs-disputed-late", { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
 
     const job = await manager.jobs(jobId);
@@ -194,7 +195,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     assert.strictEqual(job.completionRequested, true, "late completion request should be recorded");
   });
 
-  it("allows disputed completion requests while paused for agent-win recovery", async () => {
+  it("allows agent-win dispute resolution while paused after completion request", async () => {
     const payout = toBN(toWei("21"));
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
@@ -202,10 +203,10 @@ contract("AGIJobManager security regressions", (accounts) => {
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-paused-dispute", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
     await manager.pause({ from: owner });
-    await manager.requestJobCompletion(jobId, "ipfs-paused-dispute", { from: agent });
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
 
     const job = await manager.jobs(jobId);
@@ -253,6 +254,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
     await expectCustomError(manager.disputeJob.call(jobId, { from: other }), "NotAuthorized");
     await manager.disputeJob(jobId, { from: employer });

--- a/test/validatorCap.test.js
+++ b/test/validatorCap.test.js
@@ -81,7 +81,7 @@ contract("AGIJobManager validator cap", (accounts) => {
     );
   });
 
-  it("reverts when the validator cap is reached", async () => {
+  it("reverts additional votes once a dispute is triggered", async () => {
     const cap = (await manager.MAX_VALIDATORS_PER_JOB()).toNumber();
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(cap - 1, { from: owner });
@@ -105,20 +105,20 @@ contract("AGIJobManager validator cap", (accounts) => {
       .disapproveJob(jobId, "validator", EMPTY_PROOF)
       .encodeABI();
 
-    for (let i = 0; i < cap; i += 1) {
+    for (let i = 0; i < cap - 1; i += 1) {
       await sendSigned(manager, validators[i], disapproveData);
     }
 
     await expectCustomError(
       manager.disapproveJob.call(jobId, "validator", EMPTY_PROOF, { from: validators[cap].address }),
-      "ValidatorLimitReached"
+      "InvalidState"
     );
   });
 
   it("completes successfully at the validator cap", async () => {
     const cap = (await manager.MAX_VALIDATORS_PER_JOB()).toNumber();
-    await manager.setRequiredValidatorApprovals(1, { from: owner });
-    await manager.setRequiredValidatorDisapprovals(cap - 1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(0, { from: owner });
+    await manager.setRequiredValidatorApprovals(cap, { from: owner });
 
     const payout = toBN(toWei("20"));
     const jobId = await createJob(manager, token, employer, payout);
@@ -135,17 +135,12 @@ contract("AGIJobManager validator cap", (accounts) => {
       await manager.addAdditionalValidator(validator.address, { from: owner });
     }
 
-    const disapproveData = manager.contract.methods
-      .disapproveJob(jobId, "validator", EMPTY_PROOF)
-      .encodeABI();
-    for (let i = 0; i < cap - 1; i += 1) {
-      await sendSigned(manager, validators[i], disapproveData);
-    }
-
     const validateData = manager.contract.methods
       .validateJob(jobId, "validator", EMPTY_PROOF)
       .encodeABI();
-    await sendSigned(manager, validators[cap - 1], validateData, 2500000);
+    for (let i = 0; i < cap; i += 1) {
+      await sendSigned(manager, validators[i], validateData, 2500000);
+    }
 
     const job = await manager.jobs(jobId);
     assert.strictEqual(job.completed, true, "job should complete at the cap");


### PR DESCRIPTION
### Motivation
- Prevent validators from changing job outcome once a dispute is open and avoid disputed jobs being completed via validator votes.
- Prevent disputes from being used as a griefing lever after a job deadline when there is no completion submission. 
- Ensure stale-dispute owner resolution clears dispute flags before attempting completion so resolution does not deadlock.

### Description
- Added early guards that revert with `InvalidState` in `validateJob` and `disapproveJob` when `job.disputed` is true to freeze validator voting while disputed. 
- Added a defense-in-depth guard in `_completeJob` to revert when `job.disputed` is true so no completion path can proceed while disputed.
- Constrained `disputeJob` to the completion-review lane by requiring `job.completionRequested == true` before allowing a dispute to be opened.
- Updated `resolveStaleDispute` to clear `job.disputed = false` and `job.disputedAt = 0` before calling `_completeJob` when `employerWins == false`, keeping the full flow in the same transaction.
- Verified moderator resolution paths (`resolveDispute` / `resolveDisputeWithCode`) still clear dispute flags before settlement and left them unchanged in behavior aside from consistency checks.
- Added a focused test suite `test/disputeHardening.test.js` and updated many existing tests to reflect the tightened state machine (tests updated: `AGIJobManager.comprehensive.test.js`, `AGIJobManager.full.test.js`, `escrowAccounting.test.js`, `livenessTimeouts.test.js`, `regressions.better-only.js`, `scenarioEconomicStateMachine.test.js`, `scenarioLifecycle.marketplace.test.js`, `securityRegression.test.js`, `validatorCap.test.js`, plus others). 
- Documented the dispute lane policy in `README.md` under the Job lifecycle section.

### Testing
- Performed dependency/install/build steps and full test run locally: `npm install --omit=optional` (succeeded), `npm run build` (ran `truffle compile` successfully), `npm test` (ran full Truffle test suite).
- Test results: full test suite passed; last run reported `193 passing` (all tests green). 
- Linting: `npm run lint` (`solhint` check) completed with no blocking errors.
- Note: `npm ci` / `npm ci --omit=optional` failed on this environment due to an optional macOS-only dependency (`fsevents`); switched to `npm install --omit=optional` to proceed.

Commands used to validate locally:
- `npm install --omit=optional`
- `npm run build`
- `npm test`
- `npm run lint`

Files changed (high level):
- contracts/AGIJobManager.sol — guards added to `validateJob`, `disapproveJob`, `_completeJob`; `disputeJob` now requires `completionRequested`; `resolveStaleDispute` clears dispute flags before completion.
- test/disputeHardening.test.js — new focused scenarios verifying: dispute freezes voting, disputed job cannot be completed via validators, disputes only allowed after completion request, owner stale-dispute resolution works.
- Multiple test updates to align expectations with the hardened state machine.
- README.md — added a concise “Dispute lane policy” section explaining the new rules.

This change is minimal and targeted to the dispute/state-machine logic and tests; no public/external function signatures were removed and moderator/owner resolution paths remain intact.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fc07a74808333a973ba2fa63e64b2)