### PR TITLE
Fix validator payouts (approvers-only), emit blacklist events, and reduce optimizer runs to meet EIP‑170

### DIFF
--- a/docs/bytecode-and-getters.md
+++ b/docs/bytecode-and-getters.md
@@ -28,10 +28,19 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 We also enforce this in tests (`test/bytecodeSize.test.js`) so CI fails if the limit is exceeded.
 
+## Validator payout rule (approvers-only)
+
+When a job completes on an **agent win**, validator rewards are paid **only to approvers**. Validators who disapproved do **not** receive payouts or reputation. If validators participated but **no approvals** were recorded, the validator reward share is redirected to the agent so escrowed funds are still fully distributed.
+
 ## Compiler settings and warning cleanup
 
 - **Solidity version:** pinned to `0.8.19` in `truffle-config.js` to avoid the OpenZeppelin *memory-safe-assembly* deprecation warnings emitted by newer compilers.
 - **OpenZeppelin contracts:** kept at `@openzeppelin/contracts@4.9.6` (same major version).
-- **Optimizer:** enabled with **runs = 200** to balance deploy size and runtime gas (viaIR stays off).
+- **Optimizer:** enabled with **runs = 50** to balance deploy size and runtime gas (viaIR stays off).
 
 If you change compiler settings for a new deployment, keep the version and optimizer runs consistent for reproducible verification.
+
+## Ops notes
+
+- Reward pool contributions add to the contract balance and are **not escrow-locked**. While paused, the owner can withdraw them via `withdrawAGI` (subject to `lockedEscrow`).  
+- `additionalAgentPayoutPercentage` is currently **not used** in payout math and remains reserved/legacy configuration.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -174,6 +174,25 @@
         {
           "indexed": true,
           "internalType": "address",
+          "name": "agent",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "status",
+          "type": "bool"
+        }
+      ],
+      "name": "AgentBlacklisted",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
           "name": "owner",
           "type": "address"
         },
@@ -889,6 +908,25 @@
         }
       ],
       "name": "Unpaused",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "validator",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "status",
+          "type": "bool"
+        }
+      ],
+      "name": "ValidatorBlacklisted",
       "type": "event"
     },
     {

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -240,11 +240,13 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     assert.strictEqual(jobAfterAgentWin.disputed, false, "dispute flag should clear after resolution");
     const agentPayoutPct = toBN(jobAfterAgentWin.agentPayoutPct);
     const expectedAgentPayout = payout.mul(agentPayoutPct).divn(100);
-    const expectedRemaining = payout.sub(expectedAgentPayout);
+    const validationPct = toBN(await manager.validationRewardPercentage());
+    const expectedValidatorPayout = payout.mul(validationPct).divn(100);
+    const expectedRemaining = payout.sub(expectedAgentPayout).sub(expectedValidatorPayout);
     assert.equal(
       (await token.balanceOf(manager.address)).toString(),
       expectedRemaining.toString(),
-      "escrow should retain unused validator rewards on agent win"
+      "escrow should retain only the non-distributed remainder on agent win"
     );
     await expectCustomError(manager.disputeJob.call(jobId, { from: employer }), "InvalidState");
 
@@ -288,7 +290,7 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     assert.equal(
       (await token.balanceOf(manager.address)).toString(),
       expectedRemaining.toString(),
-      "escrow should retain unused validator rewards from prior agent win"
+      "escrow should retain only the non-distributed remainder from prior agent win"
     );
   });
 });

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -257,11 +257,13 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     );
     const agentPayoutPct = toBN(job.agentPayoutPct);
     const expectedAgentPayout = payout.mul(agentPayoutPct).divn(100);
-    const expectedRemaining = payout.sub(expectedAgentPayout);
+    const validationPct = toBN(await manager.validationRewardPercentage());
+    const expectedValidatorPayout = payout.mul(validationPct).divn(100);
+    const expectedRemaining = payout.sub(expectedAgentPayout).sub(expectedValidatorPayout);
     assert.equal(
       balancesAfter.contract.toString(),
       expectedRemaining.toString(),
-      "escrow should retain unused validator rewards after dispute resolution"
+      "escrow should retain only the non-distributed remainder after dispute resolution"
     );
   });
 

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,7 +50,7 @@ const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = '0.8.19';
-const solcRuns = 200;
+const solcRuns = 50;
 const solcViaIR = false;
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 


### PR DESCRIPTION
### Motivation
- Eliminate the validator griefing incentive by ensuring only approving validators get paid on an agent-win completion and avoid accidental payouts to disapprovers. 
- Fix a small correctness issue in the AGI type helper to return its named outputs and keep the on‑chain ABI/ABI export in sync with emitted events. 
- Reduce compiled runtime bytecode to be safely under EIP‑170 while keeping tests and behavior intact.

### Description
- Pay validator rewards only to approvers and, when there are validators but zero approvals, redirect the validator reward share to the agent so the escrow is fully distributed (`_completeJob` + `_payApprovingValidators` changes in `contracts/AGIJobManager.sol`).
- Add `AgentBlacklisted` and `ValidatorBlacklisted` events and emit them from `blacklistAgent`/`blacklistValidator` to improve observability (contracts + UI ABI update in `docs/ui/abi/AGIJobManager.json`).
- Ensure `_maxAGITypePayoutAfterUpdate` returns its named tuple `(exists, maxPct)` to satisfy the function signature (small return added).
- Small payout/guard refactor: validator payout percentage calculation now uses `validatorCount = job.validators.length` to avoid incorrect gating by approval counts.
- Lower the Solidity optimizer runs from `200` to `50` in `truffle-config.js` to reduce deployed runtime bytecode size (viaIR left disabled) and update docs (`docs/bytecode-and-getters.md`).
- Update two scenario tests to account for the validator-share redirection and remaining escrow expectations (`test/scenarioLifecycle.marketplace.test.js`, `test/scenarioEconomicStateMachine.test.js`).

### Testing
- Dependency install: `npm ci` failed on Linux due to the darwin-only `fsevents` optional dependency; proceeded with `npm install --omit=optional` to continue the reproduction. (This is an environment/package platform issue, not a repo fault.)
- Compiler/version: `npx truffle version` showed Truffle using `solc 0.8.19` and compilation completed successfully with our settings.
- Compile: `npx truffle compile --all` completed successfully after the changes and produced artifacts.
- Bytecode size measurement: `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log(b.length/2)"` reported `AGIJobManager deployedBytecode bytes: 24266`, which is <= `24575` (EIP‑170 safety margin). `AGIJobManagerOriginal` size: `18376` bytes.
- Full test run: `npx truffle test --network test` (using the bundled test provider) ran the suite; result summary: all automated tests passed (212 passing).
- Verified there were no `stack-too-deep` compile failures and no OpenZeppelin "memory-safe-assembly comment deprecated" warnings with the chosen `solc` pin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69828fff0c2c83338cb02ace0446c1e6)