### PR TITLE
Enforce completion metadata for settlement and NFT minting

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,8 @@ stateDiagram-v2
 ```
 *Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string clears the `disputed` flag and returns the job to its prior in‑progress state (Assigned or CompletionRequested). Agent‑win dispute resolution now requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed or while paused for dispute recovery.
 
+**Settlement invariant (payout + NFT)**: the agent can only be paid and the completion NFT can only be minted after a completion request is recorded on-chain **and** a non-empty, valid completion metadata URI is stored. Moderators/owners cannot award an agent win without that completion request, and the job NFT always points to the completion metadata (not the job spec).
+
 **Dispute lane policy**
 - Disputes can only be initiated after completion is requested (`completionRequested == true`).
 - Once disputed, validator voting is frozen; approvals/disapprovals no longer progress settlement.

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -722,6 +722,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
         if (job.disputed) revert InvalidState();
         if (job.assignedAgent == address(0)) revert InvalidState();
         if (!job.completionRequested) revert InvalidState();
+        _requireValidUri(job.jobCompletionURI);
 
         uint256 agentPayoutPercentage = job.agentPayoutPct;
         if (agentPayoutPercentage == 0) revert InvalidAgentPayoutSnapshot();
@@ -783,9 +784,8 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721URIStorage {
 
     function _mintJobNft(Job storage job) internal {
         uint256 tokenId = nextTokenId++;
-        if (bytes(job.ipfsHash).length == 0) revert InvalidParameters();
-        string memory metadataURI = bytes(job.jobCompletionURI).length > 0 ? job.jobCompletionURI : job.ipfsHash;
-        if (bytes(metadataURI).length == 0) revert InvalidParameters();
+        _requireValidUri(job.jobCompletionURI);
+        string memory metadataURI = job.jobCompletionURI;
         string memory tokenURI = _formatTokenURI(metadataURI);
         _mint(job.employer, tokenId);
         _setTokenURI(tokenId, tokenURI);

--- a/contracts/test/TestableAGIJobManager.sol
+++ b/contracts/test/TestableAGIJobManager.sol
@@ -36,6 +36,14 @@ contract TestableAGIJobManager is AGIJobManager {
         job.ipfsHash = ipfsHash;
     }
 
+    function setCompletionRequested(uint256 jobId, bool requested) external onlyOwner {
+        Job storage job = jobs[jobId];
+        job.completionRequested = requested;
+        if (!requested) {
+            job.completionRequestedAt = 0;
+        }
+    }
+
     function mintJobNftUnsafe(uint256 jobId) external {
         Job storage job = jobs[jobId];
         _mintJobNft(job);

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -1,0 +1,143 @@
+const assert = require("assert");
+
+const TestableAGIJobManager = artifacts.require("TestableAGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+contract("AGIJobManager completion settlement invariants", (accounts) => {
+  const [owner, employer, agent, validator, moderator] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await TestableAGIJobManager.new(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setDisputeReviewPeriod(100, { from: owner });
+  });
+
+  async function createJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-spec", payout, 1000, "details", { from: employer });
+    return tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+  }
+
+  async function setupDisputedJob(payout) {
+    const jobId = await createJob(payout);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await manager.disputeJob(jobId, { from: employer });
+    return jobId;
+  }
+
+  it("reverts agent-win dispute resolution without a completion request", async () => {
+    const jobId = await setupDisputedJob(toBN(toWei("5")));
+
+    await manager.setCompletionRequested(jobId, false, { from: owner });
+
+    await expectCustomError(
+      manager.resolveDisputeWithCode.call(jobId, 1, "agent win", { from: moderator }),
+      "InvalidState"
+    );
+  });
+
+  it("reverts agent-win dispute resolution when completion metadata is empty", async () => {
+    const jobId = await setupDisputedJob(toBN(toWei("6")));
+
+    await manager.setJobMetadata(jobId, "", "ipfs-spec", { from: owner });
+
+    await expectCustomError(
+      manager.resolveDisputeWithCode.call(jobId, 1, "agent win", { from: moderator }),
+      "InvalidParameters"
+    );
+  });
+
+  it("reverts stale dispute resolution without a completion request", async () => {
+    const jobId = await setupDisputedJob(toBN(toWei("7")));
+
+    await manager.setCompletionRequested(jobId, false, { from: owner });
+
+    await advanceTime(120);
+    await manager.pause({ from: owner });
+
+    await expectCustomError(manager.resolveStaleDispute.call(jobId, false, { from: owner }), "InvalidState");
+  });
+
+  it("mints completion NFTs using the completion metadata URI", async () => {
+    const jobId = await createJob(toBN(toWei("9")));
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    const tx = await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+
+    const issued = tx.logs.find((log) => log.event === "NFTIssued");
+    assert.ok(issued, "NFTIssued event should be emitted");
+
+    const tokenId = issued.args.tokenId.toNumber();
+    const tokenUri = await manager.tokenURI(tokenId);
+    assert.equal(tokenUri, "ipfs://base/ipfs-complete");
+  });
+});

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -190,7 +190,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     const createTx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
-    await manager.setJobMetadata(jobId, "", "", { from: owner });
+    await manager.setJobMetadata(jobId, "", "ipfs-job", { from: owner });
     await expectCustomError(manager.mintJobNftUnsafe.call(jobId, { from: owner }), "InvalidParameters");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent any code path from paying an agent or minting a completion NFT unless the job has an on‑chain completion request and a non‑empty, valid completion metadata URI.
- Ensure minted job NFTs always reference completion metadata (not the job spec) and add defensive checks to avoid empty tokenURIs.

### Description
- Enforce completion URI validation in settlement by calling `_requireValidUri(job.jobCompletionURI)` at the start of `_completeJob(uint256)` so any agent‑paid settlement requires `completionRequested == true` and a valid non‑empty `jobCompletionURI`.
- Tighten NFT minting in `_mintJobNft(Job storage job)` to always require and use `job.jobCompletionURI` (removed the fallback to `job.ipfsHash`) and to defensively refuse minting when completion metadata is missing/invalid.
- Added a test‑only helper `setCompletionRequested(uint256, bool)` to `contracts/test/TestableAGIJobManager.sol` to support negative tests that simulate missing completion requests.
- Added `test/completionSettlementInvariant.test.js` that asserts moderator/owner agent‑win and stale dispute paths revert without a completion request or with empty completion metadata, and that successful completion mints a tokenURI pointing to the completion metadata; updated `test/economicSafety.test.js` to match the tightened NFT invariant.
- Documented the new settlement invariant in `README.md` near the job lifecycle section and kept existing custom errors and interfaces unchanged.

### Testing
- Added/updated automated tests: `test/completionSettlementInvariant.test.js` (new) and `test/economicSafety.test.js` (updated) to cover the invariants for `resolveDisputeWithCode(... AGENT_WIN ...)`, `resolveStaleDispute`, and correct tokenURI minting behavior; these tests are included in the repo and should run under the existing Truffle test runner.
- I attempted to run the full test suite with `npm test`, but the run failed immediately because `truffle` is not available in the environment (`sh: 1: truffle: not found`).
- No CI tests were run locally here; given Truffle is available in CI, the updated tests should pass (they were written to reflect and assert the new invariant), and any existing tests that previously assumed the old bypass were updated.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fcafc247883338a8ff1c8144480f7)