### PR TITLE
Clarify audit status and refresh documentation pointers

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 **AGIJobManager** is MONTREAL.AI’s on-chain enforcement layer for agent–employer workflows: validator-gated job escrow, payouts, dispute resolution, and reputation tracking, with ENS/Merkle role gating and an ERC‑721 job NFT marketplace. It is the *enforcement* half of a “Full‑Stack Trust Layer for AI Agents.”
 
-> **Status / Caution**: Experimental research software. Treat deployments as high-risk until you have performed independent security review, validated parameters, and ensured operational readiness.
+> **Status / Caution**: Experimental research software. Treat deployments as high-risk until you have performed independent security review, validated parameters, and ensured operational readiness. No public audit report is included in this repository.
 
 ## At a glance
 
@@ -193,6 +193,8 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 ## Ecosystem links
 
 - **Repository**: https://github.com/MontrealAI/AGIJobManager
+- **Etherscan (deployment-specific)**: https://etherscan.io/address/<contract-address>
+- **OpenSea (job NFTs, deployment-specific)**: https://opensea.io/assets/ethereum/<contract-address>
 - **ERC‑8004 specification**: https://eips.ethereum.org/EIPS/eip-8004
 - **ERC‑8004 deck (framing)**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/presentation/MONTREALAI_x_ERC8004_v0.pdf
 - **ERC‑8004 deck (repo copy)**: [`presentations/MONTREALAI_x_ERC8004_v0.pdf`](presentations/MONTREALAI_x_ERC8004_v0.pdf)
@@ -202,8 +204,6 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 - **ENS NameWrapper**: https://docs.ens.domains/ens-improvement-proposals/ensip-10-namewrapper
 - **OpenZeppelin Contracts**: https://docs.openzeppelin.com/contracts/4.x/
 - **Truffle**: https://trufflesuite.com/docs/truffle/
-- **Etherscan (deployments)**: https://etherscan.io/address/<your-contract-address>
-- **OpenSea (job NFTs)**: https://opensea.io/assets/ethereum/<your-contract-address>/<token-id>
 
 ## Documentation
 
@@ -214,8 +214,10 @@ Start here:
 - [`docs/ParameterSafety.md`](docs/ParameterSafety.md)
 - [`docs/ops/parameter-safety.md`](docs/ops/parameter-safety.md)
 - [`docs/Deployment.md`](docs/Deployment.md)
+- [`docs/Security.md`](docs/Security.md)
 - [`docs/Testing.md`](docs/Testing.md)
 - [`docs/ERC8004.md`](docs/ERC8004.md)
+- [`docs/Interface.md`](docs/Interface.md)
 - **ERC‑8004 integration (control plane ↔ execution plane)**: [`docs/erc8004/README.md`](docs/erc8004/README.md)
 - **AGI.Eth Namespace (alpha)**:
   - User guide: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md)

--- a/docs/Security.md
+++ b/docs/Security.md
@@ -9,6 +9,9 @@ This document summarizes security considerations specific to the current `AGIJob
 - Job NFTs minted on completion.
 - Reputation mappings used for premium access gating.
 
+**Audit status**
+- No public audit report is included in this repository. Treat deployments as experimental until independently reviewed.
+
 **Primary trust assumptions (centralization risks)**
 - **Owner powers**: can pause flows, update token address and parameters, manage allowlists/blacklists, add AGI types, and withdraw ERC‑20 while paused (limited to `withdrawableAGI()`).
 - **Moderator powers**: resolve disputes with typed action codes via `resolveDisputeWithCode`. Code `0` (NO_ACTION) logs a reason and keeps the dispute active; `1` (AGENT_WIN) pays the agent; `2` (EMPLOYER_WIN) refunds the employer. The legacy string-based `resolveDispute` is deprecated and maps exact `agent win` / `employer win` strings to the corresponding codes.


### PR DESCRIPTION
### Motivation
- Make the repository documentation explicit about audit status, improve discoverability of key docs and ecosystem links, and avoid any accidental claims about on-chain ERC‑8004 integration while keeping contracts untouched.

### Description
- Updated `README.md` to add a clear audit/status note, expand documentation pointers and ecosystem link placeholders (Etherscan/OpenSea examples), and tidy the docs index; updated `docs/Security.md` to include an explicit audit‑status note; no contract files were modified (honoring the constraint on `contracts/AGIJobManager.sol`).

### Testing
- Ran `npm install` (dependency install completed with warnings and reported vulnerabilities), `npm run build` (ran `truffle compile` successfully; solc 0.8.33 used) and `npm test` (full test suite executed successfully with `197 passing`); CI workflow exists at `.github/workflows/ci.yml` so the existing CI badge in `README.md` remains appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fd5bff5288333bcb35201e5539ecc)