### PR TITLE
Harden validator gating & dispute coverage; document compiler/verification posture

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.33`, while the Truffle default compiler is `0.8.33` (configurable via `SOLC_VERSION`). `viaIR` is **enabled by default** because compilation without IR hits stack‑too‑deep in this contract; keep compiler settings consistent for verification.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.33`, while the Truffle default compiler is `0.8.33` (configurable via `SOLC_VERSION`). `viaIR` is **enabled by default** because compilation without IR hits stack‑too‑deep; keep compiler settings consistent for verification.
 
 ## Contract documentation
 
@@ -135,7 +135,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 - Optimizer: enabled
 - `optimizer.runs`: **200** (via `SOLC_RUNS`, default in `truffle-config.js`)
-- `viaIR`: **true** by default (set `SOLC_VIA_IR=false` only if you have a validated refactor that avoids stack‑too‑deep)
+- `viaIR`: **true** by default (required to compile without stack‑too‑deep)
 - `metadata.bytecodeHash`: **none**
 - `debug.revertStrings`: **strip**
 - `SOLC_VERSION`: **0.8.33**

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -433,6 +433,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnershipValidator(msg.sender, subdomain, proof))) revert NotAuthorized();
         if (!job.completionRequested) revert InvalidState();
+        _requireValidUri(job.jobCompletionURI);
         if (job.approvals[msg.sender]) revert InvalidState();
         if (job.disapprovals[msg.sender]) revert InvalidState();
 
@@ -454,6 +455,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnershipValidator(msg.sender, subdomain, proof))) revert NotAuthorized();
         if (!job.completionRequested) revert InvalidState();
+        _requireValidUri(job.jobCompletionURI);
         if (job.disapprovals[msg.sender]) revert InvalidState();
         if (job.approvals[msg.sender]) revert InvalidState();
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -43,7 +43,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 The mainnet-safe compiler settings used in `truffle-config.js` are:
 - Optimizer enabled with **runs = 200**.
-- `viaIR = true` by default (required to compile this contract without stack-too-deep errors).
+- `viaIR = true` by default (required to compile without stack-too-deep errors).
 - `debug.revertStrings = 'strip'`.
 - `metadata.bytecodeHash = 'none'`.
 
@@ -112,6 +112,7 @@ npx truffle run verify AGIJobManager --network mainnet
 - Keep the compiler settings (`SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`) identical to the original deployment.
 - Ensure your migration constructor parameters match the deployed contract.
 - If the Etherscan plugin fails, re‑run with `--debug` to capture full output.
+- For `viaIR=true` deployments, Etherscan’s **Standard-Json-Input** flow must include `viaIR: true`, `optimizer.runs: 200`, and `metadata.bytecodeHash: "none"` if you verify manually.
 
 ## Troubleshooting
 - **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.

--- a/docs/Testing.md
+++ b/docs/Testing.md
@@ -25,7 +25,7 @@ npx truffle compile
 ```
 
 By default the Truffle config enables `viaIR` because compilation without IR hits stack-too-deep for this contract.
-If you have a validated refactor that compiles without IR, set `SOLC_VIA_IR=false` and keep the setting consistent for verification.
+Keep the setting consistent for verification.
 
 ## Run the full test suite
 

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -130,6 +130,22 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
     await expectCustomError(manager.resolveStaleDispute.call(jobId, false, { from: owner }), "InvalidState");
   });
 
+  it("blocks validator actions when completion metadata is empty", async () => {
+    const jobId = await createJob(toBN(toWei("4")));
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await manager.setJobMetadata(jobId, "", "ipfs-spec", true, false, { from: owner });
+
+    await expectCustomError(
+      manager.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidParameters"
+    );
+    await expectCustomError(
+      manager.disapproveJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
+      "InvalidParameters"
+    );
+  });
+
   it("mints completion NFTs using the completion metadata URI", async () => {
     const jobId = await createJob(toBN(toWei("9")));
 


### PR DESCRIPTION
### Motivation
- Prevent validators from acting on incomplete/invalid completion metadata and close edge cases in dispute settlement to avoid reverts and inconsistent escrow state. 
- Maintain a minimal, narrow one-way critical config lock while keeping operational controls (moderators, pause, withdraw) available. 
- Keep compiler and verification guidance explicit (solc 0.8.33, optimizer runs = 200) and document the `viaIR` requirement needed to compile this contract without stack-too-deep errors.

### Description
- Enforced completion-metadata validation in validator flows by calling `_requireValidUri(job.jobCompletionURI)` at the start of `validateJob` and `disapproveJob`, preventing validators from approving/disapproving when the completion URI is empty/invalid. (contracts/AGIJobManager.sol)
- Expanded dispute/validation tests to cover: gating of validator actions until completion is requested, prevention of stance switching (approve ↔ disapprove), settlement of agent-win disputes with zero validators, and employer-win disputes becoming terminal and refunding escrow; added checks for empty completion metadata preventing validator actions. (test/disputeHardening.test.js, test/completionSettlementInvariant.test.js)
- Updated developer & ops docs and examples to make compiler/verification posture explicit: keep `SOLC_VERSION=0.8.33`, `SOLC_RUNS=200`, and document that `viaIR` must be enabled to compile without stack-too-deep errors and how to verify with Etherscan when `viaIR=true`. Adjusted `truffle-config.js`, `.env.example`, `README.md`, `docs/Deployment.md`, and `docs/Testing.md` accordingly.

### Testing
- Ran the full test suite locally with `npm test` (this runs `truffle compile --all && truffle test --network test` plus additional harnesses). All tests passed: `212 passing` (no failures).
- Verified compiled runtime sizes: `AGIJobManager` deployed bytecode = 24,223 bytes (under the EIP-170 24,576-byte limit); test-only `TestableAGIJobManager` compiled during tests and is larger but is a test helper (observed during local compile).
- Notes: compilation requires `viaIR=true` to avoid stack-too-deep; documentation and `.env.example` describe the verification steps for viaIR-enabled builds.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ffd5df7c8333b131fe7c03aeda3a)