### PR TITLE
docs: add mainnet deployment & security overview and align docs with Truffle config

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.19` in `truffle-config.js`. `viaIR` remains **disabled**; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled**; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
 
 ## Contract documentation
 
@@ -126,6 +126,8 @@ Detailed contract documentation lives in `docs/`:
 - [AGIJobManager operator guide](docs/AGIJobManager_Operator_Guide.md)
 - [AGIJobManager security considerations](docs/AGIJobManager_Security.md)
 - [Identity lock & treasury pause semantics](docs/identity-lock-and-treasury.md)
+- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
+- [Security policy](SECURITY.md)
 
 ## Mainnet bytecode size (EIP-170)
 
@@ -141,7 +143,7 @@ The mainnet deployment settings that keep `AGIJobManager` under the limit are:
 - `viaIR`: **false** by default
 - `metadata.bytecodeHash`: **none**
 - `debug.revertStrings`: **strip**
-- `solc` version: **0.8.19** (pinned in `truffle-config.js`)
+- `solc` version: **0.8.23** (pinned in `truffle-config.js`)
 - `evmVersion`: **london** (or the target chain default)
 
 To check runtime sizes locally after compilation:
@@ -207,7 +209,7 @@ npx truffle migrate --network development
 - Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
 - Provider polling: `RPC_POLLING_INTERVAL_MS`.
 - EVM version override: `SOLC_EVM_VERSION` (defaults to `london`).
-- Compiler settings are pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`).
+- Compiler settings are pinned in `truffle-config.js` (solc `0.8.23`, runs `50`, `evmVersion` `london`).
 - Local chain: `GANACHE_MNEMONIC`.
 
 **Network notes**

--- a/docs/Deployment.md
+++ b/docs/Deployment.md
@@ -27,12 +27,12 @@ The configuration supports both direct RPC URLs and provider keys. `PRIVATE_KEYS
 | `SEPOLIA_TIMEOUT_BLOCKS` / `MAINNET_TIMEOUT_BLOCKS` | Timeout blocks | Defaults to 500. |
 | `RPC_POLLING_INTERVAL_MS` | Provider polling interval | Defaults to 8000 ms. |
 | `SOLC_EVM_VERSION` | EVM version override | Defaults to `london` when unset. |
-| Compiler settings | Compiler settings | Pinned in `truffle-config.js` (solc `0.8.19`, runs `50`, `evmVersion` `london`). |
+| Compiler settings | Compiler settings | Pinned in `truffle-config.js` (solc `0.8.23`, runs `50`, `evmVersion` `london`). |
 | `GANACHE_MNEMONIC` | Local test mnemonic | Defaults to Ganache standard mnemonic if unset. |
 
 A template lives in [`.env.example`](../.env.example).
 
-> **Compiler note**: `AGIJobManager.sol` uses `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.19` in `truffle-config.js`. For reproducible verification, keep the solc version and optimizer runs consistent with the original deployment.
+> **Compiler note**: `AGIJobManager.sol` uses `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. For reproducible verification, keep the solc version and optimizer runs consistent with the original deployment.
 
 ## Runtime bytecode size (EIP-170)
 
@@ -110,7 +110,7 @@ npx truffle run verify AGIJobManager --network mainnet
 ```
 
 ### Verification tips
-- Keep the compiler settings from `truffle-config.js` identical to the original deployment (solc `0.8.19`, runs `50`, `evmVersion` `london`).
+- Keep the compiler settings from `truffle-config.js` identical to the original deployment (solc `0.8.23`, runs `50`, `evmVersion` `london`).
 - Ensure your migration constructor parameters match the deployed contract.
 - If the Etherscan plugin fails, re‑run with `--debug` to capture full output.
 - Etherscan’s **Standard-Json-Input** flow should include `viaIR: false`, `optimizer.runs: 50`, and `metadata.bytecodeHash: "none"` if you verify manually.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,6 +3,7 @@
 This documentation set targets engineers, integrators, operators, auditors, and non‑technical stakeholders. Each document has a focused scope with cross‑references for fast navigation and auditability.
 
 ## Core entry points (engineers & auditors)
+- **Mainnet deployment & security overview**: [`mainnet-deployment-and-security-overview.md`](mainnet-deployment-and-security-overview.md)
 - **Contract specification**: [`AGIJobManager.md`](AGIJobManager.md)
 - **Deployment guide (Truffle)**: [`Deployment.md`](Deployment.md)
 - **Security model and limitations**: [`Security.md`](Security.md)

--- a/docs/bytecode-and-getters.md
+++ b/docs/bytecode-and-getters.md
@@ -34,7 +34,7 @@ When a job completes on an **agent win**, validator rewards are paid **only to a
 
 ## Compiler settings and warning cleanup
 
-- **Solidity version:** pinned to `0.8.19` in `truffle-config.js` to avoid the OpenZeppelin *memory-safe-assembly* deprecation warnings emitted by newer compilers.
+- **Solidity version:** pinned to `0.8.23` in `truffle-config.js` (contract pragma is `^0.8.19`).
 - **OpenZeppelin contracts:** kept at `@openzeppelin/contracts@4.9.6` (same major version).
 - **Optimizer:** enabled with **runs = 50** to balance deploy size and runtime gas (viaIR stays off).
 

--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -116,7 +116,7 @@ Everything else remains operable but should be governed by your ops policy to ke
 ## 7) Verification (Etherscan)
 
 **Normal path (viaIR disabled)**:
-1. Compile with the pinned compiler settings (solc `0.8.19`, runs `50`).
+1. Compile with the pinned compiler settings (solc `0.8.23`, runs `50`).
 2. Verify using `truffle-plugin-verify` with the same compiler settings and constructor args.
 
 **Fallback (Standard JSON input)**:

--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -1,0 +1,204 @@
+# AGIJobManager – Mainnet Deployment & Security Overview
+
+## Executive summary
+AGIJobManager is an **owner‑operated** on‑chain escrow and settlement contract for employer/agent jobs with validator approvals, dispute resolution, reputation tracking, and a tightly scoped NFT marketplace for job completions. It is **not** a trustless or DAO‑governed protocol. Instead, it enforces strict escrow accounting and identity gating while keeping operational controls with the owner and moderators. All statements below reflect the current on‑chain implementation and Truffle configuration.
+
+## Trust model (owner‑operated, not trustless)
+AGIJobManager is a centralized operational system with strong on‑chain safety invariants. Users rely on:
+- **Owner integrity** for parameter tuning, allowlist/blacklist management, and operational incident response.
+- **Moderator integrity** for dispute resolution outcomes.
+- **Escrow accounting** enforced by `lockedEscrow` and `withdrawableAGI()` to prevent owner withdrawal of unsettled job funds.
+
+This is an **owner‑controlled** business system with enforceable escrow guarantees, not a decentralized court or DAO.
+
+## Owner privileges (key controls)
+The owner can:
+- **Pause/unpause** operations (`pause`, `unpause`).
+- **Update allowlists/blacklists** (Merkle roots, explicit blacklists).
+- **Tune parameters** (validator thresholds, payout bounds, review periods, max payout, duration limit).
+- **Manage moderators** (add/remove).
+- **Resolve stale disputes** only while paused (`resolveStaleDispute`).
+- **Delist jobs** that are still unassigned (`delistJob`) and refund escrow.
+- **Withdraw treasury AGI** while paused (`withdrawAGI`).
+
+Moderators (not owner) resolve disputes via `resolveDispute` / `resolveDisputeWithCode`.
+
+## Identity wiring lock
+The contract exposes a one‑way identity configuration lock (`lockIdentityConfiguration`). This lock:
+
+### Frozen by the lock
+Once `lockIdentityConfiguration()` is called, the following **cannot** be updated:
+- `updateAGITokenAddress`
+- `updateEnsRegistry`
+- `updateNameWrapper`
+- `updateRootNodes`
+
+Additionally, these identity updates require **no jobs to exist** (`nextJobId == 0`) and **no escrowed funds** (`lockedEscrow == 0`), even before the lock is set.
+
+### Not frozen by the lock
+The lock **does not** restrict:
+- Operations controls (pause/unpause, blacklists, parameter tuning)
+- Treasury withdrawals (`withdrawAGI`)
+- Job settlement flows
+- **Merkle root updates** (`updateMerkleRoots` remains allowed)
+
+The lock is designed to freeze identity wiring only; it is **not** a governance lock.
+
+## Pause semantics (what is blocked vs allowed)
+Pause is an incident‑response control intended to halt new activity without trapping exits. The exact behavior is:
+
+### Blocked while paused
+| Category | Functions |
+| --- | --- |
+| Job creation/onboarding | `createJob`, `applyForJob` |
+| Validation & new disputes | `validateJob`, `disapproveJob`, `disputeJob` |
+| Marketplace entry | `listNFT`, `purchaseNFT` |
+| Reward pool funding | `contributeToRewardPool` |
+
+### Allowed while paused
+| Category | Functions |
+| --- | --- |
+| Completion request | `requestJobCompletion` (assigned agent only) |
+| Settlement & exits | `cancelJob`, `expireJob`, `finalizeJob`, `resolveDispute`, `resolveDisputeWithCode` |
+| Stale dispute recovery | `resolveStaleDispute` (owner‑only, paused‑only) |
+| Marketplace exit | `delistNFT` |
+| Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
+
+This ensures pause does not trap existing jobs or listings.
+
+## Treasury vs escrow (withdrawal rules)
+- **Escrowed funds**: tracked in `lockedEscrow` and reserved for unsettled job payouts.
+- **Treasury**: the contract’s AGI balance **minus** `lockedEscrow`.
+
+### `withdrawableAGI()` invariant
+`withdrawableAGI()` returns `balance - lockedEscrow` and **reverts** if the balance is below `lockedEscrow` (insolvent escrow is not allowed).
+
+### Sources of treasury funds
+Treasury can grow from:
+- **Remainders** after settlement when agent + validators receive less than 100%.
+- **Rounding dust** from payout calculations.
+- **Reward pool contributions** (`contributeToRewardPool`) — currently **not segregated**, so they become treasury.
+- **Direct transfers** to the contract.
+
+### Owner withdrawal constraints
+- `withdrawAGI` is **owner‑only** and **paused‑only**.
+- The owner can **never** withdraw escrowed funds.
+- To “sunset” the contract and withdraw all remaining AGI: all jobs must be fully settled so `lockedEscrow == 0`.
+
+## Reputation system (as implemented)
+Reputation growth uses a diminishing‑returns formula with a hard cap.
+
+### Agent reputation points
+When a job completes:
+- `scaledPayout = job.payout / 1e18`
+- `payoutPoints = (scaledPayout^3) / 1e5`
+- `reputationPoints = log2(1 + payoutPoints * 1e6) + (completionTime / 10000)`
+
+### Diminishing returns & cap
+For each update:
+- `newReputation = current + reputationPoints`
+- `diminishingFactor = 1 + (newReputation^2 / 88888^2)`
+- `diminished = newReputation / diminishingFactor`
+- Final reputation is `min(diminished, 88888)`.
+
+### Validator reputation
+Only **approving validators** are paid and gain reputation. Each approving validator receives:
+- `validatorPayout = totalValidatorPayout / approverCount`
+- `validatorReputationGain = reputationPoints * validationRewardPercentage / 100`
+
+Disapprovers do not receive payouts or reputation.
+
+## Mainnet deployment constraints
+### EIP‑170 bytecode cap
+Ethereum mainnet enforces a **24,576‑byte** runtime bytecode limit (EIP‑170). The repository includes a test guard that asserts deployed bytecode remains within the configured safety margin.
+
+### How to check deployed bytecode size
+After `truffle compile`, check the runtime bytecode length:
+```bash
+node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
+```
+
+### Compiler and optimizer pinning (Truffle)
+- **Solidity compiler**: `0.8.23` (pinned in `truffle-config.js`).
+- **Optimizer**: enabled with `runs = 50`.
+- **viaIR**: **disabled** (`viaIR: false`).
+- **Metadata bytecode hash**: `none`.
+- **Revert strings**: `strip`.
+- **EVM version**: `london` (default unless overridden).
+
+These settings are critical to keep bytecode within the EIP‑170 cap and to ensure deterministic verification.
+
+## Build & verification (Truffle)
+### Deterministic build & test
+```bash
+npm ci
+npx truffle compile
+npx truffle test --network test
+```
+
+### Deployment (Truffle migrations)
+The deployment entrypoint is `migrations/2_deploy_contracts.js`, which reads constructor wiring from `migrations/deploy-config.js` and environment variables. For mainnet‑grade deployments:
+```bash
+npx truffle migrate --network mainnet
+```
+
+### Constructor arguments (AGIJobManager)
+The constructor accepts:
+1. `agiTokenAddress` (ERC‑20 used for escrow/payouts)
+2. `baseIpfs` (base URI used when completion metadata lacks a scheme)
+3. `ensConfig[0]` = ENS registry address
+4. `ensConfig[1]` = NameWrapper address
+5. `rootNodes[0]` = clubRootNode
+6. `rootNodes[1]` = agentRootNode
+7. `rootNodes[2]` = alphaClubRootNode
+8. `rootNodes[3]` = alphaAgentRootNode
+9. `merkleRoots[0]` = validatorMerkleRoot
+10. `merkleRoots[1]` = agentMerkleRoot
+
+### Verification
+`truffle-plugin-verify` is configured in `truffle-config.js`. With `ETHERSCAN_API_KEY` set:
+```bash
+npx truffle run verify AGIJobManager --network mainnet
+```
+If you prefer Etherscan’s UI, use the Standard JSON Input with the same compiler settings above.
+
+## Roles & permissions (summary)
+| Role | Capabilities |
+| --- | --- |
+| Owner | Pause/unpause, parameter tuning, allowlists/blacklists, moderator management, `withdrawAGI`, `delistJob` |
+| Moderator | Resolve disputes (`resolveDispute`, `resolveDisputeWithCode`) |
+| Employer | Create jobs, cancel pre‑assignment, dispute, receive completion NFTs |
+| Agent | Apply for jobs, request completion, receive payouts & reputation |
+| Validator | Approve/disapprove completion (if allowlisted), receive payouts & reputation on approval |
+
+## Known limitations / non‑economic notes
+- `additionalAgentPayoutPercentage` is currently **unused** in settlement logic (reserved for future use).
+- `contributeToRewardPool` **does not segregate funds**; contributions are treasury and owner‑withdrawable during pause.
+- ENS/NameWrapper gating depends on external contracts; resolver lookups or wrapper ownership checks may fail if ENS configuration is incomplete or inconsistent.
+
+## Sunsetting / migration runbook (operator guidance)
+A safe wind‑down path:
+1. **Pause** the contract to stop new activity.
+2. Allow agents to **request completion** and validators/moderators to **settle disputes**.
+3. Let **cancel/expire/finalize** paths clear all active jobs.
+4. Verify `lockedEscrow == 0`.
+5. **Withdraw** remaining treasury funds with `withdrawAGI`.
+6. Deploy a v2 if needed and migrate off‑chain coordination.
+
+## Testing status (local)
+Commands executed and results:
+- `npm ci` → **failed** on Linux because `fsevents@2.3.2` is macOS‑only (EBADPLATFORM).
+- `npm install --omit=optional` → **succeeded** (used to proceed with Truffle).
+- `npx truffle version` → **succeeded**.
+- `npx truffle compile` → **succeeded** (no compiler warnings emitted).
+- `npx truffle test` → **failed** (no local node at `http://127.0.0.1:8545`).
+- `npx truffle test --network test` → **succeeded** (216 passing).
+
+If CI requires a default `development` network, start Ganache on `127.0.0.1:8545` or set `--network test` explicitly.
+
+## Glossary (selected)
+- **Escrow**: AGI reserved for unsettled jobs (`lockedEscrow`).
+- **Treasury**: AGI balance minus `lockedEscrow` (owner‑withdrawable only while paused).
+- **Identity lock**: one‑way freeze of ENS/token/root‑node wiring.
+- **Pause**: operator safety switch that blocks new activity but allows exits.
+- **Completion request**: agent‑submitted metadata required before settlement or NFT minting.


### PR DESCRIPTION
### Motivation
- Provide a single, auditable repo-native overview that explains the trust model, pause/identity wiring semantics, treasury vs escrow rules, reputation math, and mainnet deployment constraints.
- Ensure documentation matches the actual `AGIJobManager.sol` behavior and the repository Truffle config to avoid mismatches during verification and operator onboarding.

### Description
- Added `docs/mainnet-deployment-and-security-overview.md` containing an executive summary, trust model, owner privileges, identity wiring lock details, exact pause matrix, treasury vs escrow rules, reputation formulas, EIP-170 guidance, Truffle-based deployment/verification advice, and a sunsetting runbook.
- Updated documentation index and top-level README to link the new overview and the security policy by adding entries to `docs/README.md` and `README.md`.
- Corrected compiler/version references in `README.md`, `docs/Deployment.md`, `docs/bytecode-and-getters.md`, and `docs/deployment-checklist.md` to reflect the actual `truffle-config.js` pin of `solc = 0.8.23`, `optimizer.runs = 50`, and `viaIR = false` while noting the contract pragma is `^0.8.19`.
- Kept all behavioral claims accurate to code: documented that `lockIdentityConfiguration()` freezes `updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, and `updateRootNodes` while `updateMerkleRoots` remains mutable; documented pause modifiers and that `requestJobCompletion` and `delistNFT` are allowed while paused and `withdrawAGI` is owner-only and requires pause; documented `withdrawableAGI()` invariants and `lockedEscrow` semantics.

### Testing
- Commands run: `npm ci` (failed on Linux: `EBADPLATFORM` for `fsevents@2.3.2`), `npm install --omit=optional` (succeeded), `npx truffle version` (succeeded), `npx truffle compile` (succeeded), `npx truffle test` (failed to connect to `http://127.0.0.1:8545`), and `npx truffle test --network test` (succeeded: `216 passing`).
- Notes on test results: the repo test-suite passes when using the built-in `test` network (`--network test`) where the in-process Ganache provider is used; the default `npx truffle test` expects a `development` node at `127.0.0.1:8545` and will fail if none is running.
- Minimal next fixes: for CI, either start Ganache on `127.0.0.1:8545` before running `npx truffle test` or ensure CI runs `npx truffle test --network test`; to avoid `npm ci` EBADPLATFORM on Linux, run `npm install --omit=optional` or remove optional macOS-only deps in CI install step.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983681577bc83339960fff8b02c11fb)