### PR TITLE
Update solc optimizer runs to 200 and refresh docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 
 The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 - Optimizer: enabled
-- `optimizer.runs`: **50** (pinned in `truffle-config.js`)
+- `optimizer.runs`: **200** (pinned in `truffle-config.js`)
 - `viaIR`: **false** by default
 - `metadata.bytecodeHash`: **none**
 - `debug.revertStrings`: **strip**
@@ -206,7 +206,7 @@ npx truffle migrate --network development
 **Optional tuning**
 - Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
 - Provider polling: `RPC_POLLING_INTERVAL_MS`.
-- Compiler settings are pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`).
+- Compiler settings are pinned in `truffle-config.js` (solc `0.8.19`, runs `200`, `evmVersion` `london`).
 - Local chain: `GANACHE_MNEMONIC`.
 
 **Network notes**

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -26,7 +26,7 @@ The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS
 | `SEPOLIA_CONFIRMATIONS` / `MAINNET_CONFIRMATIONS` | Confirmations to wait | Defaults to 2. |
 | `SEPOLIA_TIMEOUT_BLOCKS` / `MAINNET_TIMEOUT_BLOCKS` | Timeout blocks | Defaults to 500. |
 | `RPC_POLLING_INTERVAL_MS` | Provider polling interval | Defaults to 8000 ms. |
-| Compiler settings | Compiler settings | Pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`). |
+| Compiler settings | Compiler settings | Pinned in `truffle-config.js` (solc `0.8.19`, runs `200`, `evmVersion` `london`). |
 | `GANACHE_MNEMONIC` | Local test mnemonic | Defaults to Ganache standard mnemonic if unset. |
 
 A template lives in [`.env.example`](../.env.example).
@@ -42,7 +42,7 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 ```
 
 The mainnet-safe compiler settings used in `truffle-config.js` are:
-- Optimizer enabled with **runs = 50**.
+- Optimizer enabled with **runs = 200**.
 - `viaIR = false` by default.
 - `debug.revertStrings = 'strip'`.
 - `metadata.bytecodeHash = 'none'`.
@@ -109,10 +109,10 @@ npx truffle run verify AGIJobManager --network mainnet
 ```
 
 ### Verification tips
-- Keep the compiler settings from `truffle-config.js` identical to the original deployment (solc `0.8.19`, runs `50`, `evmVersion` `london`).
+- Keep the compiler settings from `truffle-config.js` identical to the original deployment (solc `0.8.19`, runs `200`, `evmVersion` `london`).
 - Ensure your migration constructor parameters match the deployed contract.
 - If the Etherscan plugin fails, re‑run with `--debug` to capture full output.
-- Etherscan’s **Standard-Json-Input** flow should include `viaIR: false`, `optimizer.runs: 50`, and `metadata.bytecodeHash: "none"` if you verify manually.
+- Etherscan’s **Standard-Json-Input** flow should include `viaIR: false`, `optimizer.runs: 200`, and `metadata.bytecodeHash: "none"` if you verify manually.
 
 ## Troubleshooting
 - **Missing RPC URL**: set `SEPOLIA_RPC_URL` or `MAINNET_RPC_URL`, or provide `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN` / `INFURA_KEY`.

--- a/docs/bytecode-and-getters.md
+++ b/docs/bytecode-and-getters.md
@@ -36,7 +36,7 @@ When a job completes on an **agent win**, validator rewards are paid **only to a
 
 - **Solidity version:** pinned to `0.8.19` in `truffle-config.js` to avoid the OpenZeppelin *memory-safe-assembly* deprecation warnings emitted by newer compilers.
 - **OpenZeppelin contracts:** kept at `@openzeppelin/contracts@4.9.6` (same major version).
-- **Optimizer:** enabled with **runs = 50** to balance deploy size and runtime gas (viaIR stays off).
+- **Optimizer:** enabled with **runs = 200** to balance deploy size and runtime gas (viaIR stays off).
 
 If you change compiler settings for a new deployment, keep the version and optimizer runs consistent for reproducible verification.
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -116,12 +116,12 @@ Everything else remains operable but should be governed by your ops policy to ke
 ## 7) Verification (Etherscan)
 
 **Normal path (viaIR disabled)**:
-1. Compile with the pinned compiler settings (solc `0.8.19`, runs `50`).
+1. Compile with the pinned compiler settings (solc `0.8.19`, runs `200`).
 2. Verify using `truffle-plugin-verify` with the same compiler settings and constructor args.
 
 **Fallback (Standard JSON input)**:
 1. Compile with the same optimizer/metadata settings.
 2. In Etherscan, select **Solidity (Standard-Json-Input)** and paste the JSON from the build step.
-3. Ensure the JSON includes `viaIR: false`, `optimizer.runs: 50`, `metadata.bytecodeHash: "none"`, and the exact constructor args.
+3. Ensure the JSON includes `viaIR: false`, `optimizer.runs: 200`, `metadata.bytecodeHash: "none"`, and the exact constructor args.
 
 > To reproduce Standard JSON input deterministically, keep compiler settings pinned in `truffle-config.js` and rebuild before verification.

--- a/truffle-config.js
+++ b/truffle-config.js
@@ -50,7 +50,7 @@ const timeoutBlocksMainnet = n(process.env.MAINNET_TIMEOUT_BLOCKS, 500);
 const timeoutBlocksSepolia = n(process.env.SEPOLIA_TIMEOUT_BLOCKS, 500);
 
 const solcVersion = '0.8.19';
-const solcRuns = 50;
+const solcRuns = 200;
 const solcViaIR = false;
 const evmVersion = (process.env.SOLC_EVM_VERSION || 'london').trim();
 


### PR DESCRIPTION
### Motivation
- Keep compiler settings aligned with contract pragma and deployment guidance while avoiding viaIR and OZ memory-safe-assembly warnings by pinning the solc toolchain and optimizer settings. 
- Reduce risk of runtime bytecode regressions by choosing optimizer runs that balance deployed size and runtime gas while keeping the EIP‑170 safety guard green.

### Description
- Pin optimizer runs to `200` in `truffle-config.js` while keeping `solc` at `0.8.19` and `viaIR` disabled. 
- Update documentation and README references to reflect the new optimizer runs (`200`) and the same compiler choice for reproducible verification. 
- No contract source changes were made to `contracts/AGIJobManager.sol`; this PR is limited to build configuration and docs updates only.

### Testing
- Ran `npx truffle compile` successfully (uses `solc 0.8.19`), and verified artifacts were up to date. 
- Ran the test suite with `npx truffle test --network test`, which completed successfully (`213 passing`). 
- Measured deployed/runtime bytecode via `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"` and confirmed size `24,205` bytes which is <= the safety gate `24,575` bytes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6982c5733b7083338f21830fe61e485d)