### PR TITLE
Docs: clarify bytecode size checks and docs links

### DIFF
--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 
 Start here:
 - [`docs/README.md`](docs/README.md)
+- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
+- [Security policy](SECURITY.md)
 - **Non‑technical user guides**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
 - [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
 - [`docs/ParameterSafety.md`](docs/ParameterSafety.md)

--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -110,12 +110,16 @@ Disapprovers do not receive payouts or reputation.
 
 ## Mainnet deployment constraints
 ### EIP‑170 bytecode cap
-Ethereum mainnet enforces a **24,576‑byte** runtime bytecode limit (EIP‑170). The repository includes a test guard that asserts deployed bytecode remains within the configured safety margin.
+Ethereum mainnet enforces a **24,576‑byte** runtime bytecode limit (EIP‑170). The repository includes a test guard that asserts deployed bytecode remains within the configured safety margin (currently **24,575 bytes**, see `scripts/check-bytecode-size.js` and the “Bytecode size guard” test).
 
 ### How to check deployed bytecode size
 After `truffle compile`, check the runtime bytecode length:
 ```bash
 node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
+```
+Or run the helper:
+```bash
+node scripts/check-bytecode-size.js
 ```
 
 ### Compiler and optimizer pinning (Truffle)


### PR DESCRIPTION
### Motivation
- Clarify mainnet‑grade deployment guidance so operators can reliably check the EIP‑170 runtime bytecode cap and follow Truffle‑based verification steps. 
- Surface high‑value docs links in the repository entrypoint to make the security and mainnet guidance easier to find. 

### Description
- Updated `docs/mainnet-deployment-and-security-overview.md` to document the repository's bytecode safety margin (currently **24,575 bytes**) and to point to the helper `node scripts/check-bytecode-size.js`. 
- Added direct links to the mainnet overview and `SECURITY.md` in the `README.md` docs index for easier navigation. 
- While preparing the doc changes the contract and Truffle wiring were re‑checked and the docs were aligned to code behavior (e.g., `lockIdentityConfiguration` semantics, `updateMerkleRoots` remains updatable, `requestJobCompletion` and `delistNFT` are allowed while paused, and `withdrawAGI` is owner‑only and requires pause). 

### Testing
- Commands run: `npm ci` (failed: `EBADPLATFORM` for `fsevents` on Linux), `npm install --omit=optional` (succeeded), `npx truffle version` (succeeded), `npx truffle compile` (succeeded using `solc 0.8.23`), `npx truffle test` (failed: connection error to `http://127.0.0.1:8545`), and `npx truffle test --network test` (succeeded; `216 passing`).
- Noted failures and minimal next fixes: `npm ci` fails on Linux due to an optional macOS‑only dependency — use `npm install --omit=optional` in CI or pin dependencies; `npx truffle test` against `development` fails when no local node is running — either start Ganache on `127.0.0.1:8545` or run tests with `--network test` (the repo's `test` network uses an in‑process Ganache provider and passed).
- Discovered doc/code mismatches and resolution: `AGIJobManager.sol` uses `pragma ^0.8.19` while `truffle-config.js` pins `solc` to `0.8.23`; this was already documented in the README and the docs were not changed to the code — instead documentation records the Truffle pin and the repo's deterministic build settings (optimizer runs = 50, `viaIR = false`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983716614a08333ba2726636daab309)