### PR TITLE
Disable viaIR by default and document verification flow

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,7 +32,7 @@ MAINNET_TIMEOUT_BLOCKS=500
 # Compiler settings (optional)
 SOLC_VERSION=0.8.26
 SOLC_RUNS=200
-SOLC_VIA_IR=true
+SOLC_VIA_IR=false
 SOLC_EVM_VERSION=london
 
 # Local test chain

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.26`, while the Truffle default compiler is `0.8.26` (configurable via `SOLC_VERSION`). `viaIR` is enabled by default because the legacy contract and current shape hit stack‑too‑deep without it; keep compiler settings consistent for verification.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.26`, while the Truffle default compiler is `0.8.26` (configurable via `SOLC_VERSION`). `viaIR` is disabled by default; enable it only if a non‑IR build cannot compile. Keep compiler settings consistent for verification.
 
 ## Contract documentation
 
@@ -135,7 +135,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 - Optimizer: enabled
 - `optimizer.runs`: **200** (via `SOLC_RUNS`, default in `truffle-config.js`)
-- `viaIR`: **true** by default (set `SOLC_VIA_IR=false` only if you have a validated refactor that avoids stack‑too‑deep)
+- `viaIR`: **false** by default (set `SOLC_VIA_IR=true` only if a non‑IR build cannot compile)
 - `metadata.bytecodeHash`: **none**
 - `debug.revertStrings`: **strip**
 - `SOLC_VERSION`: **0.8.26**

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -26,7 +26,7 @@ The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS
 | `SEPOLIA_CONFIRMATIONS` / `MAINNET_CONFIRMATIONS` | Confirmations to wait | Defaults to 2. |
 | `SEPOLIA_TIMEOUT_BLOCKS` / `MAINNET_TIMEOUT_BLOCKS` | Timeout blocks | Defaults to 500. |
 | `RPC_POLLING_INTERVAL_MS` | Provider polling interval | Defaults to 8000 ms. |
-| `SOLC_VERSION` / `SOLC_RUNS` / `SOLC_VIA_IR` / `SOLC_EVM_VERSION` | Compiler settings | Defaults: `SOLC_VERSION=0.8.26`, `SOLC_RUNS=200`, `SOLC_VIA_IR=true`, `SOLC_EVM_VERSION=london`. |
+| `SOLC_VERSION` / `SOLC_RUNS` / `SOLC_VIA_IR` / `SOLC_EVM_VERSION` | Compiler settings | Defaults: `SOLC_VERSION=0.8.26`, `SOLC_RUNS=200`, `SOLC_VIA_IR=false`, `SOLC_EVM_VERSION=london`. |
 | `GANACHE_MNEMONIC` | Local test mnemonic | Defaults to Ganache standard mnemonic if unset. |
 
 A template lives in [`.env.example`](../.env.example).
@@ -43,7 +43,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 The mainnet-safe compiler settings used in `truffle-config.js` are:
 - Optimizer enabled with **runs = 200**.
-- `viaIR = true` (required to compile the current contract without stack-too-deep errors).
+- `viaIR = false` (enable only if you can demonstrate a non-IR build cannot compile).
 - `debug.revertStrings = 'strip'`.
 - `metadata.bytecodeHash = 'none'`.
 

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -24,8 +24,8 @@ npx ganache -p 8545
 npx truffle compile
 ```
 
-By default the Truffle config enables `viaIR` to avoid stack-too-deep compilation errors at this contract size.
-If you need to compare non-IR compilation, set `SOLC_VIA_IR=false` in your environment (compilation may fail).
+By default the Truffle config disables `viaIR`. Enable it only if a non-IR build cannot compile.
+To force IR compilation, set `SOLC_VIA_IR=true` in your environment.
 
 ## Run the full test suite
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -114,11 +114,11 @@ Everything else remains operable but should be governed by your ops policy to ke
 
 ## 7) Verification (Etherscan)
 
-**Normal path (viaIR enabled)**:
-1. Compile with `SOLC_VERSION=0.8.26`, `SOLC_RUNS=200`, `SOLC_VIA_IR=true`.
+**Normal path (viaIR disabled)**:
+1. Compile with `SOLC_VERSION=0.8.26`, `SOLC_RUNS=200`, `SOLC_VIA_IR=false`.
 2. Verify using `truffle-plugin-verify` with the same compiler settings and constructor args.
 
-**Fallback (Standard JSON input)**:
+**Fallback (Standard JSON input with viaIR)**:
 1. Compile with `SOLC_VIA_IR=true` and the same optimizer/metadata settings.
 2. In Etherscan, select **Solidity (Standard-Json-Input)** and paste the JSON from the build step.
 3. Ensure the JSON includes `viaIR: true`, `optimizer.runs: 200`, `metadata.bytecodeHash: "none"`, and the exact constructor args.

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -159,6 +159,11 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.lockConfiguration({ from: owner });
     assert.equal(await manager.configLocked(), true, "config should be locked");
 
+    await manager.addModerator(other, { from: owner });
+    assert.equal(await manager.moderators(other), true, "moderator should be added post-lock");
+    await manager.removeModerator(other, { from: owner });
+    assert.equal(await manager.moderators(other), false, "moderator should be removed post-lock");
+
     await manager.updateMerkleRoots(clubRoot, agentRoot, { from: owner });
 
     await manager.setMaxJobPayout(toBN(toWei("1")), { from: owner });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -51,7 +51,7 @@ const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = (process.env.SOLC_VERSION || '0.8.26').trim();
 const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 200));
-const solcViaIR = (process.env.SOLC_VIA_IR || 'true').toLowerCase() === 'true';
+const solcViaIR = (process.env.SOLC_VIA_IR || 'false').toLowerCase() === 'true';
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 
 const testProvider = ganache.provider({


### PR DESCRIPTION
### Motivation
- Align the repo with the “configure once, operate with minimal governance” posture by avoiding IR compilation unless necessary (reduces toolchain surface and keeps verification straightforward). 
- Make the non-IR compilation the default for deterministic deployments and document a clear fallback path for viaIR-based verification when truly required. 
- Ensure minimal behavioral tests cover that moderator management remains available after the one-way config lock (critical break‑glass controls must survive lock).

### Description
- Change Truffle defaults to disable IR by default by setting `SOLC_VIA_IR=false` fallback in `truffle-config.js`. (Only enable viaIR via env if a non-IR build cannot compile.)
- Update `.env.example` to reflect `SOLC_VIA_IR=false` as the default.
- Update user/developer docs to match the new default and to document a fallback verification path that uses `viaIR=true` with Standard-JSON input when necessary; files updated: `README.md`, `docs/Deployment.md`, `docs/deployment-checklist.md`, and `docs/Testing.md`.
- Extend `test/adminOps.test.js` to assert moderator add/remove operations continue to work after `lockConfiguration()` (verifies break‑glass moderator management remains available post-lock).
- No changes to contract source (`contracts/AGIJobManager.sol`) or optimizer `runs` (remains 200), and pragma/version pins remain unchanged.

### Testing
- Ran `npm test` in the workspace to trigger the repo test pipeline but it failed immediately with `sh: 1: truffle: not found`; no Truffle-based test execution occurred in this environment.
- Performed quick static checks and test file edits locally (unit changes are limited to a single test addition) and committed the changes; full automated test suite should be run in CI or a local environment with Truffle installed via `npm install`/`npm ci`.

Known next steps: run `npm ci && npm test` (or `npx truffle test`) in CI/local dev to validate the change across the full test matrix; if any test failures surface, report them and apply minimal fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981f0ab5b908333bfc0e3477d6f0272)