### PR TITLE
Allow paused completion/delist and clarify identity wiring lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,6 +117,7 @@ Detailed contract documentation lives in `docs/`:
 - [Configure-once deployment profile](docs/DEPLOYMENT_PROFILE.md)
 - [Deployment checklist](docs/deployment-checklist.md)
 - [Minimal governance operations](docs/minimal-governance.md)
+- [Identity wiring lock & treasury pause model](docs/identity-lock-and-treasury.md)
 - [Minimal governance model](docs/GOVERNANCE.md)
 - [AGI Jobs one-pager (canonical narrative)](docs/AGI_JOBS_ONE_PAGER.md)
 - [AGIJobManager overview](docs/AGIJobManager.md)

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -29,7 +29,6 @@
 | `blacklistedValidators(address)` | view | bool |
 | `clubRootNode()` | view | bytes32 |
 | `completionReviewPeriod()` | view | uint256 |
-| `configLocked()` | view | bool |
 | `contactEmail()` | view | string |
 | `disputeReviewPeriod()` | view | uint256 |
 | `ens()` | view | address |
@@ -37,6 +36,7 @@
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
+| `lockIdentityConfig()` | view | bool |
 | `lockedEscrow()` | view | uint256 |
 | `maxJobPayout()` | view | uint256 |
 | `moderators(address)` | view | bool |
@@ -65,7 +65,7 @@
 | `validatorVotedJobs(address, uint256)` | view | uint256 |
 | `pause()` | nonpayable | — |
 | `unpause()` | nonpayable | — |
-| `lockConfiguration()` | nonpayable | — |
+| `lockIdentityConfiguration()` | nonpayable | — |
 | `createJob(string _jobSpecURI, uint256 _payout, uint256 _duration, string _details)` | nonpayable | — |
 | `applyForJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
 | `requestJobCompletion(uint256 _jobId, string _jobCompletionURI)` | nonpayable | — |
@@ -131,15 +131,16 @@
 | `AGITypeUpdated(address nftAddress, uint256 payoutPercentage)` | indexed address nftAddress, uint256 payoutPercentage |
 | `AGIWithdrawn(address to, uint256 amount, uint256 remainingWithdrawable)` | indexed address to, uint256 amount, uint256 remainingWithdrawable |
 | `AdditionalAgentPayoutPercentageUpdated(uint256 newPercentage)` | uint256 newPercentage |
+| `AgentBlacklisted(address agent, bool status)` | indexed address agent, bool status |
 | `Approval(address owner, address approved, uint256 tokenId)` | indexed address owner, indexed address approved, indexed uint256 tokenId |
 | `ApprovalForAll(address owner, address operator, bool approved)` | indexed address owner, indexed address operator, bool approved |
 | `CompletionReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
-| `ConfigurationLocked(address locker, uint256 atTimestamp)` | indexed address locker, uint256 atTimestamp |
 | `DisputeResolved(uint256 jobId, address resolver, string resolution)` | uint256 jobId, address resolver, string resolution |
 | `DisputeResolvedWithCode(uint256 jobId, address resolver, uint8 resolutionCode, string reason)` | uint256 jobId, address resolver, uint8 resolutionCode, string reason |
 | `DisputeReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
 | `DisputeTimeoutResolved(uint256 jobId, address resolver, bool employerWins)` | uint256 jobId, address resolver, bool employerWins |
 | `EnsRegistryUpdated(address newEnsRegistry)` | indexed address newEnsRegistry |
+| `IdentityConfigurationLocked(address locker, uint256 atTimestamp)` | indexed address locker, uint256 atTimestamp |
 | `JobApplied(uint256 jobId, address agent)` | uint256 jobId, address agent |
 | `JobCancelled(uint256 jobId)` | uint256 jobId |
 | `JobCompleted(uint256 jobId, address agent, uint256 reputationPoints)` | uint256 jobId, address agent, uint256 reputationPoints |
@@ -164,6 +165,7 @@
 | `RootNodesUpdated(bytes32 clubRootNode, bytes32 agentRootNode, bytes32 alphaClubRootNode, bytes32 alphaAgentRootNode)` | bytes32 clubRootNode, bytes32 agentRootNode, bytes32 alphaClubRootNode, bytes32 alphaAgentRootNode |
 | `Transfer(address from, address to, uint256 tokenId)` | indexed address from, indexed address to, indexed uint256 tokenId |
 | `Unpaused(address account)` | address account |
+| `ValidatorBlacklisted(address validator, bool status)` | indexed address validator, bool status |
 
 ## Custom errors
 | Error | Inputs |

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -96,7 +96,7 @@ Merkle roots are **allowlists only**. They grant access to apply/validate but do
 After setup and validation, lock configuration to minimize governance:
 
 - **Preferred**: set `LOCK_CONFIG=true` before migration to auto-lock.
-- **Manual**: call `lockConfiguration()` from the owner account.
+- **Manual**: call `lockIdentityConfiguration()` from the owner account.
 
 Once locked, **critical configuration setters** are disabled permanently (see `docs/minimal-governance.md`).
 Critical wiring includes the AGI token address, ENS registry, NameWrapper, and ENS root nodes; each is only mutable pre‑first‑job and pre‑lock.

--- a/docs/identity-lock-and-treasury.md
+++ b/docs/identity-lock-and-treasury.md
@@ -1,0 +1,73 @@
+# Identity wiring lock & treasury pause model
+
+This note summarizes the **operational trust model** for AGIJobManager: the owner operates the marketplace, but escrow funds remain protected and identity wiring can be permanently frozen.
+
+## Marketplace operations model
+
+AGIJobManager is a **business‑operated marketplace**. The owner sets parameters, manages allowlists/blacklists, and can pause/unpause operations. This is **not** a DAO or permissionless court; moderators and the owner have explicit operational authority.
+
+## Escrow protection invariant
+
+All job payouts are escrowed on-chain and tracked in `lockedEscrow`. The owner can **never** withdraw escrowed funds:
+
+```
+withdrawableAGI = tokenBalance - lockedEscrow
+```
+
+If `withdrawableAGI` is insufficient, `withdrawAGI` reverts. This keeps employer‑funded escrow protected even during incidents.
+
+## Treasury definition
+
+**Treasury** is any non‑escrow AGI held by the contract, including:
+
+- leftover remainder from settlement math,
+- rounding dust,
+- direct transfers to the contract,
+- reward‑pool contributions.
+
+Treasury funds are owner‑withdrawable **only while paused**, and only up to `withdrawableAGI`.
+
+## Pause semantics (brief pause for treasury withdrawals)
+
+Pausing is intended as a **brief incident/withdrawal window** without trapping users. While paused:
+
+**Blocked actions**
+- New job creation and assignment (`createJob`, `applyForJob`).
+- Validation flow (`validateJob`, `disapproveJob`, `disputeJob`).
+- Marketplace listing and purchase (`listNFT`, `purchaseNFT`).
+- Reward‑pool contributions.
+
+**Still allowed**
+- **Agent completion submission** (`requestJobCompletion`) for assigned, non‑expired, non‑completed jobs.
+- **NFT delisting** by the seller (`delistNFT`).
+- **Settlement exits** when their normal predicates are met: `cancelJob`, `expireJob`, `finalizeJob`.
+- Owner break‑glass tools: `resolveStaleDispute` and `withdrawAGI` (treasury only).
+
+This ensures agents can still submit completion metadata and sellers can exit listings even during a pause.
+
+## Identity wiring lock (permanent)
+
+The identity wiring lock **freezes only identity wiring** and does **not** freeze business operations.
+
+### Frozen after lock
+- AGI token address.
+- ENS registry.
+- NameWrapper.
+- Root nodes (identity namespaces).
+
+### Not frozen after lock
+- Pausing/unpausing.
+- Withdrawals of **non‑escrow** treasury (only when paused).
+- Job settlement/payouts.
+- Blacklists / allowlists (Merkle roots).
+- Economic parameters (thresholds, payout settings, review periods).
+
+Once `lockIdentityConfiguration()` is called, identity wiring is immutable forever.
+
+## Notes on unused parameters
+
+`additionalAgentPayoutPercentage` remains a **reserved configuration value**. It is **not used** in current payout calculations and is retained for future extensibility.
+
+## Reward‑pool contributions
+
+Reward‑pool contributions are treated as **treasury**. They are **owner‑withdrawable while paused** (subject to the escrow invariant).

--- a/docs/minimal-governance.md
+++ b/docs/minimal-governance.md
@@ -1,16 +1,18 @@
 # Minimal governance model
 
-This document explains the **critical configuration lock** and the intended “configure once → operate” posture.
+This document explains the **identity wiring lock** and the intended “configure once → operate” posture.
 
-## What the configuration lock does
+## What the identity wiring lock does
 
-Calling `lockConfiguration()` permanently disables **critical configuration setters**. It is **one-way** and irreversible.
+Calling `lockIdentityConfiguration()` permanently disables **identity wiring setters**. It is **one-way** and irreversible.
 
-Once locked, the contract keeps operating for normal jobs, escrows, and dispute flows, but the **critical config surface** is frozen.
+Once locked, the contract keeps operating for normal jobs, escrows, and dispute flows, but the **identity wiring surface** is frozen.
+
+> **Scope reminder:** this lock is **not** governance- or operations-wide; it only freezes identity wiring (token/ENS/root nodes).
 
 ## Functions disabled after lock
 
-These functions are guarded by `whenCriticalConfigurable` and **revert** once the configuration is locked:
+These functions are guarded by `whenIdentityConfigurable` and **revert** once the identity wiring is locked:
 
 **Critical routing / identity**
 - `updateAGITokenAddress` (only allowed before any job exists and before the lock)
@@ -41,7 +43,7 @@ Other configuration knobs (thresholds, review periods, allowlists, metadata, etc
 1. **Deploy** (set ENS/NameWrapper/token/root nodes and Merkle roots).
 2. **Configure** (thresholds, payouts, metadata, moderators, allowlists).
 3. **Validate** (run sanity checks and real job flow).
-4. **Lock** (`lockConfiguration()` or `LOCK_CONFIG=true` during migration).
+4. **Lock** (`lockIdentityConfiguration()` or `LOCK_CONFIG=true` during migration).
 5. **Operate** (minimal governance with incident-response tools only).
 
 ## Monitoring suggestions (post-lock)
@@ -49,7 +51,7 @@ Other configuration knobs (thresholds, review periods, allowlists, metadata, etc
 To keep operations low-touch, monitor the following invariants and events:
 
 - **Escrow solvency**: track `lockedEscrow` vs. token balance; `withdrawableAGI()` must stay non‑negative.
-- **Critical wiring changes (pre-lock)**: watch `EnsRegistryUpdated`, `NameWrapperUpdated`, `RootNodesUpdated`, and `ConfigurationLocked`.
+- **Critical wiring changes (pre-lock)**: watch `EnsRegistryUpdated`, `NameWrapperUpdated`, `RootNodesUpdated`, and `IdentityConfigurationLocked`.
 - **Allowlist updates**: `MerkleRootsUpdated` signals validator/agent allowlist changes (access only, not payout logic).
 - **Dispute recovery**: `DisputeTimeoutResolved` indicates break‑glass resolution by the owner.
 

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -260,25 +260,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": true,
-          "internalType": "address",
-          "name": "locker",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "atTimestamp",
-          "type": "uint256"
-        }
-      ],
-      "name": "ConfigurationLocked",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": false,
           "internalType": "uint256",
           "name": "jobId",
@@ -386,6 +367,25 @@
         }
       ],
       "name": "EnsRegistryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "locker",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "atTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "IdentityConfigurationLocked",
       "type": "event"
     },
     {
@@ -1224,19 +1224,6 @@
     },
     {
       "inputs": [],
-      "name": "configLocked",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
       "name": "contactEmail",
       "outputs": [
         {
@@ -1358,6 +1345,19 @@
         {
           "internalType": "bool",
           "name": "isActive",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lockIdentityConfig",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
           "type": "bool"
         }
       ],
@@ -1787,7 +1787,7 @@
     },
     {
       "inputs": [],
-      "name": "lockConfiguration",
+      "name": "lockIdentityConfiguration",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -83,7 +83,7 @@ module.exports = async function (deployer, network, accounts) {
 
   const manager = await AGIJobManager.deployed();
   if (isTrue(process.env.LOCK_CONFIG)) {
-    await manager.lockConfiguration({ from: accounts[0] });
+    await manager.lockIdentityConfiguration({ from: accounts[0] });
   }
 
   console.log("AGIJobManager deployment summary:");
@@ -97,5 +97,5 @@ module.exports = async function (deployer, network, accounts) {
   console.log(`- alpha agent root: ${alphaAgentRootNode}`);
   console.log(`- validator merkle root: ${validatorMerkleRoot}`);
   console.log(`- agent merkle root: ${agentMerkleRoot}`);
-  console.log(`- config locked: ${await manager.configLocked()}`);
+  console.log(`- identity config locked: ${await manager.lockIdentityConfig()}`);
 };

--- a/scripts/postdeploy-config.js
+++ b/scripts/postdeploy-config.js
@@ -209,9 +209,9 @@ module.exports = async function postdeployConfig(callback) {
     const currentApprovals = await instance.requiredValidatorApprovals();
     const currentDisapprovals = await instance.requiredValidatorDisapprovals();
     const maxValidators = await instance.MAX_VALIDATORS_PER_JOB();
-    const configLocked = await instance.configLocked();
+    const identityConfigLocked = await instance.lockIdentityConfig();
 
-    if (configLocked) {
+    if (identityConfigLocked) {
       const lockedKeys = [
         "requiredValidatorApprovals",
         "requiredValidatorDisapprovals",
@@ -234,7 +234,7 @@ module.exports = async function postdeployConfig(callback) {
       const lockedRequested = lockedKeys.filter((key) => config[key] !== undefined);
       if (lockedRequested.length) {
         throw new Error(
-          `Configuration is locked; remove these settings and retry: ${lockedRequested.join(", ")}`
+          `Identity configuration is locked; remove these settings and retry: ${lockedRequested.join(", ")}`
         );
       }
     }

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -113,7 +113,7 @@ contract("AGIJobManager admin ops", (accounts) => {
 
     await token.mint(manager.address, surplus, { from: owner });
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
 
     const balanceBefore = await token.balanceOf(owner);
     await expectRevert.unspecified(manager.withdrawAGI(surplus, { from: owner }));
@@ -156,8 +156,8 @@ contract("AGIJobManager admin ops", (accounts) => {
   });
 
   it("locks configuration changes while retaining break-glass controls", async () => {
-    await manager.lockConfiguration({ from: owner });
-    assert.equal(await manager.configLocked(), true, "config should be locked");
+    await manager.lockIdentityConfiguration({ from: owner });
+    assert.equal(await manager.lockIdentityConfig(), true, "identity config should be locked");
 
     await manager.updateMerkleRoots(clubRoot, agentRoot, { from: owner });
 
@@ -173,7 +173,7 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.pause({ from: owner });
     await manager.unpause({ from: owner });
 
-    await expectCustomError(manager.lockConfiguration.call({ from: owner }), "ConfigLocked");
+    await expectCustomError(manager.lockIdentityConfiguration.call({ from: owner }), "ConfigLocked");
   });
 
   it("updates ENS wiring and root nodes before jobs, then locks them", async () => {
@@ -201,7 +201,7 @@ contract("AGIJobManager admin ops", (accounts) => {
       "InvalidState"
     );
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
     await expectCustomError(manager.updateEnsRegistry.call(ens.address, { from: owner }), "ConfigLocked");
     await expectCustomError(manager.updateNameWrapper.call(nameWrapper.address, { from: owner }), "ConfigLocked");
   });
@@ -222,7 +222,7 @@ contract("AGIJobManager admin ops", (accounts) => {
       "InvalidState"
     );
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
     await expectCustomError(
       manager.updateAGITokenAddress.call(newToken.address, { from: owner }),
       "ConfigLocked"

--- a/test/nftMarketplace.test.js
+++ b/test/nftMarketplace.test.js
@@ -152,14 +152,16 @@ contract("AGIJobManager NFT marketplace", (accounts) => {
     await manager.listNFT(tokenId, price, { from: employer });
 
     await manager.pause({ from: owner });
-    await expectPausedRevert(
-      manager.delistNFT(tokenId, { from: employer }),
-      () => manager.delistNFT.call(tokenId, { from: employer }),
-      owner
-    );
+    await manager.delistNFT(tokenId, { from: employer });
+    const pausedListing = await manager.listings(tokenId);
+    assert.strictEqual(pausedListing.isActive, false, "listing should be inactive after paused delist");
+
+    await manager.unpause({ from: owner });
+    await manager.listNFT(tokenId, price, { from: employer });
 
     await token.mint(buyer, price, { from: owner });
     await token.approve(manager.address, price, { from: buyer });
+    await manager.pause({ from: owner });
     await expectPausedRevert(
       manager.purchaseNFT(tokenId, { from: buyer }),
       () => manager.purchaseNFT.call(tokenId, { from: buyer }),

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -377,8 +377,9 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
 
     await manager.pause({ from: owner });
-    await expectRevert.unspecified(
-      manager.requestJobCompletion(jobId, "ipfs-paused", { from: agent }));
+    await manager.requestJobCompletion(jobId, "ipfs-paused", { from: agent });
+    const pausedValidation = await manager.getJobValidation(jobId);
+    assert.strictEqual(pausedValidation.completionRequested, true, "completion request should be allowed while paused");
     await expectRevert.unspecified(
       manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }));
     await expectRevert.unspecified(
@@ -387,7 +388,6 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     await expectRevert.unspecified(manager.contributeToRewardPool(payout, { from: employer }));
 
     await manager.unpause({ from: owner });
-    await manager.requestJobCompletion(jobId, "ipfs-resumed", { from: agent });
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
 


### PR DESCRIPTION
### Motivation
- Permit a short, owner-controlled pause window for treasury withdrawals without trapping users by allowing agents to submit completion and sellers to delist during pause. 
- Clarify the intent of the one-way configuration lock: make it explicitly an identity-wiring lock (token/ENS/namewrapper/root nodes) and avoid implying it's a broad governance lock.

### Description
- Removed the pause gate from `requestJobCompletion` so assigned, non-expired, non-completed agents can submit completion while the contract is paused (`paused()` check removed). 
- Allowed `delistNFT` during pause by removing `whenNotPaused` from its declaration while keeping seller-check and active-listing invariants. 
- Renamed identity lock plumbing with minimal churn: `configLocked` → `lockIdentityConfig`, `whenCriticalConfigurable` → `whenIdentityConfigurable`, `lockConfiguration()` → `lockIdentityConfiguration()`, and `ConfigurationLocked` → `IdentityConfigurationLocked`, and updated all internal references, tests, scripts, migrations and docs accordingly. 
- Added a short high‑signal doc `docs/identity-lock-and-treasury.md` and linked it from `README.md`; updated `docs/minimal-governance.md`, `migrations/2_deploy_contracts.js`, `scripts/postdeploy-config.js`, and regenerated `docs/Interface.md` and `docs/ui/abi/AGIJobManager.json`. 
- Adjusted tests to reflect pause semantics: allow `requestJobCompletion` and `delistNFT` while paused, and added coverage that cancellation/expiry/finalize flows and treasury withdrawals behave correctly during pauses; updated admin tests to use the new lock names. No logic/economic behavior changes beyond the requested pause/lock semantics.

### Testing
- `npm install --omit=optional --no-package-lock` succeeded to install dependencies (note: `npm ci` fails on this platform due to `fsevents` being macOS-only). (succeeded)
- `npx truffle version` (reports Truffle + solc environment). (succeeded)
- `npx truffle compile` compiled cleanly with `solc 0.8.19` and no compile warnings. (succeeded)
- Measured deployed/runtime bytecode size via: `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log(b.length/2)"` which reported `24205` bytes, under the EIP‑170 safety margin `24575` bytes. (succeeded)
- `npx truffle test` could not be executed in this environment because Truffle could not connect to a local node at `http://127.0.0.1:8545` (CI guard/test artifacts updated but full test run requires a running dev node). (blocked)

Additional notes:
- Chosen solc version: `0.8.19` (matches contract pragma and `truffle-config.js` to avoid OpenZeppelin memory-safe-assembly warnings and keep deterministic, warning-free compilation). 
- Deployed/runtime bytecode size measured: `24,205` bytes (<= 24,575 bytes limit). 
- Remaining actionable environment issues: run `npx truffle test` with a local Ganache/Ganache CLI or CI-provided test network to validate the full test suite end-to-end; `npm ci` on Linux CI may need `--omit=optional` to avoid `fsevents` platform mismatch.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982baddbc508333accb96c84339077f)