### PR TITLE
Allow completions/delists while paused; rename config lock to identity wiring lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ Detailed contract documentation lives in `docs/`:
 - [Bytecode size & job getters](docs/bytecode-and-getters.md)
 - [AGIJobManager operator guide](docs/AGIJobManager_Operator_Guide.md)
 - [AGIJobManager security considerations](docs/AGIJobManager_Security.md)
+- [Identity lock & treasury pause semantics](docs/identity-lock-and-treasury.md)
 
 ## Mainnet bytecode size (EIP-170)
 

--- a/docs/Interface.md
+++ b/docs/Interface.md
@@ -29,7 +29,6 @@
 | `blacklistedValidators(address)` | view | bool |
 | `clubRootNode()` | view | bytes32 |
 | `completionReviewPeriod()` | view | uint256 |
-| `configLocked()` | view | bool |
 | `contactEmail()` | view | string |
 | `disputeReviewPeriod()` | view | uint256 |
 | `ens()` | view | address |
@@ -37,6 +36,7 @@
 | `isApprovedForAll(address owner, address operator)` | view | bool |
 | `jobDurationLimit()` | view | uint256 |
 | `listings(uint256)` | view | uint256, address, uint256, bool |
+| `lockIdentityConfig()` | view | bool |
 | `lockedEscrow()` | view | uint256 |
 | `maxJobPayout()` | view | uint256 |
 | `moderators(address)` | view | bool |
@@ -65,7 +65,7 @@
 | `validatorVotedJobs(address, uint256)` | view | uint256 |
 | `pause()` | nonpayable | — |
 | `unpause()` | nonpayable | — |
-| `lockConfiguration()` | nonpayable | — |
+| `lockIdentityConfiguration()` | nonpayable | — |
 | `createJob(string _jobSpecURI, uint256 _payout, uint256 _duration, string _details)` | nonpayable | — |
 | `applyForJob(uint256 _jobId, string subdomain, bytes32[] proof)` | nonpayable | — |
 | `requestJobCompletion(uint256 _jobId, string _jobCompletionURI)` | nonpayable | — |
@@ -131,15 +131,16 @@
 | `AGITypeUpdated(address nftAddress, uint256 payoutPercentage)` | indexed address nftAddress, uint256 payoutPercentage |
 | `AGIWithdrawn(address to, uint256 amount, uint256 remainingWithdrawable)` | indexed address to, uint256 amount, uint256 remainingWithdrawable |
 | `AdditionalAgentPayoutPercentageUpdated(uint256 newPercentage)` | uint256 newPercentage |
+| `AgentBlacklisted(address agent, bool status)` | indexed address agent, bool status |
 | `Approval(address owner, address approved, uint256 tokenId)` | indexed address owner, indexed address approved, indexed uint256 tokenId |
 | `ApprovalForAll(address owner, address operator, bool approved)` | indexed address owner, indexed address operator, bool approved |
 | `CompletionReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
-| `ConfigurationLocked(address locker, uint256 atTimestamp)` | indexed address locker, uint256 atTimestamp |
 | `DisputeResolved(uint256 jobId, address resolver, string resolution)` | uint256 jobId, address resolver, string resolution |
 | `DisputeResolvedWithCode(uint256 jobId, address resolver, uint8 resolutionCode, string reason)` | uint256 jobId, address resolver, uint8 resolutionCode, string reason |
 | `DisputeReviewPeriodUpdated(uint256 oldPeriod, uint256 newPeriod)` | uint256 oldPeriod, uint256 newPeriod |
 | `DisputeTimeoutResolved(uint256 jobId, address resolver, bool employerWins)` | uint256 jobId, address resolver, bool employerWins |
 | `EnsRegistryUpdated(address newEnsRegistry)` | indexed address newEnsRegistry |
+| `IdentityConfigurationLocked(address locker, uint256 atTimestamp)` | indexed address locker, uint256 atTimestamp |
 | `JobApplied(uint256 jobId, address agent)` | uint256 jobId, address agent |
 | `JobCancelled(uint256 jobId)` | uint256 jobId |
 | `JobCompleted(uint256 jobId, address agent, uint256 reputationPoints)` | uint256 jobId, address agent, uint256 reputationPoints |
@@ -164,6 +165,7 @@
 | `RootNodesUpdated(bytes32 clubRootNode, bytes32 agentRootNode, bytes32 alphaClubRootNode, bytes32 alphaAgentRootNode)` | bytes32 clubRootNode, bytes32 agentRootNode, bytes32 alphaClubRootNode, bytes32 alphaAgentRootNode |
 | `Transfer(address from, address to, uint256 tokenId)` | indexed address from, indexed address to, indexed uint256 tokenId |
 | `Unpaused(address account)` | address account |
+| `ValidatorBlacklisted(address validator, bool status)` | indexed address validator, bool status |
 
 ## Custom errors
 | Error | Inputs |

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -27,7 +27,7 @@ Provide these addresses via environment variables (see `.env.example`):
 | Alpha agent root node | `AGI_ALPHA_AGENT_ROOT_NODE` | Alpha namespace root (agents). |
 | Validator Merkle root | `AGI_VALIDATOR_MERKLE_ROOT` | Allowlist root for validators. |
 | Agent Merkle root | `AGI_AGENT_MERKLE_ROOT` | Allowlist root for agents. |
-| Optional auto-lock | `LOCK_CONFIG=true` | Locks configuration at the end of migration. |
+| Optional auto-lock | `LOCK_IDENTITY_CONFIG=true` | Locks identity wiring at the end of migration. |
 
 ### Defaults (mainnet)
 
@@ -95,8 +95,8 @@ Merkle roots are **allowlists only**. They grant access to apply/validate but do
 
 After setup and validation, lock configuration to minimize governance:
 
-- **Preferred**: set `LOCK_CONFIG=true` before migration to auto-lock.
-- **Manual**: call `lockConfiguration()` from the owner account.
+- **Preferred**: set `LOCK_IDENTITY_CONFIG=true` before migration to auto-lock.
+- **Manual**: call `lockIdentityConfiguration()` from the owner account.
 
 Once locked, **critical configuration setters** are disabled permanently (see `docs/minimal-governance.md`).
 Critical wiring includes the AGI token address, ENS registry, NameWrapper, and ENS root nodes; each is only mutable pre‑first‑job and pre‑lock.

--- a/docs/identity-lock-and-treasury.md
+++ b/docs/identity-lock-and-treasury.md
@@ -1,0 +1,66 @@
+# Identity lock & treasury pause semantics
+
+This document summarizes the operational trust model for **AGIJobManager** and clarifies how the identity wiring lock and pause state interact with treasury withdrawals and user exits.
+
+## Business-operated marketplace model
+
+AGIJobManager is an operator-run marketplace: the owner retains operational control (pausing, parameter updates, allowlist maintenance, and incident response) while user funds in escrow are protected by on-chain accounting. The contract is intentionally **not** a decentralized governance system; instead, it enforces strong safety invariants around escrow and identity wiring while allowing operational controls for the business operator.
+
+## Escrow protection invariant
+
+- **Escrowed funds are tracked by `lockedEscrow` and are never withdrawable** by the owner.
+- Any attempt to withdraw more than the non-escrow balance reverts with `InsufficientWithdrawableBalance`.
+- Escrow is released only through job settlement flows (completion, cancellation, expiration, dispute resolution).
+
+## Treasury definition (owner-withdrawable during pause)
+
+The treasury is defined as **all AGI held by the contract that is *not* locked in escrow**. This includes:
+
+- Any remainder left after job settlement (rounding dust).
+- Reward-pool contributions (`contributeToRewardPool`).
+- Any direct transfers sent to the contract address.
+
+Treasury withdrawals are **only allowed while paused** via `withdrawAGI`, and never touch escrowed balances.
+
+## Pause semantics (brief withdrawal pause)
+
+Pausing is intended to be a **brief, operator-initiated window** (e.g., to withdraw treasury funds) with minimal user disruption.
+
+### Blocked while paused
+- Job creation and onboarding: `createJob`, `applyForJob`.
+- Validation and disputes: `validateJob`, `disapproveJob`, `disputeJob`.
+- Marketplace entry: `listNFT`, `purchaseNFT`.
+- Reward pool contributions: `contributeToRewardPool`.
+
+### Allowed while paused
+- **Completion submission**: assigned agents can call `requestJobCompletion` for valid, active jobs.
+- **Marketplace exit**: sellers can call `delistNFT` to remove active listings.
+- **Settlement exits**: `cancelJob`, `expireJob`, and `finalizeJob` still operate when their normal predicates are satisfied.
+- **Owner withdrawals**: `withdrawAGI` is available only while paused.
+
+These exceptions ensure users can complete or exit positions even during a brief treasury withdrawal pause.
+
+## Identity wiring lock (not a governance lock)
+
+The **identity wiring lock** permanently freezes only the identity-related wiring and does **not** freeze business operations.
+
+### Frozen by `lockIdentityConfiguration()`
+- `updateAGITokenAddress`
+- `updateEnsRegistry`
+- `updateNameWrapper`
+- `updateRootNodes`
+
+### Not frozen by the identity lock
+- Pausing/unpausing
+- Treasury withdrawals
+- Job settlement or dispute resolution
+- Blacklists and allowlists
+- Economic parameters (thresholds, limits, review periods, payouts)
+- Merkle root updates (`updateMerkleRoots`)
+
+This lock is intended to **freeze identity wiring only**, allowing the operator to keep running the marketplace without being able to rewire identity primitives.
+
+## Additional notes
+
+- `additionalAgentPayoutPercentage` is **reserved for future use**; it is not currently used to modify settlement economics.
+- Reward-pool contributions are treated as **treasury funds** and are owner-withdrawable during pause, subject to the escrow invariant.

--- a/docs/minimal-governance.md
+++ b/docs/minimal-governance.md
@@ -1,18 +1,18 @@
 # Minimal governance model
 
-This document explains the **critical configuration lock** and the intended “configure once → operate” posture.
+This document explains the **identity wiring lock** and the intended “configure once → operate” posture.
 
-## What the configuration lock does
+## What the identity wiring lock does
 
-Calling `lockConfiguration()` permanently disables **critical configuration setters**. It is **one-way** and irreversible.
+Calling `lockIdentityConfiguration()` permanently disables **identity wiring setters**. It is **one-way** and irreversible.
 
-Once locked, the contract keeps operating for normal jobs, escrows, and dispute flows, but the **critical config surface** is frozen.
+Once locked, the contract keeps operating for normal jobs, escrows, and dispute flows, but the **identity wiring surface** is frozen.
 
 ## Functions disabled after lock
 
-These functions are guarded by `whenCriticalConfigurable` and **revert** once the configuration is locked:
+These functions are guarded by `whenIdentityConfigurable` and **revert** once the identity wiring is locked:
 
-**Critical routing / identity**
+**Identity wiring**
 - `updateAGITokenAddress` (only allowed before any job exists and before the lock)
 - `updateEnsRegistry` (only allowed before any job exists and before the lock)
 - `updateNameWrapper` (only allowed before any job exists and before the lock)
@@ -29,7 +29,7 @@ These are considered **break-glass** or operational safety controls and remain a
 - `addModerator()` / `removeModerator()` — optional moderator rotation for continuity.
 - `withdrawAGI()` — surplus withdrawals while paused (escrow is always reserved).
 
-Other configuration knobs (thresholds, review periods, allowlists, metadata, etc.) remain **tunable** after lock because they are not part of the critical configuration surface.
+Other configuration knobs (thresholds, review periods, allowlists, metadata, etc.) remain **tunable** after lock because they are not part of the identity wiring surface.
 
 **Allowlists remain mutable after lock**:
 - `updateMerkleRoots` stays available post-lock so validator/agent allowlists can evolve.
@@ -41,7 +41,7 @@ Other configuration knobs (thresholds, review periods, allowlists, metadata, etc
 1. **Deploy** (set ENS/NameWrapper/token/root nodes and Merkle roots).
 2. **Configure** (thresholds, payouts, metadata, moderators, allowlists).
 3. **Validate** (run sanity checks and real job flow).
-4. **Lock** (`lockConfiguration()` or `LOCK_CONFIG=true` during migration).
+4. **Lock** (`lockIdentityConfiguration()` or `LOCK_IDENTITY_CONFIG=true` during migration).
 5. **Operate** (minimal governance with incident-response tools only).
 
 ## Monitoring suggestions (post-lock)
@@ -49,7 +49,7 @@ Other configuration knobs (thresholds, review periods, allowlists, metadata, etc
 To keep operations low-touch, monitor the following invariants and events:
 
 - **Escrow solvency**: track `lockedEscrow` vs. token balance; `withdrawableAGI()` must stay non‑negative.
-- **Critical wiring changes (pre-lock)**: watch `EnsRegistryUpdated`, `NameWrapperUpdated`, `RootNodesUpdated`, and `ConfigurationLocked`.
+- **Identity wiring changes (pre-lock)**: watch `EnsRegistryUpdated`, `NameWrapperUpdated`, `RootNodesUpdated`, and `IdentityConfigurationLocked`.
 - **Allowlist updates**: `MerkleRootsUpdated` signals validator/agent allowlist changes (access only, not payout logic).
 - **Dispute recovery**: `DisputeTimeoutResolved` indicates break‑glass resolution by the owner.
 

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -260,25 +260,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": true,
-          "internalType": "address",
-          "name": "locker",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "atTimestamp",
-          "type": "uint256"
-        }
-      ],
-      "name": "ConfigurationLocked",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": false,
           "internalType": "uint256",
           "name": "jobId",
@@ -386,6 +367,25 @@
         }
       ],
       "name": "EnsRegistryUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "locker",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "atTimestamp",
+          "type": "uint256"
+        }
+      ],
+      "name": "IdentityConfigurationLocked",
       "type": "event"
     },
     {
@@ -1224,19 +1224,6 @@
     },
     {
       "inputs": [],
-      "name": "configLocked",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
       "name": "contactEmail",
       "outputs": [
         {
@@ -1358,6 +1345,19 @@
         {
           "internalType": "bool",
           "name": "isActive",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lockIdentityConfig",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
           "type": "bool"
         }
       ],
@@ -1787,7 +1787,7 @@
     },
     {
       "inputs": [],
-      "name": "lockConfiguration",
+      "name": "lockIdentityConfiguration",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -82,8 +82,8 @@ module.exports = async function (deployer, network, accounts) {
   );
 
   const manager = await AGIJobManager.deployed();
-  if (isTrue(process.env.LOCK_CONFIG)) {
-    await manager.lockConfiguration({ from: accounts[0] });
+  if (isTrue(process.env.LOCK_IDENTITY_CONFIG) || isTrue(process.env.LOCK_CONFIG)) {
+    await manager.lockIdentityConfiguration({ from: accounts[0] });
   }
 
   console.log("AGIJobManager deployment summary:");
@@ -97,5 +97,5 @@ module.exports = async function (deployer, network, accounts) {
   console.log(`- alpha agent root: ${alphaAgentRootNode}`);
   console.log(`- validator merkle root: ${validatorMerkleRoot}`);
   console.log(`- agent merkle root: ${agentMerkleRoot}`);
-  console.log(`- config locked: ${await manager.configLocked()}`);
+  console.log(`- identity config locked: ${await manager.lockIdentityConfig()}`);
 };

--- a/scripts/postdeploy-config.js
+++ b/scripts/postdeploy-config.js
@@ -209,34 +209,10 @@ module.exports = async function postdeployConfig(callback) {
     const currentApprovals = await instance.requiredValidatorApprovals();
     const currentDisapprovals = await instance.requiredValidatorDisapprovals();
     const maxValidators = await instance.MAX_VALIDATORS_PER_JOB();
-    const configLocked = await instance.configLocked();
+    const identityConfigLocked = await instance.lockIdentityConfig();
 
-    if (configLocked) {
-      const lockedKeys = [
-        "requiredValidatorApprovals",
-        "requiredValidatorDisapprovals",
-        "premiumReputationThreshold",
-        "validationRewardPercentage",
-        "maxJobPayout",
-        "jobDurationLimit",
-        "completionReviewPeriod",
-        "disputeReviewPeriod",
-        "additionalAgentPayoutPercentage",
-        "termsAndConditionsIpfsHash",
-        "contactEmail",
-      "additionalText1",
-      "additionalText2",
-      "additionalText3",
-      "additionalValidators",
-      "additionalAgents",
-      "agiTypes",
-      ];
-      const lockedRequested = lockedKeys.filter((key) => config[key] !== undefined);
-      if (lockedRequested.length) {
-        throw new Error(
-          `Configuration is locked; remove these settings and retry: ${lockedRequested.join(", ")}`
-        );
-      }
+    if (identityConfigLocked) {
+      console.log("Identity wiring is locked; token/ENS/root updates are disabled.");
     }
 
     const ops = [];

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -113,7 +113,7 @@ contract("AGIJobManager admin ops", (accounts) => {
 
     await token.mint(manager.address, surplus, { from: owner });
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
 
     const balanceBefore = await token.balanceOf(owner);
     await expectRevert.unspecified(manager.withdrawAGI(surplus, { from: owner }));
@@ -156,8 +156,8 @@ contract("AGIJobManager admin ops", (accounts) => {
   });
 
   it("locks configuration changes while retaining break-glass controls", async () => {
-    await manager.lockConfiguration({ from: owner });
-    assert.equal(await manager.configLocked(), true, "config should be locked");
+    await manager.lockIdentityConfiguration({ from: owner });
+    assert.equal(await manager.lockIdentityConfig(), true, "config should be locked");
 
     await manager.updateMerkleRoots(clubRoot, agentRoot, { from: owner });
 
@@ -173,7 +173,7 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.pause({ from: owner });
     await manager.unpause({ from: owner });
 
-    await expectCustomError(manager.lockConfiguration.call({ from: owner }), "ConfigLocked");
+    await expectCustomError(manager.lockIdentityConfiguration.call({ from: owner }), "ConfigLocked");
   });
 
   it("updates ENS wiring and root nodes before jobs, then locks them", async () => {
@@ -201,7 +201,7 @@ contract("AGIJobManager admin ops", (accounts) => {
       "InvalidState"
     );
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
     await expectCustomError(manager.updateEnsRegistry.call(ens.address, { from: owner }), "ConfigLocked");
     await expectCustomError(manager.updateNameWrapper.call(nameWrapper.address, { from: owner }), "ConfigLocked");
   });
@@ -222,7 +222,7 @@ contract("AGIJobManager admin ops", (accounts) => {
       "InvalidState"
     );
 
-    await manager.lockConfiguration({ from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
     await expectCustomError(
       manager.updateAGITokenAddress.call(newToken.address, { from: owner }),
       "ConfigLocked"

--- a/test/nftMarketplace.test.js
+++ b/test/nftMarketplace.test.js
@@ -152,12 +152,6 @@ contract("AGIJobManager NFT marketplace", (accounts) => {
     await manager.listNFT(tokenId, price, { from: employer });
 
     await manager.pause({ from: owner });
-    await expectPausedRevert(
-      manager.delistNFT(tokenId, { from: employer }),
-      () => manager.delistNFT.call(tokenId, { from: employer }),
-      owner
-    );
-
     await token.mint(buyer, price, { from: owner });
     await token.approve(manager.address, price, { from: buyer });
     await expectPausedRevert(
@@ -166,7 +160,12 @@ contract("AGIJobManager NFT marketplace", (accounts) => {
       owner
     );
 
+    await manager.delistNFT(tokenId, { from: employer });
+    const delisted = await manager.listings(tokenId);
+    assert.strictEqual(delisted.isActive, false, "listing should deactivate while paused");
+
     await manager.unpause({ from: owner });
+    await manager.listNFT(tokenId, price, { from: employer });
     await manager.purchaseNFT(tokenId, { from: buyer });
 
     const newOwner = await manager.ownerOf(tokenId);

--- a/test/scenarioLifecycle.marketplace.test.js
+++ b/test/scenarioLifecycle.marketplace.test.js
@@ -377,8 +377,7 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
 
     await manager.pause({ from: owner });
-    await expectRevert.unspecified(
-      manager.requestJobCompletion(jobId, "ipfs-paused", { from: agent }));
+    await manager.requestJobCompletion(jobId, "ipfs-paused", { from: agent });
     await expectRevert.unspecified(
       manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA }));
     await expectRevert.unspecified(
@@ -387,7 +386,6 @@ contract("AGIJobManager scenario coverage", (accounts) => {
     await expectRevert.unspecified(manager.contributeToRewardPool(payout, { from: employer }));
 
     await manager.unpause({ from: owner });
-    await manager.requestJobCompletion(jobId, "ipfs-resumed", { from: agent });
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
 


### PR DESCRIPTION
### Motivation
- Allow a short, owner-initiated pause for treasury withdrawals without trapping users by still permitting assigned agents to submit completions and sellers to delist NFTs. 
- Make the “config lock” name explicit about intent: it freezes identity wiring (token/ENS/NameWrapper/root nodes) only, not operational controls. 
- Keep the contract build and CI constraints: no `viaIR`, stay within the EIP‑170 runtime limit, and keep Truffle workflow unchanged. 

### Description
- Pause UX: `requestJobCompletion` is now callable while the contract is paused for assigned, non-expired, non-completed jobs (removed the unconditional `paused()` guard), and `delistNFT` no longer uses `whenNotPaused` so sellers can exit while paused. 
- Identity lock rename: storage `configLocked` → `lockIdentityConfig`; modifier `whenCriticalConfigurable` → `whenIdentityConfigurable`; function `lockConfiguration()` → `lockIdentityConfiguration()`; event `ConfigurationLocked` → `IdentityConfigurationLocked`; all internal references, migrations (`migrations/2_deploy_contracts.js`), postdeploy script, tests, and ABI/docs updated to match. 
- Docs & operator guidance: added `docs/identity-lock-and-treasury.md` and updated `docs/minimal-governance.md`, `docs/deployment-checklist.md`, and README link to describe the identity-wiring-only semantics and pause exceptions. 
- Tests & interface: adjusted and added tests to assert new pause semantics and lock naming, regenerated the interface/ABI export, and kept the API surface minimal (no behavioral changes outside the explicit pause/lock changes). 
- Compiler/config: kept `solc` pinned to `0.8.19`, `viaIR = false`, optimizer enabled with `runs = 50` in `truffle-config.js` to align with pragma and keep runtime bytecode small. 

### Testing
- `npx truffle compile --all` — compiled successfully with `solc 0.8.19` and no lingering compile warnings after final config changes. (Initial experiment with `runs=200` produced a code-size warning and was reverted to `runs=50`.)
- `npx truffle test --network test` — full test suite executed in-process Ganache: all tests passed (213 passing). 
- `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"` — measured runtime deployed bytecode: `24205` bytes (<= 24575 EIP‑170 limit). 
- Notes: `npx truffle test` (default network) failed locally when no external RPC was available (`Couldn't connect to node http://127.0.0.1:8545`), which is an environment issue not related to the changes; CI uses the in-process `test` network and passed.

Commands run (high-level): `npm ci` / `npm ci --force` (dependency bootstrap), `npx truffle version`, `npx truffle compile --all`, `npx truffle test --network test`, `node -e ...` (bytecode size), `node scripts/generate-interface-doc.js`, `npm run ui:abi`. All automated tests/invariants referenced in the PR were executed and succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982baddbc508333accb96c84339077f)