### PR TITLE
Pin solc to 0.8.12, shave bytecode and add bytecode-size guard

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -42,7 +42,7 @@ OVERRIDING AUTHORITY: AGI.ETH
 
 */
 
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
@@ -688,18 +688,8 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         unchecked {
             uint256 scaledPayout = _payout / 1e18;
             uint256 payoutPoints = scaledPayout ** 3 / 1e5;
-            return log2(1 + payoutPoints * 1e6) + _duration / 10000;
+            return Math.log2(1 + payoutPoints * 1e6) + _duration / 10000;
         }
-    }
-
-    function calculateValidatorReputationPoints(uint256 agentReputationGain) internal view returns (uint256) {
-        unchecked {
-            return (agentReputationGain * validationRewardPercentage) / 100;
-        }
-    }
-
-    function log2(uint x) internal pure returns (uint y) {
-        return Math.log2(x);
     }
 
     function enforceReputationGrowth(address _user, uint256 _points) internal {
@@ -854,7 +844,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             totalValidatorPayout = (job.payout * validationRewardPercentage) / 100;
             validatorPayout = totalValidatorPayout / vCount;
         }
-        uint256 validatorReputationGain = calculateValidatorReputationPoints(reputationPoints);
+        uint256 validatorReputationGain;
+        unchecked {
+            validatorReputationGain = (reputationPoints * validationRewardPercentage) / 100;
+        }
 
         for (uint256 i = 0; i < vCount; ) {
             address validator = job.validators[i];

--- a/contracts/legacy/AGIJobManagerOriginal.sol
+++ b/contracts/legacy/AGIJobManagerOriginal.sol
@@ -102,7 +102,7 @@ OVERRIDING AUTHORITY: AGI.ETH
    
 */
 
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/extensions/ERC721URIStorage.sol";

--- a/contracts/test/ERC20NoReturn.sol
+++ b/contracts/test/ERC20NoReturn.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/FailTransferToken.sol
+++ b/contracts/test/FailTransferToken.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/FailingERC20.sol
+++ b/contracts/test/FailingERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/MarketplaceReceiverMocks.sol
+++ b/contracts/test/MarketplaceReceiverMocks.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";

--- a/contracts/test/MockENS.sol
+++ b/contracts/test/MockENS.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 contract MockENS {
     mapping(bytes32 => address) private resolvers;

--- a/contracts/test/MockERC20.sol
+++ b/contracts/test/MockERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/MockERC721.sol
+++ b/contracts/test/MockERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC721/ERC721.sol";
 

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 contract MockNameWrapper {
     mapping(uint256 => address) private owners;

--- a/contracts/test/MockResolver.sol
+++ b/contracts/test/MockResolver.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 contract MockResolver {
     mapping(bytes32 => address) private addresses;

--- a/contracts/test/ReentrantERC20.sol
+++ b/contracts/test/ReentrantERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
 

--- a/contracts/test/TestableAGIJobManager.sol
+++ b/contracts/test/TestableAGIJobManager.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.33;
+pragma solidity ^0.8.12;
 
 import "../AGIJobManager.sol";
 

--- a/docs/bytecode-and-getters.md
+++ b/docs/bytecode-and-getters.md
@@ -34,6 +34,8 @@ This reads `build/contracts/AGIJobManager.json` and prints the runtime byte
 length. CI also enforces the same limit.
 
 ## Compiler configuration
-`viaIR` remains **OFF** in `truffle-config.js`. Optimizer runs are pinned low
-(`runs=1`) to keep runtime bytecode under the EIP‑170 safety margin; if you
+`viaIR` remains **OFF** in `truffle-config.js`. The repo pins Solidity
+`0.8.12` to avoid the OpenZeppelin `memory-safe-assembly` deprecation warnings
+seen with newer compilers, while keeping compatibility with OZ 4.9.x. Optimizer
+runs are kept low (`runs=1`) to stay within the EIP‑170 bytecode limit; if you
 adjust this, ensure the bytecode limit test still passes.

--- a/scripts/check-contract-sizes.js
+++ b/scripts/check-contract-sizes.js
@@ -3,7 +3,6 @@ const path = require("path");
 
 const MAX_RUNTIME_BYTES = 24575;
 const artifactsDir = path.join(__dirname, "..", "build", "contracts");
-const IGNORED_CONTRACTS = new Set(["TestableAGIJobManager"]);
 
 function deployedSizeBytes(artifact) {
   const deployedBytecode =
@@ -27,7 +26,7 @@ for (const file of artifacts) {
   const name = artifact.contractName || path.basename(file, ".json");
   const sizeBytes = deployedSizeBytes(artifact);
   console.log(`${name} deployedBytecode size: ${sizeBytes} bytes`);
-  if (sizeBytes > MAX_RUNTIME_BYTES && !IGNORED_CONTRACTS.has(name)) {
+  if (sizeBytes > MAX_RUNTIME_BYTES) {
     oversized.push({ name, sizeBytes });
   }
 }

--- a/test/bytecodeSize.test.js
+++ b/test/bytecodeSize.test.js
@@ -1,18 +1,31 @@
 const assert = require("assert");
 
+const MAX_RUNTIME_BYTES = 24575;
+
 const AGIJobManager = artifacts.require("AGIJobManager");
+const TestableAGIJobManager = artifacts.require("TestableAGIJobManager");
 
-contract("AGIJobManager bytecode size", () => {
-  it("stays within the EIP-170 safety margin", async () => {
-    const deployedBytecode = AGIJobManager.deployedBytecode || "";
-    const hex = deployedBytecode.startsWith("0x")
-      ? deployedBytecode.slice(2)
-      : deployedBytecode;
-    const byteLength = hex.length / 2;
+function deployedSizeBytes(artifact) {
+  const deployedBytecode =
+    artifact._json?.deployedBytecode || artifact.deployedBytecode || "";
+  const hex = deployedBytecode.startsWith("0x")
+    ? deployedBytecode.slice(2)
+    : deployedBytecode;
+  return hex.length / 2;
+}
 
-    assert.ok(
-      byteLength <= 24575,
-      `AGIJobManager deployedBytecode is ${byteLength} bytes (limit: 24575)`
+contract("Bytecode size", () => {
+  it("keeps runtime bytecode within the EIP-170 safety margin", () => {
+    const agiSize = deployedSizeBytes(AGIJobManager);
+    assert(
+      agiSize <= MAX_RUNTIME_BYTES,
+      `AGIJobManager runtime bytecode too large: ${agiSize} bytes`
+    );
+
+    const testableSize = deployedSizeBytes(TestableAGIJobManager);
+    assert(
+      testableSize <= MAX_RUNTIME_BYTES,
+      `TestableAGIJobManager runtime bytecode too large: ${testableSize} bytes`
     );
   });
 });

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -49,7 +49,7 @@ const confirmationsSepolia = n(process.env.SEPOLIA_CONFIRMATIONS, 2);
 const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
-const solcVersion = (process.env.SOLC_VERSION || '0.8.33').trim();
+const solcVersion = (process.env.SOLC_VERSION || '0.8.12').trim();
 const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 1));
 const solcViaIR = false;
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();


### PR DESCRIPTION
### Motivation

- Prevent deploy-time and CI breakage caused by Solidity/OpenZeppelin incompatibilities and EIP-170 runtime bytecode limit warnings. 
- Reduce generated bytecode size and remove small helper indirections that bloat runtime code while keeping behavior intact. 
- Add an automated guard so future changes cannot regress bytecode beyond the safety threshold.

### Description

- Pin the compiler to `solc 0.8.12` (viaIR off) and set optimizer `runs=1` in `truffle-config.js` to eliminate OpenZeppelin `memory-safe-assembly` deprecation warnings and keep bytecode small. 
- Align contract pragmas for core and test contracts to `^0.8.12` so compilation is deterministic with the pinned compiler. 
- Reduce a few small helper wrappers inside `AGIJobManager` (inline `Math.log2` usage and inline validator-reputation math) to shave runtime bytecode without changing external behavior. 
- Enforce the EIP-170 safety margin for both contracts by adding `test/bytecodeSize.test.js` and by tightening `scripts/check-contract-sizes.js` to fail on any contract exceeding `24575` bytes (includes `TestableAGIJobManager`). 
- Update docs `docs/bytecode-and-getters.md` to document the compiler choice, optimizer rationale, and bytecode-size check procedure.

### Testing

- Ran `npx truffle compile --all` with the pinned `solc 0.8.12` and compilation succeeded with no OpenZeppelin `memory-safe-assembly` deprecation warnings. 
- Measured runtime/deployed bytecode sizes from artifacts and confirmed both contracts are under the threshold: `AGIJobManager: 24319 bytes`, `TestableAGIJobManager: 24563 bytes`. 
- Ran the test suite with `npx truffle test --network test` and the test run completed successfully (all automated tests passed; 213 passing). 
- Added the deterministic bytecode-size test `test/bytecodeSize.test.js`, which passes in CI and locally with the pinned compiler and optimizer settings.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69824c4ffb608333a2757700dc438897)