### PR TITLE
Limit configuration lock to critical settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.26`, while the Truffle default compiler is `0.8.26` (configurable via `SOLC_VERSION`). The current build enables `viaIR` to avoid stack‑too‑deep errors; keep compiler settings consistent for verification and document the tradeoffs.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.26`, while the Truffle default compiler is `0.8.26` (configurable via `SOLC_VERSION`). `viaIR` is enabled by default because the current contract shape otherwise hits stack‑too‑deep errors; keep compiler settings consistent for verification and only change if you have a validated refactor.
 
 ## Contract documentation
 

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -253,7 +253,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         _;
     }
 
-    modifier whenConfigurable() {
+    modifier whenCriticalConfigurable() {
         if (configLocked) revert ConfigLocked();
         _;
     }
@@ -362,7 +362,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function pause() external onlyOwner { _pause(); }
     function unpause() external onlyOwner { _unpause(); }
-    function lockConfiguration() external onlyOwner whenConfigurable {
+    function lockConfiguration() external onlyOwner whenCriticalConfigurable {
         configLocked = true;
         emit ConfigurationLocked(msg.sender, block.timestamp);
     }
@@ -543,14 +543,14 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit DisputeTimeoutResolved(_jobId, msg.sender, employerWins);
     }
 
-    function blacklistAgent(address _agent, bool _status) external onlyOwner whenConfigurable {
+    function blacklistAgent(address _agent, bool _status) external onlyOwner {
         blacklistedAgents[_agent] = _status;
     }
-    function blacklistValidator(address _validator, bool _status) external onlyOwner whenConfigurable {
+    function blacklistValidator(address _validator, bool _status) external onlyOwner {
         blacklistedValidators[_validator] = _status;
     }
 
-    function delistJob(uint256 _jobId) external onlyOwner whenConfigurable {
+    function delistJob(uint256 _jobId) external onlyOwner {
         Job storage job = _job(_jobId);
         if (job.completed || job.assignedAgent != address(0)) revert InvalidState();
         _releaseEscrow(job);
@@ -561,42 +561,46 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function addModerator(address _moderator) external onlyOwner { moderators[_moderator] = true; }
     function removeModerator(address _moderator) external onlyOwner { moderators[_moderator] = false; }
-    function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenConfigurable { agiToken = IERC20(_newTokenAddress); }
-    function setBaseIpfsUrl(string calldata _url) external onlyOwner whenConfigurable { baseIpfsUrl = _url; }
-    function setRequiredValidatorApprovals(uint256 _approvals) external onlyOwner whenConfigurable {
+    function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenCriticalConfigurable {
+        if (_newTokenAddress == address(0)) revert InvalidParameters();
+        if (nextJobId != 0 || lockedEscrow != 0) revert InvalidState();
+        agiToken = IERC20(_newTokenAddress);
+    }
+    function setBaseIpfsUrl(string calldata _url) external onlyOwner { baseIpfsUrl = _url; }
+    function setRequiredValidatorApprovals(uint256 _approvals) external onlyOwner {
         _validateValidatorThresholds(_approvals, requiredValidatorDisapprovals);
         requiredValidatorApprovals = _approvals;
     }
-    function setRequiredValidatorDisapprovals(uint256 _disapprovals) external onlyOwner whenConfigurable {
+    function setRequiredValidatorDisapprovals(uint256 _disapprovals) external onlyOwner {
         _validateValidatorThresholds(requiredValidatorApprovals, _disapprovals);
         requiredValidatorDisapprovals = _disapprovals;
     }
-    function setPremiumReputationThreshold(uint256 _threshold) external onlyOwner whenConfigurable { premiumReputationThreshold = _threshold; }
-    function setMaxJobPayout(uint256 _maxPayout) external onlyOwner whenConfigurable { maxJobPayout = _maxPayout; }
-    function setJobDurationLimit(uint256 _limit) external onlyOwner whenConfigurable { jobDurationLimit = _limit; }
-    function setCompletionReviewPeriod(uint256 _period) external onlyOwner whenConfigurable {
+    function setPremiumReputationThreshold(uint256 _threshold) external onlyOwner { premiumReputationThreshold = _threshold; }
+    function setMaxJobPayout(uint256 _maxPayout) external onlyOwner { maxJobPayout = _maxPayout; }
+    function setJobDurationLimit(uint256 _limit) external onlyOwner { jobDurationLimit = _limit; }
+    function setCompletionReviewPeriod(uint256 _period) external onlyOwner {
         if (!(_period > 0 && _period <= MAX_REVIEW_PERIOD)) revert InvalidParameters();
         uint256 oldPeriod = completionReviewPeriod;
         completionReviewPeriod = _period;
         emit CompletionReviewPeriodUpdated(oldPeriod, _period);
     }
-    function setDisputeReviewPeriod(uint256 _period) external onlyOwner whenConfigurable {
+    function setDisputeReviewPeriod(uint256 _period) external onlyOwner {
         if (!(_period > 0 && _period <= MAX_REVIEW_PERIOD)) revert InvalidParameters();
         uint256 oldPeriod = disputeReviewPeriod;
         disputeReviewPeriod = _period;
         emit DisputeReviewPeriodUpdated(oldPeriod, _period);
     }
-    function setAdditionalAgentPayoutPercentage(uint256 _percentage) external onlyOwner whenConfigurable {
+    function setAdditionalAgentPayoutPercentage(uint256 _percentage) external onlyOwner {
         if (!(_percentage > 0 && _percentage <= 100)) revert InvalidParameters();
         if (_percentage > 100 - validationRewardPercentage) revert InvalidParameters();
         additionalAgentPayoutPercentage = _percentage;
         emit AdditionalAgentPayoutPercentageUpdated(_percentage);
     }
-    function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner whenConfigurable { termsAndConditionsIpfsHash = _hash; }
-    function updateContactEmail(string calldata _email) external onlyOwner whenConfigurable { contactEmail = _email; }
-    function updateAdditionalText1(string calldata _text) external onlyOwner whenConfigurable { additionalText1 = _text; }
-    function updateAdditionalText2(string calldata _text) external onlyOwner whenConfigurable { additionalText2 = _text; }
-    function updateAdditionalText3(string calldata _text) external onlyOwner whenConfigurable { additionalText3 = _text; }
+    function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner { termsAndConditionsIpfsHash = _hash; }
+    function updateContactEmail(string calldata _email) external onlyOwner { contactEmail = _email; }
+    function updateAdditionalText1(string calldata _text) external onlyOwner { additionalText1 = _text; }
+    function updateAdditionalText2(string calldata _text) external onlyOwner { additionalText2 = _text; }
+    function updateAdditionalText3(string calldata _text) external onlyOwner { additionalText3 = _text; }
 
     function getJobStatus(uint256 _jobId) external view returns (bool, bool, string memory) {
         Job storage job = jobs[_jobId];
@@ -641,7 +645,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         return JobStatus.InProgress;
     }
 
-    function setValidationRewardPercentage(uint256 _percentage) external onlyOwner whenConfigurable {
+    function setValidationRewardPercentage(uint256 _percentage) external onlyOwner {
         if (!(_percentage > 0 && _percentage <= 100)) revert InvalidParameters();
         uint256 maxPct = _maxAGITypePayoutPercentage();
         if (maxPct > 100 - _percentage) revert InvalidParameters();
@@ -996,10 +1000,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         return false;
     }
 
-    function addAdditionalValidator(address validator) external onlyOwner whenConfigurable { additionalValidators[validator] = true; }
-    function removeAdditionalValidator(address validator) external onlyOwner whenConfigurable { additionalValidators[validator] = false; }
-    function addAdditionalAgent(address agent) external onlyOwner whenConfigurable { additionalAgents[agent] = true; }
-    function removeAdditionalAgent(address agent) external onlyOwner whenConfigurable { additionalAgents[agent] = false; }
+    function addAdditionalValidator(address validator) external onlyOwner { additionalValidators[validator] = true; }
+    function removeAdditionalValidator(address validator) external onlyOwner { additionalValidators[validator] = false; }
+    function addAdditionalAgent(address agent) external onlyOwner { additionalAgents[agent] = true; }
+    function removeAdditionalAgent(address agent) external onlyOwner { additionalAgents[agent] = false; }
 
     function withdrawableAGI() public view returns (uint256) {
         uint256 bal = agiToken.balanceOf(address(this));
@@ -1007,7 +1011,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         return bal - lockedEscrow;
     }
 
-    function withdrawAGI(uint256 amount) external onlyOwner whenPaused nonReentrant whenConfigurable {
+    function withdrawAGI(uint256 amount) external onlyOwner whenPaused nonReentrant {
         if (amount == 0) revert InvalidParameters();
         uint256 available = withdrawableAGI();
         if (amount > available) revert InsufficientWithdrawableBalance();
@@ -1025,7 +1029,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit RewardPoolContribution(msg.sender, amount);
     }
 
-    function addAGIType(address nftAddress, uint256 payoutPercentage) external onlyOwner whenConfigurable {
+    function addAGIType(address nftAddress, uint256 payoutPercentage) external onlyOwner {
         if (!(nftAddress != address(0) && payoutPercentage > 0 && payoutPercentage <= 100)) revert InvalidParameters();
 
         (bool exists, uint256 maxPct) = _maxAGITypePayoutAfterUpdate(nftAddress, payoutPercentage);

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -43,7 +43,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 The mainnet-safe compiler settings used in `truffle-config.js` are:
 - Optimizer enabled with **runs = 200**.
-- `viaIR = true` (required to avoid stack-too-deep errors at this contract size).
+- `viaIR = true` (required to compile the current contract without stack-too-deep errors).
 - `debug.revertStrings = 'strip'`.
 - `metadata.bytecodeHash = 'none'`.
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -93,7 +93,8 @@ After setup and validation, lock configuration to minimize governance:
 - **Preferred**: set `LOCK_CONFIG=true` before migration to auto-lock.
 - **Manual**: call `lockConfiguration()` from the owner account.
 
-Once locked, all configuration setters are disabled permanently (see `docs/minimal-governance.md`).
+Once locked, **critical configuration setters** are disabled permanently (see `docs/minimal-governance.md`).
+In the current implementation, only the token address is lockable because ENS wiring and root nodes are constructor-only.
 
 ## 6) Break-glass runbook (after lock)
 
@@ -101,5 +102,8 @@ After lock, operators should only use:
 - `pause()` / `unpause()` for incident response.
 - `resolveStaleDispute()` (owner + paused, after timeout) for dispute recovery.
 - Optional moderator rotation if required.
+- Surplus withdrawals (`withdrawAGI`) while paused; escrowed funds remain reserved (`lockedEscrow`).
 
-Everything else is frozen to keep governance surface minimal.
+> **Escrow safety:** withdrawals can never touch escrowed job funds because `withdrawableAGI = balance - lockedEscrow` and the call reverts if the escrow balance is insolvent.
+
+Everything else remains operable but should be governed by your ops policy to keep the surface minimal.


### PR DESCRIPTION
### Motivation
- Reduce the governance surface by making the one-way configuration lock apply only to the truly critical configuration that can reroute funds or break identity anchors. 
- Preserve operator flexibility for routine admin operations (thresholds, metadata, allowlists, moderators, withdrawals) while preventing catastrophic misconfiguration. 
- Keep compilation and deployment ergonomics explicit (compiler version, optimizer runs, and the `viaIR` tradeoff) to keep CI reproducible and mainnet-safe.

### Description
- Narrowed the configuration lock: introduced `whenCriticalConfigurable` and limited the irreversible `lockConfiguration()` guard to only the critical setter `updateAGITokenAddress` (which is additionally constrained to run only before any job/escrow exists).
- Left operational and tunable setters operable after the lock (thresholds, review periods, allowlists, AGI types, metadata, moderator management, blacklist/whitelist, delist/cancel semantics and surplus withdrawals) and ensured `withdrawAGI` remains callable while paused and never touches escrow via `withdrawableAGI`. 
- Adjusted `AGIJobManager.sol` to use the new modifier and to add pre-job guards around token updates; removed `whenConfigurable` from non-critical setters to keep them tunable. 
- Updated tests in `test/adminOps.test.js` to cover the new semantics (pre-job token updates, token update rejection post-jobs, lock behavior, and withdraw invariants). 
- Updated operational docs: `docs/minimal-governance.md`, `docs/deployment-checklist.md`, `docs/Deployment.md`, and `README.md` to describe the narrower critical-config lock, the canonical mainnet token/root-node invariants, and the compiler `viaIR` tradeoff. 
- Made Truffle/CI defaults explicit: `SOLC_VERSION` stays at `0.8.26`, optimizer runs default to `200`, and `SOLC_VIA_IR` is documented/enabled because the current contract shape requires it to compile without stack-too-deep errors (this is documented and kept configurable via env). The `.env.example` and `truffle-config.js` settings were adjusted accordingly.

### Testing
- Commands executed: `npm install` and `npm test` (which runs `truffle compile --all`, the full `truffle test --network test` suite, the JS harness, and runtime bytecode checks).
- Result: Full test suite passed locally: 201 passing tests and ABI smoke checks succeeded; runtime size checks reported `AGIJobManager` deployed bytecode under the mainnet EIP‑170 limit (reported sizes in test output). 
- Additional check: attempted compilation with `SOLC_VIA_IR=false` reproduced a compiler error (`Stack too deep`), so `viaIR` must remain enabled for the current contract layout; this failure is documented in `docs/Deployment.md` and `README.md` and the default env example.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698178fb35ec8333a0d54d8a12ba4819)