### PR TITLE
Reduce AGIJobManager bytecode size with unchecked loops and compiler tuning

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,21 @@ npm test
 
 **Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.17`, while the Truffle default compiler is `0.8.33` (configurable via `SOLC_VERSION`). Keep the deploy-time compiler settings consistent for verification.
 
+### Mainnet bytecode size (EIP-170)
+
+Ethereum mainnet enforces a deployed runtime bytecode limit of **24,576 bytes** (Spurious Dragon / EIP-170). Measure the runtime size locally after compiling:
+
+```bash
+node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
+```
+
+Mainnet deploy settings (from `truffle-config.js`):
+- `optimizer.enabled = true`
+- `optimizer.runs = 10` (override with `SOLC_RUNS` if needed)
+- `viaIR = true`
+- `metadata.bytecodeHash = 'none'`
+- `evmVersion = 'london'`
+
 ## Web UI (GitHub Pages)
 
 - Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -311,10 +311,13 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function _maxAGITypePayoutPercentage() internal view returns (uint256) {
         uint256 maxPercentage = 0;
-        for (uint256 i = 0; i < agiTypes.length; i++) {
+        for (uint256 i = 0; i < agiTypes.length; ) {
             uint256 pct = agiTypes[i].payoutPercentage;
             if (pct > maxPercentage) {
                 maxPercentage = pct;
+            }
+            unchecked {
+                ++i;
             }
         }
         return maxPercentage;
@@ -766,10 +769,13 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 validatorPayout = totalValidatorPayout / vCount;
         uint256 validatorReputationGain = calculateValidatorReputationPoints(reputationPoints);
 
-        for (uint256 i = 0; i < vCount; i++) {
+        for (uint256 i = 0; i < vCount; ) {
             address validator = job.validators[i];
             _t(validator, validatorPayout);
             enforceReputationGrowth(validator, validatorReputationGain);
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -805,9 +811,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function _isFullUri(string memory uri) internal pure returns (bool) {
         bytes memory data = bytes(uri);
         if (data.length < 3) return false;
-        for (uint256 i = 0; i + 2 < data.length; i++) {
+        for (uint256 i = 0; i + 2 < data.length; ) {
             if (data[i] == ":" && data[i + 1] == "/" && data[i + 2] == "/") {
                 return true;
+            }
+            unchecked {
+                ++i;
             }
         }
         return false;
@@ -816,9 +825,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function _requireValidUri(string memory uri) internal pure {
         bytes memory data = bytes(uri);
         if (data.length == 0) revert InvalidParameters();
-        for (uint256 i = 0; i < data.length; i++) {
+        for (uint256 i = 0; i < data.length; ) {
             bytes1 c = data[i];
             if (c == 0x20 || c == 0x09 || c == 0x0a || c == 0x0d) revert InvalidParameters();
+            unchecked {
+                ++i;
+            }
         }
     }
 
@@ -934,7 +946,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
         uint256 maxPct = payoutPercentage;
         bool exists = false;
-        for (uint256 i = 0; i < agiTypes.length; i++) {
+        for (uint256 i = 0; i < agiTypes.length; ) {
             uint256 pct = agiTypes[i].payoutPercentage;
             if (agiTypes[i].nftAddress == nftAddress) {
                 pct = payoutPercentage;
@@ -943,15 +955,21 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             if (pct > maxPct) {
                 maxPct = pct;
             }
+            unchecked {
+                ++i;
+            }
         }
         if (maxPct > 100 - validationRewardPercentage) revert InvalidParameters();
         if (!exists) {
             agiTypes.push(AGIType({ nftAddress: nftAddress, payoutPercentage: payoutPercentage }));
         } else {
-            for (uint256 i = 0; i < agiTypes.length; i++) {
+            for (uint256 i = 0; i < agiTypes.length; ) {
                 if (agiTypes[i].nftAddress == nftAddress) {
                     agiTypes[i].payoutPercentage = payoutPercentage;
                     break;
+                }
+                unchecked {
+                    ++i;
                 }
             }
         }
@@ -961,9 +979,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function getHighestPayoutPercentage(address agent) public view returns (uint256) {
         uint256 highestPercentage = 0;
-        for (uint256 i = 0; i < agiTypes.length; i++) {
+        for (uint256 i = 0; i < agiTypes.length; ) {
             if (IERC721(agiTypes[i].nftAddress).balanceOf(agent) > 0 && agiTypes[i].payoutPercentage > highestPercentage) {
                 highestPercentage = agiTypes[i].payoutPercentage;
+            }
+            unchecked {
+                ++i;
             }
         }
         return highestPercentage;

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,7 +50,7 @@ const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = (process.env.SOLC_VERSION || '0.8.33').trim();
-const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 1));
+const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 10));
 const solcViaIR = (process.env.SOLC_VIA_IR || 'true').toLowerCase() === 'true';
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 


### PR DESCRIPTION
### Motivation
- Address the EIP-170 mainnet deployability warning by reducing the deployed runtime bytecode size of `AGIJobManager` to <= 24,576 bytes while preserving external behavior and test compatibility.

### Description
- Replace several `for`-loop patterns with `for (... ; ) { ... unchecked { ++i; } }` increments in `contracts/AGIJobManager.sol` to slightly reduce compiled bytecode without changing semantics.
- Raise the default compiler optimizer `runs` from `1` to `10` in `truffle-config.js` (`const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 10));`) to use the highest-tested optimizer setting that remains under the EIP-170 limit. 
- Keep `viaIR = true`, `metadata.bytecodeHash = 'none'`, and `evmVersion = 'london'` in `truffle-config.js` to further reduce footprint and preserve verification workflow. 
- Add a short doc note to `README.md` explaining the EIP-170 24,576-byte limit, the runtime-size measurement command (`node -e ...`), and the recommended solc settings for mainnet deploys.

### Testing
- Measured baseline runtime size before changes with `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"` which reported **24,572 bytes**. 
- Recompiled iteratively and validated sizes across optimizer runs; final compiled deployed runtime size is **24,566 bytes**, which is below the 24,576-byte EIP-170 limit. 
- Ran the full test suite with `npm test` (which runs `truffle compile --all` + `truffle test --network test`), and all automated tests passed: **197 passing**. 

Solc details used during validation: `solc 0.8.33` with `optimizer.enabled = true`, `optimizer.runs = 10`, `viaIR = true`, `metadata.bytecodeHash = 'none'`, and `evmVersion = 'london'`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697fe422bbcc8333a950f5e007e28ade)