### PR TITLE
Require completion metadata before validator votes and add verification note

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -433,6 +433,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnershipValidator(msg.sender, subdomain, proof))) revert NotAuthorized();
         if (!job.completionRequested) revert InvalidState();
+        _requireValidUri(job.jobCompletionURI);
         if (job.approvals[msg.sender]) revert InvalidState();
         if (job.disapprovals[msg.sender]) revert InvalidState();
 
@@ -454,6 +455,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (blacklistedValidators[msg.sender]) revert Blacklisted();
         if (!(additionalValidators[msg.sender] || _verifyOwnershipValidator(msg.sender, subdomain, proof))) revert NotAuthorized();
         if (!job.completionRequested) revert InvalidState();
+        _requireValidUri(job.jobCompletionURI);
         if (job.disapprovals[msg.sender]) revert InvalidState();
         if (job.approvals[msg.sender]) revert InvalidState();
 

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -112,6 +112,7 @@ npx truffle run verify AGIJobManager --network mainnet
 - Keep the compiler settings (`SOLC_VERSION`, `SOLC_RUNS`, `SOLC_VIA_IR`, `SOLC_EVM_VERSION`) identical to the original deployment.
 - Ensure your migration constructor parameters match the deployed contract.
 - If the Etherscan plugin fails, re‑run with `--debug` to capture full output.
+- If `SOLC_VIA_IR=true` is used, be prepared to verify with Etherscan’s **Standard JSON input** using the exact compiler settings and metadata options captured by Truffle.
 
 ## Troubleshooting
 - **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.


### PR DESCRIPTION
### Motivation
- Ensure validators can only act on jobs that have a recorded, non-empty completion metadata URI to prevent premature or unsafe validation/disapproval actions.

### Description
- Enforce presence and validity of completion metadata by calling `_requireValidUri(job.jobCompletionURI)` in `validateJob` and `disapproveJob` so validator actions revert if the completion URI is missing or invalid. 
- Add a short verification note to `docs/Deployment.md` explaining that when `SOLC_VIA_IR=true` Etherscan verification may require providing the **Standard JSON input** (capture exact compiler settings and metadata).

### Testing
- Ran the full test suite with `npm test`; all automated tests passed (`207 passing`) including the ABI smoke checks and runtime bytecode size checks, and no regressions were observed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6981ffd5df7c8333b131fe7c03aeda3a)