### PR TITLE
Clarify job getters and bytecode guard documentation

### DIFF
--- a/docs/bytecode-and-getters.md
+++ b/docs/bytecode-and-getters.md
@@ -7,8 +7,9 @@
 Use these getters instead:
 
 - `getJobCore(jobId)` for core job fields (employer, assigned agent, payout, duration, assignment data, completion/dispute/expiry state, and agent payout percentage).
-- `getJobValidation(jobId)` for validation-related fields (completion request state and validator counts).
-- `getJobStatus(jobId)` and `getJobAgentPayoutPct(jobId)` for narrower single-purpose reads.
+- `getJobValidation(jobId)` for validation-related fields (completion request state and validator counts/timestamps).
+- `getJobSpecURI(jobId)` for the job specification URI.
+- `getJobCompletionURI(jobId)` for the completion URI (when provided).
 
 ## Runtime bytecode size limit (EIP-170)
 


### PR DESCRIPTION
### Motivation
- Clarify the canonical, small-arity getters that replace the large autogenerated `jobs` getter and record the compiler/optimizer choices used to avoid OZ "memory-safe-assembly" warnings while keeping runtime bytecode under the EIP‑170 safety margin.

### Description
- Update `docs/bytecode-and-getters.md` to list the supported read helpers (`getJobCore`, `getJobValidation`, `getJobSpecURI`, `getJobCompletionURI`) and document the pinned compiler and optimizer settings (`solc 0.8.19`, `optimizer runs = 50`, `viaIR = false`).

### Testing
- Reproduced and validated locally: `npm ci` failed due to darwin-only `fsevents` (used `npm install --omit=optional` to proceed), `npx truffle compile` succeeded with `solc 0.8.19`, and `npx truffle test --network test` passed (213 passing), including the bytecode size guard; measured runtime sizes were `AGIJobManager = 24295 bytes` and `TestableAGIJobManager = 24545 bytes`, both ≤ 24575.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982659859848333887feb46d0b9bea5)