### PR TITLE
Reduce test contract bytecode size and add size guard

### DIFF
--- a/contracts/test/TestableAGIJobManager.sol
+++ b/contracts/test/TestableAGIJobManager.sol
@@ -34,19 +34,15 @@ contract TestableAGIJobManager is AGIJobManager {
         uint256 jobId,
         string calldata completionURI,
         string calldata ipfsHash,
-        bool completionRequested
+        bool completionRequested,
+        bool mintNft
     ) external {
         Job storage job = jobs[jobId];
         job.jobCompletionURI = completionURI;
         job.ipfsHash = ipfsHash;
         job.completionRequested = completionRequested;
-        if (!completionRequested) {
-            job.completionRequestedAt = 0;
+        if (mintNft) {
+            _mintJobNft(job);
         }
-    }
-
-    function mintJobNftUnsafe(uint256 jobId) external {
-        Job storage job = jobs[jobId];
-        _mintJobNft(job);
     }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "build": "truffle compile",
     "docs:interface": "node scripts/generate-interface-doc.js",
     "lint": "solhint \"contracts/**/*.sol\"",
-    "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js",
+    "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js",
     "test:ui": "node scripts/ui/run_ui_smoke_test.js",
     "ui:abi": "node scripts/ui/export_abi.js"
   },

--- a/scripts/check-contract-sizes.js
+++ b/scripts/check-contract-sizes.js
@@ -1,0 +1,37 @@
+const fs = require("fs");
+const path = require("path");
+
+const MAX_RUNTIME_BYTES = 24576;
+const targets = ["AGIJobManager", "TestableAGIJobManager"];
+
+function deployedSizeBytes(artifact) {
+  const deployedBytecode =
+    artifact.deployedBytecode || artifact.evm?.deployedBytecode?.object || "";
+  const hex = deployedBytecode.startsWith("0x")
+    ? deployedBytecode.slice(2)
+    : deployedBytecode;
+  return hex.length / 2;
+}
+
+let failed = false;
+for (const name of targets) {
+  const artifactPath = path.join(__dirname, "..", "build", "contracts", `${name}.json`);
+  if (!fs.existsSync(artifactPath)) {
+    console.error(`Missing Truffle artifact: ${artifactPath}`);
+    failed = true;
+    continue;
+  }
+  const artifact = JSON.parse(fs.readFileSync(artifactPath, "utf8"));
+  const sizeBytes = deployedSizeBytes(artifact);
+  console.log(`${name} deployedBytecode size: ${sizeBytes} bytes`);
+  if (name === "AGIJobManager" && sizeBytes > MAX_RUNTIME_BYTES) {
+    console.error(
+      `AGIJobManager deployed bytecode exceeds ${MAX_RUNTIME_BYTES} bytes: ${sizeBytes}`
+    );
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -96,7 +96,7 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
   it("reverts agent-win dispute resolution without a completion request", async () => {
     const jobId = await setupDisputedJob(toBN(toWei("5")));
 
-    await manager.setJobMetadata(jobId, "ipfs-complete", "ipfs-spec", false, { from: owner });
+    await manager.setJobMetadata(jobId, "ipfs-complete", "ipfs-spec", false, false, { from: owner });
 
     await expectCustomError(
       manager.resolveDisputeWithCode.call(jobId, 1, "agent win", { from: moderator }),
@@ -107,7 +107,7 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
   it("reverts agent-win dispute resolution when completion metadata is empty", async () => {
     const jobId = await setupDisputedJob(toBN(toWei("6")));
 
-    await manager.setJobMetadata(jobId, "", "ipfs-spec", true, { from: owner });
+    await manager.setJobMetadata(jobId, "", "ipfs-spec", true, false, { from: owner });
 
     await expectCustomError(
       manager.resolveDisputeWithCode.call(jobId, 1, "agent win", { from: moderator }),
@@ -118,7 +118,7 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
   it("reverts stale dispute resolution without a completion request", async () => {
     const jobId = await setupDisputedJob(toBN(toWei("7")));
 
-    await manager.setJobMetadata(jobId, "ipfs-complete", "ipfs-spec", false, { from: owner });
+    await manager.setJobMetadata(jobId, "ipfs-complete", "ipfs-spec", false, false, { from: owner });
 
     await advanceTime(120);
     await manager.pause({ from: owner });

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -190,7 +190,9 @@ contract("AGIJobManager economic safety", (accounts) => {
     const createTx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
-    await manager.setJobMetadata(jobId, "", "ipfs-job", true, { from: owner });
-    await expectCustomError(manager.mintJobNftUnsafe.call(jobId, { from: owner }), "InvalidParameters");
+    await expectCustomError(
+      manager.setJobMetadata.call(jobId, "", "ipfs-job", true, true, { from: owner }),
+      "InvalidParameters"
+    );
   });
 });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,7 +50,7 @@ const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = (process.env.SOLC_VERSION || '0.8.33').trim();
-const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 50));
+const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 1));
 const solcViaIR = (process.env.SOLC_VIA_IR || 'true').toLowerCase() === 'true';
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 


### PR DESCRIPTION
### Motivation
- Solve the Solidity compiler code-size warning by ensuring AGIJobManager runtime deployed bytecode is <= 24,576 bytes under CI default compilation settings.
- Prefer configuration-only fixes first and add a deterministic size guard to prevent regressions.
- Keep on-chain behavior and public ABI stable; only change test helper APIs where needed to reduce helper bytecode.

### Description
- Lower the default optimizer `runs` to `1` in `truffle-config.js` while keeping `viaIR` and `metadata.bytecodeHash = 'none'`, and preserve environment overrides via `SOLC_RUNS` (so CI defaults produce smaller runtime bytecode).
- Tightened the test helper `contracts/test/TestableAGIJobManager.sol` by removing the separate `mintJobNftUnsafe` helper and consolidating mint behavior into `setJobMetadata(..., bool mintNft)`, reducing compiled size of that test-only contract; updated tests that referenced the old helper to match the new signature.
- Added `scripts/check-contract-sizes.js` that reads Truffle artifacts and computes deployed/runtime bytecode sizes and fails if `AGIJobManager` exceeds 24,576 bytes; wired this script into the default `npm test` pipeline by updating `package.json`.

### Testing
- Reproduced original compile and size outputs using `npm install` and `npm run build` and captured before sizes: `AGIJobManager` = 24078 bytes; `TestableAGIJobManager` = 24669 bytes.
- After changes compiled and ran tests with `npm test` (which runs `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`), and observed: `197 passing` tests and size outputs `AGIJobManager deployedBytecode size: 24022 bytes` and `TestableAGIJobManager deployedBytecode size: 24570 bytes`, with the size guard script exiting successfully.
- Commands run (representative): `npm install`, `npm run build`, `npx truffle compile --all`, and `npm test`; compilation succeeded with warnings but tests all passed and the size check passed.

Notes: only a test helper contract ABI was changed (`TestableAGIJobManager.setJobMetadata` gained a `mintNft` flag and `mintJobNftUnsafe` was removed) and all internal test call sites were updated accordingly; the production `contracts/AGIJobManager.sol` public ABI and behavior were not modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697ffd0fc67c8333af905302edf622c6)