### PR TITLE
Add bytecode-size guard, pin solc settings, and document job getters

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,10 +29,7 @@ MAINNET_CONFIRMATIONS=2
 SEPOLIA_TIMEOUT_BLOCKS=500
 MAINNET_TIMEOUT_BLOCKS=500
 
-# Compiler settings (optional)
-SOLC_VERSION=0.8.19
-SOLC_RUNS=50
-SOLC_EVM_VERSION=london
+# Compiler settings are pinned in truffle-config.js.
 
 # Local test chain
 GANACHE_MNEMONIC=test test test test test test test test test test test junk

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle default compiler is `0.8.19` (configurable via `SOLC_VERSION`). `viaIR` remains **disabled**; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.19` in `truffle-config.js`. `viaIR` remains **disabled**; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
 
 ## Contract documentation
 
@@ -136,11 +136,11 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 - Optimizer: enabled
-- `optimizer.runs`: **50** (via `SOLC_RUNS`, default in `truffle-config.js`)
+- `optimizer.runs`: **50** (pinned in `truffle-config.js`)
 - `viaIR`: **false** by default
 - `metadata.bytecodeHash`: **none**
 - `debug.revertStrings`: **strip**
-- `SOLC_VERSION`: **0.8.19**
+- `solc` version: **0.8.19** (pinned in `truffle-config.js`)
 - `evmVersion`: **london** (or the target chain default)
 
 To check runtime sizes locally after compilation:
@@ -205,7 +205,7 @@ npx truffle migrate --network development
 **Optional tuning**
 - Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
 - Provider polling: `RPC_POLLING_INTERVAL_MS`.
-- Compiler settings: `SOLC_VERSION`, `SOLC_RUNS`, `SOLC_EVM_VERSION`.
+- Compiler settings are pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`).
 - Local chain: `GANACHE_MNEMONIC`.
 
 **Network notes**

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -26,12 +26,12 @@ The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS
 | `SEPOLIA_CONFIRMATIONS` / `MAINNET_CONFIRMATIONS` | Confirmations to wait | Defaults to 2. |
 | `SEPOLIA_TIMEOUT_BLOCKS` / `MAINNET_TIMEOUT_BLOCKS` | Timeout blocks | Defaults to 500. |
 | `RPC_POLLING_INTERVAL_MS` | Provider polling interval | Defaults to 8000 ms. |
-| `SOLC_VERSION` / `SOLC_RUNS` / `SOLC_EVM_VERSION` | Compiler settings | Defaults: `SOLC_VERSION=0.8.19`, `SOLC_RUNS=50`, `SOLC_EVM_VERSION=london`. |
+| Compiler settings | Compiler settings | Pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`). |
 | `GANACHE_MNEMONIC` | Local test mnemonic | Defaults to Ganache standard mnemonic if unset. |
 
 A template lives in [`.env.example`](../.env.example).
 
-> **Compiler note**: `AGIJobManager.sol` uses `pragma solidity ^0.8.19`, while the default Truffle compiler is `0.8.19`. For reproducible verification, keep `SOLC_VERSION` and optimizer runs consistent with the original deployment.
+> **Compiler note**: `AGIJobManager.sol` uses `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.19` in `truffle-config.js`. For reproducible verification, keep the solc version and optimizer runs consistent with the original deployment.
 
 ## Runtime bytecode size (EIP-170)
 
@@ -109,7 +109,7 @@ npx truffle run verify AGIJobManager --network mainnet
 ```
 
 ### Verification tips
-- Keep the compiler settings (`SOLC_VERSION`, `SOLC_RUNS`, `SOLC_EVM_VERSION`) identical to the original deployment.
+- Keep the compiler settings from `truffle-config.js` identical to the original deployment (solc `0.8.19`, runs `50`, `evmVersion` `london`).
 - Ensure your migration constructor parameters match the deployed contract.
 - If the Etherscan plugin fails, re‑run with `--debug` to capture full output.
 - Etherscan’s **Standard-Json-Input** flow should include `viaIR: false`, `optimizer.runs: 50`, and `metadata.bytecodeHash: "none"` if you verify manually.

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -115,7 +115,7 @@ Everything else remains operable but should be governed by your ops policy to ke
 ## 7) Verification (Etherscan)
 
 **Normal path (viaIR disabled)**:
-1. Compile with `SOLC_VERSION=0.8.19`, `SOLC_RUNS=50`.
+1. Compile with the pinned compiler settings (solc `0.8.19`, runs `50`).
 2. Verify using `truffle-plugin-verify` with the same compiler settings and constructor args.
 
 **Fallback (Standard JSON input)**:

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -49,8 +49,8 @@ const confirmationsSepolia = n(process.env.SEPOLIA_CONFIRMATIONS, 2);
 const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
-const solcVersion = (process.env.SOLC_VERSION || '0.8.19').trim();
-const solcRuns = Math.floor(n(process.env.SOLC_RUNS, 50));
+const solcVersion = '0.8.19';
+const solcRuns = 50;
 const solcViaIR = false;
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 


### PR DESCRIPTION
### Motivation

- Prevent legacy (non-viaIR) stack-too-deep and oversized auto-getter problems by keeping the large `jobs` getter out of the public ABI and documenting the compact read getters and bytecode-size rules.  
- Ensure deployed/runtime bytecode stays under the EIP-170 safety margin and stop CI noise from OpenZeppelin deprecation warnings without touching `node_modules` or enabling `viaIR`.

### Description

- Pinned the compiler in `truffle-config.js` to `solc 0.8.19` and fixed optimizer runs to `50` (keeps `viaIR = false`).  
- Added a deterministic Truffle test guard `test/bytecodeSize.test.js` that asserts `AGIJobManager` and `TestableAGIJobManager` deployed bytecode <= 24,575 bytes.  
- Added docs `docs/bytecode-and-getters.md` and updated `README.md`, `docs/Deployment.md`, `docs/deployment-checklist.md`, and `.env.example` to document the pinned compiler, optimizer settings, the rationale for `jobs` visibility, and how to measure runtime bytecode.  
- Left OpenZeppelin dependency at `@openzeppelin/contracts@4.9.6` and avoided patching `node_modules`; the compiler pin avoids memory-safe-assembly deprecation warnings emitted by newer compilers.  

### Testing

- Ran `npx truffle compile --all`; compilation succeeded with `solc 0.8.19` and no memory-safe-assembly deprecation warnings. (Success.)  
- Ran the full test suite `npx truffle test --network test`; all tests passed (213 passing). (Success.)  
- Measured deployed/runtime bytecode sizes from the built artifacts and verified against the guard: `AGIJobManager = 24,295 bytes` and `TestableAGIJobManager = 24,545 bytes`, both <= `24,575` (Success).  

Commands run (high-level):  
- `npx truffle compile --all` — OK  
- `npx truffle test --network test` — OK (213 passing)  
- `node -e "const a=require('./build/contracts/AGIJobManager.json');const b=(a.deployedBytecode||'').replace(/^0x/,'');console.log(b.length/2)"` — printed `24295`  
- `node -e "const a=require('./build/contracts/TestableAGIJobManager.json');const b=(a.deployedBytecode||'').replace(/^0x/,'');console.log(b.length/2)"` — printed `24545`  

Notes:  
- `npm ci` failed initially in the environment due to an optional `fsevents` platform restriction; installation and test runs were completed in the environment by installing dependencies (CI in GitHub should continue to run in its normal environment).  
- No changes were made to the `Job` struct or storage layout; reads are served via the existing/new compact getters described in the docs.  

Summary of choices: `solc = 0.8.19`, optimizer enabled with `runs = 50`, `viaIR = false`, `@openzeppelin/contracts` kept at `4.9.6`, runtime sizes: `AGIJobManager = 24295`, `TestableAGIJobManager = 24545`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982582e1b3883339792af3783b644b2)