### PR TITLE
docs: clarify mainnet deployment, pause/withdrawal, and identity lock

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@
 - **Not a generalized NFT marketplace**: listings are only for job NFTs minted by this contract.
 - **Not a decentralized court or DAO**: moderators and the owner have significant authority; there is no slashing or permissionless validator set.
 
+## Documentation
+- [Mainnet deployment & security overview (canonical)](docs/mainnet-deployment-and-security-overview.md)
+
+### Important trust notes (read before mainnet use)
+- **Owner-operated**: the owner can pause/unpause, tune parameters, manage allowlists/blacklists, and delist unassigned jobs.
+- **Escrow invariant**: the owner can only withdraw **treasury** AGI (`balance - lockedEscrow`) and only while paused.
+- **Pause semantics**: new activity is blocked while paused, but completion requests, delists, and settlement/exit paths remain available when eligible.
+- **Identity wiring lock**: `lockIdentityConfiguration` permanently freezes the token/ENS/namewrapper/root-node wiring while leaving ops controls intact.
+
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
 **ERC‑8004** standardizes *trust signals* (identity, reputation, validation outcomes) for off-chain publication and indexing. **AGIJobManager** enforces *settlement* (escrow, payouts, dispute resolution, reputation updates) on-chain.
@@ -223,7 +232,7 @@ npx truffle migrate --network development
 
 ## Security considerations
 
-- **Centralization risk**: the owner can change critical parameters and withdraw escrowed ERC‑20; moderators can resolve disputes.
+- **Centralization risk**: the owner can change critical parameters and withdraw only surplus AGI (balance minus `lockedEscrow`) while paused; moderators can resolve disputes.
 - **Eligibility gating**: ENS registry/NameWrapper/root nodes are intended to be configured before any job exists and then locked; Merkle roots remain configurable for allowlist updates.
 - **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
 - **Marketplace reentrancy guard**: `purchaseNFT` is protected by `nonReentrant` because it crosses an external ERC‑20 `transferFrom` boundary; removing this protection requires a redeploy even though the ABI is unchanged.

--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -62,6 +62,7 @@ Pause is an incident‑response control intended to halt new activity without tr
 | Settlement & exits | `cancelJob`, `expireJob`, `finalizeJob`, `resolveDispute`, `resolveDisputeWithCode` |
 | Stale dispute recovery | `resolveStaleDispute` (owner‑only, paused‑only) |
 | Marketplace exit | `delistNFT` |
+| Owner job delist | `delistJob` (owner‑only, unassigned jobs only) |
 | Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
 
 This ensures pause does not trap existing jobs or listings.
@@ -178,6 +179,7 @@ If you prefer Etherscan’s UI, use the Standard JSON Input with the same compil
 ## Known limitations / non‑economic notes
 - `additionalAgentPayoutPercentage` is currently **unused** in settlement logic (reserved for future use).
 - `contributeToRewardPool` **does not segregate funds**; contributions are treasury and owner‑withdrawable during pause.
+- The contract has **no generic token rescue** function; non‑AGI assets sent to the contract are not recoverable via the ABI.
 - ENS/NameWrapper gating depends on external contracts; resolver lookups or wrapper ownership checks may fail if ENS configuration is incomplete or inconsistent.
 
 ## Sunsetting / migration runbook (operator guidance)
@@ -192,7 +194,7 @@ A safe wind‑down path:
 ## Testing status (local)
 Commands executed and results:
 - `npm ci` → **failed** on Linux because `fsevents@2.3.2` is macOS‑only (EBADPLATFORM).
-- `npm install --omit=optional` → **succeeded** (used to proceed with Truffle).
+- `npm install` → **succeeded** (used to proceed with Truffle after `npm ci` failed).
 - `npx truffle version` → **succeeded**.
 - `npx truffle compile` → **succeeded** (no compiler warnings emitted).
 - `npx truffle test` → **failed** (no local node at `http://127.0.0.1:8545`).


### PR DESCRIPTION
### Motivation
- Ensure the repository documentation truthfully reflects on-chain behavior and the Truffle build configuration used for mainnet releases, removing ambiguous or incorrect claims. 
- Make the README a clear canonical entrypoint and capture operational safety notes (pause, treasury vs escrow, identity lock) so operators understand limits before deploying.

### Description
- Added a canonical link to `docs/mainnet-deployment-and-security-overview.md` and a concise “Important trust notes” summary in `README.md`. 
- Updated `docs/mainnet-deployment-and-security-overview.md` to explicitly list `delistJob` as an owner-only delist allowed while paused, to document that there is no generic token rescue ABI (non-AGI tokens are not recoverable), and to correct the owner-withdrawal wording to reflect the `withdrawableAGI()` invariant (`balance - lockedEscrow`).
- Clarified that `lockIdentityConfiguration()` freezes token/ENS/NameWrapper/root-node wiring while leaving Merkle roots and operational controls editable, and reiterated the recommended deploy→configure→lock→operate sequence. 
- Files changed: `README.md`, `docs/mainnet-deployment-and-security-overview.md`.

### Testing
- Ran `npm ci` which failed on Linux due to a macOS-only optional dependency (`fsevents@2.3.2`, EBADPLATFORM). 
- Ran `npm install` which succeeded and allowed further steps. 
- Verified toolchain: `npx truffle version` succeeded and shows `Solidity - 0.8.23 (solc-js)`, and `npx truffle compile` succeeded with artifacts written and no compiler warnings. 
- Test runs: `npx truffle test` (default) failed because no node is listening at `http://127.0.0.1:8545`; `npx truffle test --network test` (in-process Ganache provider) succeeded with `216 passing` tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837afadd748333aaceaebc95aab598)