### PR TITLE
Add UI config & legacy fallback, mainnet warning, and UI ABI drift check

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 ## Web UI (GitHub Pages)
 
 - Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)
+- Usage guide: [`docs/agijobmanager_ui.md`](docs/agijobmanager_ui.md)
 - Expected Pages URL pattern: `https://<org>.github.io/<repo>/ui/agijobmanager.html`
 - GitHub Pages setup: Settings → Pages → Source “Deploy from branch” → Branch `main` → Folder `/docs`.
 - The contract address is user-configurable and must be provided until the new mainnet deployment is finalized.

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -17,8 +17,8 @@ Then open:
 http://localhost:8000/ui/agijobmanager.html
 ```
 
-You can also run the server from `docs/ui/` and open `http://localhost:8000/agijobmanager.html`,
-but the deployments hints will be unavailable because `docs/deployments/` is outside that server root.
+You can also run the server from `docs/ui/` and open `http://localhost:8000/agijobmanager.html`.
+The UI config file (`agijobmanager.config.json`) lives alongside the HTML and will still be available.
 
 Alternatively, you can serve the UI directly:
 
@@ -31,6 +31,7 @@ npx http-server docs/ui
 The UI does **not** assume a default deployment. Provide a contract address explicitly:
 
 - Query param: `?contract=0x...`
+- Config file: `docs/ui/agijobmanager.config.json` (`preferredContract`)
 - Manual entry in the “Contract address” field
 - Save button: persists to `localStorage` under the key `agijobmanager_contract`
 
@@ -39,7 +40,7 @@ To reset:
 - Click **Clear** in the UI, or
 - Remove `localStorage` key `agijobmanager_contract` in your browser’s dev tools.
 
-The legacy v0 address is displayed as a reference and only used if you explicitly opt in.
+If none of the above are set, the UI falls back to the legacy v0 address, which is clearly labeled as legacy.
 
 ## ABI export + drift guardrails
 

--- a/docs/ui/agijobmanager.config.json
+++ b/docs/ui/agijobmanager.config.json
@@ -1,0 +1,6 @@
+{
+  "defaultNetwork": "mainnet",
+  "legacyContract": "0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477",
+  "preferredContract": "",
+  "notes": "preferredContract intentionally blank until the new mainnet deployment is finalized"
+}

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -312,13 +312,14 @@
           <div class="inline">
             <button id="saveContract">Save address</button>
             <button id="clearContract" class="secondary">Clear</button>
-            <button id="legacyContract" class="secondary">Use legacy v0 (not the new deployment)</button>
+            <button id="legacyContract" class="secondary">Use legacy fallback (v0)</button>
           </div>
           <p class="muted">
-            Known mainnet deployment: <span id="mainnetDeployment">TBD</span>. Legacy v0:
+            Preferred mainnet deployment (config): <span id="mainnetDeployment">TBD</span>. Legacy fallback:
             <code id="legacyAddress">0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477</code> (opt-in only).
           </p>
-          <p class="muted">Supported sources: query param <code>?contract=0x...</code>, localStorage, or manual input.</p>
+          <p class="muted">Active source: <span id="contractSource">—</span></p>
+          <p class="muted">Supported sources: query param <code>?contract=0x...</code>, localStorage, config file, or legacy fallback.</p>
         </div>
       </div>
       <div class="panel-row">
@@ -332,6 +333,10 @@
           <button id="switchMainnet">Switch to Mainnet</button>
           <p class="muted">If you are not on Ethereum Mainnet, interactions may revert.</p>
         </div>
+      </div>
+      <div id="mainnetWarning" class="banner" hidden>
+        You are connected to <strong><span id="mainnetWarningNetwork">—</span></strong>, not Ethereum Mainnet.
+        Please switch networks before using production contracts.
       </div>
     </section>
 
@@ -986,6 +991,8 @@
       chainId: null,
       chainName: null,
       contractAddress: null,
+      contractSource: null,
+      config: null,
       legacyAddress: null,
       agiTokenAddress: null,
       agiTokenDecimals: 18,
@@ -1031,6 +1038,12 @@
     };
 
     const legacyAddress = "0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477";
+    const configDefaults = {
+      defaultNetwork: "mainnet",
+      legacyContract: legacyAddress,
+      preferredContract: "",
+      notes: "",
+    };
     const storageKey = "agijobmanager_contract";
     const uiSettingsKey = "agijobmanager_ui_settings_v1";
     const indexCacheKey = "agijobmanager_index_cache_v1";
@@ -1181,9 +1194,17 @@
       ids(id).textContent = value;
     }
 
-    function setDeploymentHints(mainnetAddress) {
-      setText("legacyAddress", legacyAddress);
-      setText("mainnetDeployment", mainnetAddress || "TBD");
+    const contractSourceLabels = {
+      query: "Query param",
+      localStorage: "LocalStorage",
+      config: "Config file",
+      legacy: "Legacy fallback",
+      manual: "Manual entry",
+    };
+
+    function updateContractSourceDisplay() {
+      const label = state.contractSource ? contractSourceLabels[state.contractSource] : null;
+      setText("contractSource", label || "—");
     }
 
     function setLegacyAddress(value) {
@@ -1248,26 +1269,47 @@
       if (!state.walletAddress) {
         pill.textContent = "Disconnected";
         pill.className = "pill danger";
+        updateMainnetWarning();
         return;
       }
       if (!state.chainId) {
         pill.textContent = "Connected (unknown network)";
         pill.className = "pill warn";
+        updateMainnetWarning();
         return;
       }
       if (!supportedChainIds.has(state.chainId)) {
         pill.textContent = `Unsupported chain (chain ${state.chainId})`;
         pill.className = "pill danger";
+        updateMainnetWarning();
         return;
       }
       if (state.contractAddress && state.contractDeployed === false) {
         pill.textContent = "Contract not found on this chain";
         pill.className = "pill danger";
+        updateMainnetWarning();
         return;
       }
       const label = state.chainName ? state.chainName : `chain ${state.chainId}`;
       pill.textContent = `Connected (${label})`;
       pill.className = "pill ok";
+      updateMainnetWarning();
+    }
+
+    function updateMainnetWarning() {
+      const warning = ids("mainnetWarning");
+      if (!warning) return;
+      if (!state.chainId) {
+        warning.hidden = true;
+        return;
+      }
+      if (state.chainId === 1n) {
+        warning.hidden = true;
+        return;
+      }
+      const label = state.chainName ? `${state.chainName} (${state.chainId})` : `chain ${state.chainId}`;
+      setText("mainnetWarningNetwork", label);
+      warning.hidden = false;
     }
 
     function getExplorerTxUrl(txHash) {
@@ -1317,7 +1359,7 @@
       const link = document.createElement("a");
       link.href = `${base}${address}`;
       link.target = "_blank";
-      link.rel = "noreferrer";
+      link.rel = "noreferrer noopener";
       link.textContent = shortAddr(address);
       link.title = address;
       return link;
@@ -1454,6 +1496,19 @@
       }
     }
 
+    function applyContractAddress(address, { source = "manual", persist = false } = {}) {
+      const parsed = parseAddress(address, "Contract address");
+      state.contractAddress = parsed;
+      state.contractSource = source;
+      ids("contractAddress").value = parsed;
+      updateContractSourceDisplay();
+      if (persist) {
+        localStorage.setItem(storageKey, parsed);
+      }
+      maybeInitProvider();
+      setContracts();
+    }
+
     function parseUint(value, fieldLabel) {
       const trimmed = value.trim();
       if (!trimmed) {
@@ -1538,7 +1593,7 @@
           .replace(/\*\*(.+?)\*\*/g, "<strong>$1</strong>")
           .replace(/\*(.+?)\*/g, "<em>$1</em>")
           .replace(/`(.+?)`/g, "<code>$1</code>")
-          .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noreferrer">$1</a>');
+          .replace(/\[(.+?)\]\((.+?)\)/g, '<a href="$2" target="_blank" rel="noreferrer noopener">$1</a>');
         return `<div>${htmlLine}</div>`;
       });
       return rendered.join("");
@@ -3650,79 +3705,90 @@
       contract.on("NFTDelisted", (tokenId) => logEvent(`NFTDelisted #${tokenId}`));
     }
 
-    function loadContractFromQuery() {
+    async function loadUiConfig() {
+      let config = { ...configDefaults };
+      try {
+        const response = await fetch("./agijobmanager.config.json", { cache: "no-store" });
+        if (response.ok) {
+          const data = await response.json();
+          config = { ...configDefaults, ...(data || {}) };
+        }
+      } catch (error) {
+        // Non-fatal: fall back to defaults.
+      }
+
+      let preferred = "";
+      if (config.preferredContract) {
+        try {
+          preferred = parseAddress(config.preferredContract, "Preferred contract address");
+        } catch (error) {
+          logEvent(`⚠️ Config preferredContract invalid: ${error.message}`);
+        }
+      }
+      let legacy = "";
+      if (config.legacyContract) {
+        try {
+          legacy = setLegacyAddress(config.legacyContract);
+        } catch (error) {
+          logEvent(`⚠️ Config legacyContract invalid: ${error.message}`);
+        }
+      }
+      if (!legacy) {
+        try {
+          legacy = setLegacyAddress(legacyAddress);
+        } catch (error) {
+          legacy = "";
+        }
+      }
+
+      state.config = {
+        ...config,
+        preferredContract: preferred,
+        legacyContract: legacy,
+      };
+      setText("mainnetDeployment", preferred || "TBD");
+      if (!legacy) {
+        state.legacyAddress = null;
+        setText("legacyAddress", "Unavailable");
+      }
+      return state.config;
+    }
+
+    function resolveInitialContractAddress() {
       const url = new URL(window.location.href);
       const contract = url.searchParams.get("contract");
       if (contract) {
         try {
-          const parsed = ethers.getAddress(contract);
-          ids("contractAddress").value = parsed;
-          state.contractAddress = parsed;
-          localStorage.setItem(storageKey, parsed);
-          maybeInitProvider();
-          setContracts();
+          applyContractAddress(contract, { source: "query", persist: true });
+          return;
         } catch (error) {
           showAlert("Invalid contract address in query string.");
         }
-      } else {
-        const stored = localStorage.getItem(storageKey);
-        if (stored) {
-          try {
-            const parsed = ethers.getAddress(stored);
-            ids("contractAddress").value = parsed;
-            state.contractAddress = parsed;
-            maybeInitProvider();
-            setContracts();
-          } catch (error) {
-            localStorage.removeItem(storageKey);
-          }
+      }
+
+      const stored = localStorage.getItem(storageKey);
+      if (stored) {
+        try {
+          applyContractAddress(stored, { source: "localStorage" });
+          return;
+        } catch (error) {
+          localStorage.removeItem(storageKey);
         }
       }
-    }
 
-    async function loadKnownDeployment() {
-      try {
-        const response = await fetch("../deployments/mainnet.json", { cache: "no-store" });
-        if (!response.ok) {
-          state.legacyAddress = null;
-          setText("legacyAddress", "Unavailable");
-          setText("mainnetDeployment", "TBD");
+      if (state.config?.preferredContract) {
+        try {
+          applyContractAddress(state.config.preferredContract, { source: "config" });
           return;
+        } catch (error) {
+          logEvent(`⚠️ Config preferredContract invalid: ${error.message}`);
         }
-        const data = await response.json();
-        const legacy = typeof data.legacyV0 === "string" ? data.legacyV0 : "";
-        const mainnet = typeof data.agiJobManager === "string" ? data.agiJobManager : "";
-        if (legacy) {
-          try {
-            setLegacyAddress(legacy);
-          } catch (error) {
-            state.legacyAddress = null;
-            setText("legacyAddress", "Unavailable");
-          }
-        } else {
-          state.legacyAddress = null;
-          setText("legacyAddress", "Unavailable");
-        }
-        if (mainnet) {
-          try {
-            const parsed = ethers.getAddress(mainnet);
-            setText("mainnetDeployment", parsed);
-            if (!state.contractAddress && !ids("contractAddress").value.trim()) {
-              ids("contractAddress").value = parsed;
-              state.contractAddress = parsed;
-              maybeInitProvider();
-              setContracts();
-            }
-          } catch (error) {
-            setText("mainnetDeployment", "TBD");
-          }
-        } else {
-          setText("mainnetDeployment", "TBD");
-        }
-      } catch (error) {
-        state.legacyAddress = null;
-        setText("legacyAddress", "Unavailable");
-        setText("mainnetDeployment", "TBD");
+      }
+
+      if (state.legacyAddress) {
+        applyContractAddress(state.legacyAddress, { source: "legacy" });
+      } else {
+        updateContractSourceDisplay();
       }
     }
 
@@ -3731,11 +3797,9 @@
       if (!value) {
         throw new Error("Contract address cannot be empty.");
       }
-      state.contractAddress = parseAddress(value, "Contract address");
-      localStorage.setItem(storageKey, state.contractAddress);
+      applyContractAddress(value, { source: "manual", persist: true });
       const provider = maybeInitProvider();
       if (provider) {
-        setContracts();
         await updateWriteAccess();
         await refreshDashboard();
       } else {
@@ -3777,23 +3841,21 @@
     ids("clearContract").addEventListener("click", () => {
       ids("contractAddress").value = "";
       state.contractAddress = null;
+      state.contractSource = null;
       localStorage.removeItem(storageKey);
       setContracts();
       setWriteEnabled(false, "Contract address not set.");
       resetSnapshot();
       resetRoleFlags();
+      updateContractSourceDisplay();
     });
 
     ids("legacyContract").addEventListener("click", () => {
       if (!state.legacyAddress) {
-        showAlert("Legacy address unavailable. Check deployments config.");
+        showAlert("Legacy address unavailable. Check UI config.");
         return;
       }
-      ids("contractAddress").value = state.legacyAddress;
-      state.contractAddress = state.legacyAddress;
-      localStorage.setItem(storageKey, state.legacyAddress);
-      maybeInitProvider();
-      setContracts();
+      applyContractAddress(state.legacyAddress, { source: "legacy", persist: true });
     });
 
     ids("switchMainnet").addEventListener("click", async () => {
@@ -4611,7 +4673,7 @@
 
     async function bootstrap() {
       await loadAbi();
-      setDeploymentHints();
+      await loadUiConfig();
       loadUiSettings();
       hydrateUiControls();
       refreshCredentialStatus();
@@ -4619,8 +4681,7 @@
       syncMarkdownPreview();
       await refreshJobSpecPreview();
       await refreshCompletionPreview();
-      loadContractFromQuery();
-      loadKnownDeployment();
+      resolveInitialContractAddress();
       initNetwork();
       unbindWalletEvents();
       bindWalletEvents();

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "lint": "solhint \"contracts/**/*.sol\"",
     "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js",
     "test:ui": "node scripts/ui/run_ui_smoke_test.js",
-    "ui:abi": "node scripts/ui/export_abi.js"
+    "ui:abi": "node scripts/ui/export_abi.js",
+    "ui:abi:check": "node scripts/ui/check_ui_abi.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "^4.9.5"

--- a/scripts/ui/check_ui_abi.js
+++ b/scripts/ui/check_ui_abi.js
@@ -1,0 +1,112 @@
+const fs = require("fs");
+const path = require("path");
+
+const rootDir = path.resolve(__dirname, "..", "..");
+const artifactPath = path.join(rootDir, "build", "contracts", "AGIJobManager.json");
+const requiredPath = path.join(rootDir, "docs", "ui", "abi", "ui_required_interface.json");
+
+function readJson(filePath) {
+  if (!fs.existsSync(filePath)) {
+    throw new Error(`Missing file: ${filePath}`);
+  }
+  const raw = fs.readFileSync(filePath, "utf8");
+  return JSON.parse(raw);
+}
+
+function buildFunctionIndex(abi) {
+  const index = new Map();
+  for (const item of abi) {
+    if (item.type !== "function") continue;
+    const name = item.name;
+    const count = Array.isArray(item.inputs) ? item.inputs.length : 0;
+    if (!index.has(name)) {
+      index.set(name, new Set());
+    }
+    index.get(name).add(count);
+  }
+  return index;
+}
+
+function buildEventIndex(abi) {
+  const events = new Set();
+  for (const item of abi) {
+    if (item.type === "event" && item.name) {
+      events.add(item.name);
+    }
+  }
+  return events;
+}
+
+function buildErrorIndex(abi) {
+  const errors = new Set();
+  for (const item of abi) {
+    if (item.type === "error" && item.name) {
+      errors.add(item.name);
+    }
+  }
+  return errors;
+}
+
+function main() {
+  const required = readJson(requiredPath);
+  const artifact = readJson(artifactPath);
+  const abi = artifact.abi;
+
+  if (!Array.isArray(abi)) {
+    throw new Error("ABI missing from build artifact.");
+  }
+
+  const functionsIndex = buildFunctionIndex(abi);
+  const eventsIndex = buildEventIndex(abi);
+  const errorsIndex = buildErrorIndex(abi);
+
+  const missingFunctions = [];
+  const missingEvents = [];
+  const missingErrors = [];
+
+  const requiredFunctions = required.functions || {};
+  for (const [name, inputCount] of Object.entries(requiredFunctions)) {
+    const counts = functionsIndex.get(name);
+    if (!counts || !counts.has(Number(inputCount))) {
+      missingFunctions.push(`${name}(${inputCount})`);
+    }
+  }
+
+  const requiredEvents = required.events || [];
+  for (const name of requiredEvents) {
+    if (!eventsIndex.has(name)) {
+      missingEvents.push(name);
+    }
+  }
+
+  const requiredErrors = required.errors || [];
+  for (const name of requiredErrors) {
+    if (!errorsIndex.has(name)) {
+      missingErrors.push(name);
+    }
+  }
+
+  if (missingFunctions.length || missingEvents.length || missingErrors.length) {
+    const lines = ["UI ABI drift detected:"];
+    if (missingFunctions.length) {
+      lines.push(`- Missing functions: ${missingFunctions.join(", ")}`);
+    }
+    if (missingEvents.length) {
+      lines.push(`- Missing events: ${missingEvents.join(", ")}`);
+    }
+    if (missingErrors.length) {
+      lines.push(`- Missing errors: ${missingErrors.join(", ")}`);
+    }
+    lines.push("Rebuild artifacts with `truffle compile` and update UI ABI if needed.");
+    throw new Error(lines.join("\n"));
+  }
+
+  process.stdout.write("UI ABI check passed.\n");
+}
+
+try {
+  main();
+} catch (error) {
+  process.stderr.write(`${error.message}\n`);
+  process.exit(1);
+}


### PR DESCRIPTION
### Motivation

- Provide a production‑quality, configurable static web UI that can target any AGIJobManager deployment without hardcoding a new mainnet address and to make the UI safer and easier to maintain. 

### Description

- Added a small JSON deployment config `docs/ui/agijobmanager.config.json` and updated the UI to resolve the contract address in this priority: query param > localStorage > config `preferredContract` > legacy fallback, while clearly labeling the source and legacy fallback. 
- Hardened the static UI (`docs/ui/agijobmanager.html`) with a visible Mainnet warning banner, explicit contract source display, safer external links (`rel="noreferrer noopener"`), and helper functions to apply/persist contract addresses. 
- Added a lightweight ABI drift check script `scripts/ui/check_ui_abi.js` and exposed it as `npm run ui:abi:check`, and updated `package.json` and UI docs to document usage and ENS/Merkle/dispute behaviors. 
- Files added/updated: `docs/ui/agijobmanager.config.json`, `scripts/ui/check_ui_abi.js`, `docs/ui/agijobmanager.html`, `docs/agijobmanager_ui.md`, `docs/ui/README.md`, `README.md`, and `package.json` (script entry). 

### Testing

- `npx truffle compile` completed successfully and wrote build artifacts (compiler warnings only). 
- `npx truffle test --network test` passed (UI/contract smoke + full test suite run in the repository test network; reported `197 passing`). 
- `node scripts/ui/check_ui_abi.js` (ABI drift guard) passed and printed `UI ABI check passed.`. 
- `npm ci` failed in this environment due to an optional `fsevents` dependency being darwin-only (known platform limitation), while `npm install --omit=optional` / `npm install` completed for the purpose of running `truffle` commands. 
- A static runtime sanity check was performed by serving `docs/` via `python3 -m http.server` and using a headless Playwright script to fetch `http://127.0.0.1:8000/ui/agijobmanager.html` and capture a screenshot (sanity check succeeded). 

Notes: the new mainnet deployment address is intentionally left blank in config (`preferredContract`) until the canonical deployment is finalized; users should supply `?contract=0x...` or save an address via the UI until the preferred address is published.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ff96613748333b86e3c118c9fe213)