### PR TITLE
Update mainnet deployment & trust docs; add README trust notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,15 @@
 - **Not a generalized NFT marketplace**: listings are only for job NFTs minted by this contract.
 - **Not a decentralized court or DAO**: moderators and the owner have significant authority; there is no slashing or permissionless validator set.
 
+## Important trust notes
+- **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
+- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`) and only while paused; escrowed funds are not withdrawable.
+- **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available; NFT sellers can still delist.
+- **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
+
+## Documentation (mainnet)
+Start with the canonical deployment/security overview: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md).
+
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
 **ERC‑8004** standardizes *trust signals* (identity, reputation, validation outcomes) for off-chain publication and indexing. **AGIJobManager** enforces *settlement* (escrow, payouts, dispute resolution, reputation updates) on-chain.
@@ -223,7 +232,7 @@ npx truffle migrate --network development
 
 ## Security considerations
 
-- **Centralization risk**: the owner can change critical parameters and withdraw escrowed ERC‑20; moderators can resolve disputes.
+- **Centralization risk**: the owner can change critical parameters and withdraw surplus AGI (balance minus `lockedEscrow`) while paused; moderators can resolve disputes.
 - **Eligibility gating**: ENS registry/NameWrapper/root nodes are intended to be configured before any job exists and then locked; Merkle roots remain configurable for allowlist updates.
 - **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
 - **Marketplace reentrancy guard**: `purchaseNFT` is protected by `nonReentrant` because it crosses an external ERC‑20 `transferFrom` boundary; removing this protection requires a redeploy even though the ABI is unchanged.

--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -1,57 +1,53 @@
 # AGIJobManager – Mainnet Deployment & Security Overview
 
-## Executive summary
-AGIJobManager is an **owner‑operated** on‑chain escrow and settlement contract for employer/agent jobs with validator approvals, dispute resolution, reputation tracking, and a tightly scoped NFT marketplace for job completions. It is **not** a trustless or DAO‑governed protocol. Instead, it enforces strict escrow accounting and identity gating while keeping operational controls with the owner and moderators. All statements below reflect the current on‑chain implementation and Truffle configuration.
+## What this contract is
+AGIJobManager is an **owner-operated** on-chain escrow and settlement contract for employer/agent jobs with validator approvals, dispute resolution, reputation tracking, and a tightly scoped ERC-721 job NFT marketplace. It is not a trustless protocol or DAO; the owner and moderators retain operational control while the contract enforces escrow and settlement invariants.
 
-## Trust model (owner‑operated, not trustless)
-AGIJobManager is a centralized operational system with strong on‑chain safety invariants. Users rely on:
-- **Owner integrity** for parameter tuning, allowlist/blacklist management, and operational incident response.
-- **Moderator integrity** for dispute resolution outcomes.
-- **Escrow accounting** enforced by `lockedEscrow` and `withdrawableAGI()` to prevent owner withdrawal of unsettled job funds.
+**Roles**
+- **Owner**: operational control (pause/unpause, parameter tuning, allowlists/blacklists, moderator management, treasury withdrawal while paused).
+- **Moderator**: dispute resolution authority.
+- **Employer**: creates jobs, funds escrow, cancels unassigned jobs, disputes.
+- **Agent**: applies for jobs, requests completion, earns payout + reputation, receives completion NFT.
+- **Validator**: approves/disapproves completion, earns payout + reputation on approval.
 
-This is an **owner‑controlled** business system with enforceable escrow guarantees, not a decentralized court or DAO.
+## Trust model (owner-operated marketplace)
+AGIJobManager is a centralized operational system with on-chain escrow guarantees. Users must trust:
+- **Owner integrity** to pause/unpause appropriately, tune parameters, maintain allowlists/blacklists, and operate within documented withdrawal bounds.
+- **Moderator integrity** to resolve disputes fairly.
+- **Escrow accounting** to prevent owner withdrawal of unsettled funds via `lockedEscrow` and `withdrawableAGI()` invariants.
 
-## Owner privileges (key controls)
-The owner can:
-- **Pause/unpause** operations (`pause`, `unpause`).
-- **Update allowlists/blacklists** (Merkle roots, explicit blacklists).
-- **Tune parameters** (validator thresholds, payout bounds, review periods, max payout, duration limit).
-- **Manage moderators** (add/remove).
-- **Resolve stale disputes** only while paused (`resolveStaleDispute`).
-- **Delist jobs** that are still unassigned (`delistJob`) and refund escrow.
-- **Withdraw treasury AGI** while paused (`withdrawAGI`).
+This is an owner-operated marketplace with enforced escrow, not a decentralized court or DAO.
 
-Moderators (not owner) resolve disputes via `resolveDispute` / `resolveDisputeWithCode`.
-
-## Identity wiring lock
-The contract exposes a one‑way identity configuration lock (`lockIdentityConfiguration`). This lock:
+## Identity wiring lock (`lockIdentityConfig`)
+The contract exposes a one-way identity configuration lock, gated by `lockIdentityConfiguration()` and the `lockIdentityConfig` flag. It is intended to freeze identity wiring after initial setup.
 
 ### Frozen by the lock
 Once `lockIdentityConfiguration()` is called, the following **cannot** be updated:
-- `updateAGITokenAddress`
+- `updateAGITokenAddress` (ERC-20 escrow token address)
 - `updateEnsRegistry`
 - `updateNameWrapper`
 - `updateRootNodes`
 
-Additionally, these identity updates require **no jobs to exist** (`nextJobId == 0`) and **no escrowed funds** (`lockedEscrow == 0`), even before the lock is set.
+**Pre-lock constraints**: even before the lock is set, the identity wiring functions above require **no jobs to exist** (`nextJobId == 0`) and **no escrowed funds** (`lockedEscrow == 0`).
 
 ### Not frozen by the lock
 The lock **does not** restrict:
-- Operations controls (pause/unpause, blacklists, parameter tuning)
-- Treasury withdrawals (`withdrawAGI`)
+- Operational controls (pause/unpause, allowlists/blacklists, parameter tuning)
+- Treasury withdrawals (`withdrawAGI`, owner-only, paused-only)
 - Job settlement flows
 - **Merkle root updates** (`updateMerkleRoots` remains allowed)
 
-The lock is designed to freeze identity wiring only; it is **not** a governance lock.
+### Recommended operational sequence
+Deploy → configure ENS/token/root nodes → confirm wiring → lock identity config → operate.
 
-## Pause semantics (what is blocked vs allowed)
-Pause is an incident‑response control intended to halt new activity without trapping exits. The exact behavior is:
+## Pause semantics (blocked vs allowed)
+Pause is an incident-response control intended to halt new activity without trapping exits.
 
 ### Blocked while paused
 | Category | Functions |
 | --- | --- |
-| Job creation/onboarding | `createJob`, `applyForJob` |
-| Validation & new disputes | `validateJob`, `disapproveJob`, `disputeJob` |
+| Job creation & onboarding | `createJob`, `applyForJob` |
+| Validation & dispute entry | `validateJob`, `disapproveJob`, `disputeJob` |
 | Marketplace entry | `listNFT`, `purchaseNFT` |
 | Reward pool funding | `contributeToRewardPool` |
 
@@ -60,60 +56,58 @@ Pause is an incident‑response control intended to halt new activity without tr
 | --- | --- |
 | Completion request | `requestJobCompletion` (assigned agent only) |
 | Settlement & exits | `cancelJob`, `expireJob`, `finalizeJob`, `resolveDispute`, `resolveDisputeWithCode` |
-| Stale dispute recovery | `resolveStaleDispute` (owner‑only, paused‑only) |
-| Marketplace exit | `delistNFT` |
-| Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
+| Owner recovery | `resolveStaleDispute` (owner-only, paused-only) |
+| Marketplace exit | `delistNFT` (seller-only) |
+| Owner delist | `delistJob` (owner-only; unassigned only) |
+| Treasury withdrawal | `withdrawAGI` (owner-only, paused-only) |
 
-This ensures pause does not trap existing jobs or listings.
+**Explicit exceptions:** agents may still request completion while paused, and NFT sellers may delist while paused.
 
 ## Treasury vs escrow (withdrawal rules)
-- **Escrowed funds**: tracked in `lockedEscrow` and reserved for unsettled job payouts.
-- **Treasury**: the contract’s AGI balance **minus** `lockedEscrow`.
+- **Escrow**: job payout deposits tracked by `lockedEscrow`.
+- **Treasury**: AGI balance **minus** `lockedEscrow` (owner-withdrawable only while paused).
 
 ### `withdrawableAGI()` invariant
-`withdrawableAGI()` returns `balance - lockedEscrow` and **reverts** if the balance is below `lockedEscrow` (insolvent escrow is not allowed).
+`withdrawableAGI()` returns `balance - lockedEscrow` and **reverts** if `balance < lockedEscrow` (escrow insolvency is not allowed).
 
-### Sources of treasury funds
-Treasury can grow from:
-- **Remainders** after settlement when agent + validators receive less than 100%.
-- **Rounding dust** from payout calculations.
-- **Reward pool contributions** (`contributeToRewardPool`) — currently **not segregated**, so they become treasury.
-- **Direct transfers** to the contract.
+### `withdrawAGI()` gating
+- **Owner-only** and **paused-only**.
+- **Cannot exceed** `withdrawableAGI()`.
+- **Never withdraws escrowed funds**.
 
-### Owner withdrawal constraints
-- `withdrawAGI` is **owner‑only** and **paused‑only**.
-- The owner can **never** withdraw escrowed funds.
-- To “sunset” the contract and withdraw all remaining AGI: all jobs must be fully settled so `lockedEscrow == 0`.
+**Example**: if the contract holds **1,000 AGI** and `lockedEscrow` is **800 AGI**, then `withdrawableAGI()` is **200 AGI**. The owner can withdraw at most **200 AGI** while paused.
+
+### Shutdown / migration note
+To withdraw all AGI, `lockedEscrow` must reach **0** through job settlement, cancellation, expiry, or refunds. There is no owner sweep of escrowed funds.
 
 ## Reputation system (as implemented)
-Reputation growth uses a diminishing‑returns formula with a hard cap.
+Reputation grows with diminishing returns and a hard cap.
 
 ### Agent reputation points
-When a job completes:
+On completion:
 - `scaledPayout = job.payout / 1e18`
 - `payoutPoints = (scaledPayout^3) / 1e5`
 - `reputationPoints = log2(1 + payoutPoints * 1e6) + (completionTime / 10000)`
 
 ### Diminishing returns & cap
-For each update:
 - `newReputation = current + reputationPoints`
 - `diminishingFactor = 1 + (newReputation^2 / 88888^2)`
 - `diminished = newReputation / diminishingFactor`
 - Final reputation is `min(diminished, 88888)`.
 
-### Validator reputation
-Only **approving validators** are paid and gain reputation. Each approving validator receives:
+### Validator reputation and payouts
+Only **approving validators** receive payouts and reputation. Each approver receives:
 - `validatorPayout = totalValidatorPayout / approverCount`
 - `validatorReputationGain = reputationPoints * validationRewardPercentage / 100`
 
-Disapprovers do not receive payouts or reputation.
+Disapprovers receive no payout or reputation.
 
 ## Mainnet deployment constraints
-### EIP‑170 bytecode cap
-Ethereum mainnet enforces a **24,576‑byte** runtime bytecode limit (EIP‑170). The repository includes a test guard that asserts deployed bytecode remains within the configured safety margin (currently **24,575 bytes**, see `scripts/check-bytecode-size.js` and the “Bytecode size guard” test).
+### EIP-170 bytecode cap
+Ethereum mainnet enforces a **24,576-byte** runtime bytecode limit (EIP-170). The test suite includes a **Bytecode size guard** that asserts the deployed bytecode remains within the configured safety margin.
 
 ### How to check deployed bytecode size
-After `truffle compile`, check the runtime bytecode length:
+After `truffle compile`, check runtime bytecode length:
 ```bash
 node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
 ```
@@ -130,9 +124,9 @@ node scripts/check-bytecode-size.js
 - **Revert strings**: `strip`.
 - **EVM version**: `london` (default unless overridden).
 
-These settings are critical to keep bytecode within the EIP‑170 cap and to ensure deterministic verification.
+These settings are required to keep bytecode within the EIP-170 cap and to ensure deterministic verification.
 
-## Build & verification (Truffle)
+## Build, deploy, verify (Truffle)
 ### Deterministic build & test
 ```bash
 npm ci
@@ -141,14 +135,13 @@ npx truffle test --network test
 ```
 
 ### Deployment (Truffle migrations)
-The deployment entrypoint is `migrations/2_deploy_contracts.js`, which reads constructor wiring from `migrations/deploy-config.js` and environment variables. For mainnet‑grade deployments:
+The deployment entrypoint is `migrations/2_deploy_contracts.js`, which reads constructor wiring from `migrations/deploy-config.js` and environment variables. For mainnet-grade deployments:
 ```bash
 npx truffle migrate --network mainnet
 ```
 
 ### Constructor arguments (AGIJobManager)
-The constructor accepts:
-1. `agiTokenAddress` (ERC‑20 used for escrow/payouts)
+1. `agiTokenAddress` (ERC-20 used for escrow/payouts)
 2. `baseIpfs` (base URI used when completion metadata lacks a scheme)
 3. `ensConfig[0]` = ENS registry address
 4. `ensConfig[1]` = NameWrapper address
@@ -164,45 +157,28 @@ The constructor accepts:
 ```bash
 npx truffle run verify AGIJobManager --network mainnet
 ```
-If you prefer Etherscan’s UI, use the Standard JSON Input with the same compiler settings above.
+If you prefer Etherscan’s UI, use the Standard JSON Input with the same compiler settings above and the constructor arguments listed here.
 
-## Roles & permissions (summary)
-| Role | Capabilities |
-| --- | --- |
-| Owner | Pause/unpause, parameter tuning, allowlists/blacklists, moderator management, `withdrawAGI`, `delistJob` |
-| Moderator | Resolve disputes (`resolveDispute`, `resolveDisputeWithCode`) |
-| Employer | Create jobs, cancel pre‑assignment, dispute, receive completion NFTs |
-| Agent | Apply for jobs, request completion, receive payouts & reputation |
-| Validator | Approve/disapprove completion (if allowlisted), receive payouts & reputation on approval |
-
-## Known limitations / non‑economic notes
+## Known limitations / explicit non-features
 - `additionalAgentPayoutPercentage` is currently **unused** in settlement logic (reserved for future use).
-- `contributeToRewardPool` **does not segregate funds**; contributions are treasury and owner‑withdrawable during pause.
-- ENS/NameWrapper gating depends on external contracts; resolver lookups or wrapper ownership checks may fail if ENS configuration is incomplete or inconsistent.
-
-## Sunsetting / migration runbook (operator guidance)
-A safe wind‑down path:
-1. **Pause** the contract to stop new activity.
-2. Allow agents to **request completion** and validators/moderators to **settle disputes**.
-3. Let **cancel/expire/finalize** paths clear all active jobs.
-4. Verify `lockedEscrow == 0`.
-5. **Withdraw** remaining treasury funds with `withdrawAGI`.
-6. Deploy a v2 if needed and migrate off‑chain coordination.
+- `contributeToRewardPool` **does not segregate funds**; contributions become treasury and are owner-withdrawable during pause.
+- There is **no token rescue** function for arbitrary ERC-20s or ERC-721s; avoid sending non-AGI tokens directly to the contract.
+- ENS/NameWrapper gating depends on external ENS contracts; misconfiguration or resolver changes can cause allowlist failures.
 
 ## Testing status (local)
 Commands executed and results:
-- `npm ci` → **failed** on Linux because `fsevents@2.3.2` is macOS‑only (EBADPLATFORM).
+- `npm ci` → **failed** on Linux because `fsevents@2.3.2` is macOS-only (EBADPLATFORM).
 - `npm install --omit=optional` → **succeeded** (used to proceed with Truffle).
 - `npx truffle version` → **succeeded**.
 - `npx truffle compile` → **succeeded** (no compiler warnings emitted).
 - `npx truffle test` → **failed** (no local node at `http://127.0.0.1:8545`).
 - `npx truffle test --network test` → **succeeded** (216 passing).
 
-If CI requires a default `development` network, start Ganache on `127.0.0.1:8545` or set `--network test` explicitly.
+**Next fix when `npx truffle test` fails**: start Ganache on `127.0.0.1:8545` (e.g., `npx ganache -p 8545`) or run `npx truffle test --network test`.
 
 ## Glossary (selected)
 - **Escrow**: AGI reserved for unsettled jobs (`lockedEscrow`).
-- **Treasury**: AGI balance minus `lockedEscrow` (owner‑withdrawable only while paused).
-- **Identity lock**: one‑way freeze of ENS/token/root‑node wiring.
+- **Treasury**: AGI balance minus `lockedEscrow` (owner-withdrawable only while paused).
+- **Identity lock**: one-way freeze of ENS/token/root-node wiring (`lockIdentityConfig`).
 - **Pause**: operator safety switch that blocks new activity but allows exits.
-- **Completion request**: agent‑submitted metadata required before settlement or NFT minting.
+- **Completion request**: agent-submitted metadata required before settlement or NFT minting.


### PR DESCRIPTION
### Motivation
- Ensure repository docs accurately reflect on-chain behavior and the Truffle toolchain (compiler pinning, optimizer, `viaIR`), and avoid claims that conflict with the code.
- Clarify the project trust model (owner-operated marketplace), pause semantics, identity wiring lock, and treasury vs escrow invariants for safe mainnet operations.
- Provide a single canonical entrypoint for mainnet deployment & security guidance so operators and auditors have an up-to-date source of truth.

### Description
- Rewrote `docs/mainnet-deployment-and-security-overview.md` to match the contract code and `truffle-config.js`, documenting: owner privileges, exact pause gating (blocked vs allowed functions), `lockIdentityConfig` semantics (what is frozen and what remains adjustable), `lockedEscrow` / `withdrawableAGI()` invariants, reputation formulas, compiler/optimizer settings, and bytecode-size guidance.
- Updated `README.md` to add an "Important trust notes" summary linking to the canonical docs and corrected security language about owner withdrawals (treasury only = `balance - lockedEscrow`, owner withdrawal gated to paused state).
- Confirmed implementation details while authoring docs: `solc` pinned to `0.8.23`, optimizer enabled with `runs = 50`, `viaIR: false`, `metadata.bytecodeHash: 'none'`, and a bytecode-size guard present in the test suite and `scripts/check-bytecode-size.js`.
- Files changed: `docs/mainnet-deployment-and-security-overview.md`, `README.md`.

### Testing
- `npm ci` → failed on this Linux environment due to `fsevents@2.3.2` being macOS-only (EBADPLATFORM), which is an optional platform dependency and expected on non-macOS CI; recommended workaround is `npm install --omit=optional` or CI that supports optional deps.
- `npm install --omit=optional` → succeeded, allowing the rest of the toolchain to run.
- `npx truffle version` → succeeded (Truffle v5.11.5, `solc: 0.8.23` via `solc-js`).
- `npx truffle compile` → succeeded with compiler `0.8.23` and no compiler warnings emitted.
- `npx truffle test` (default `development` network at `http://127.0.0.1:8545`) → failed because no local node was running at that address; start Ganache or use the `test` network.
- `npx truffle test --network test` → succeeded: all automated tests passed (`216 passing`) including the bytecode size guard test.

Notes: failing `npx truffle test` is environmental (missing local Ganache) not a contract/test-suite failure; recommended operator commands are `npx ganache -p 8545` or run tests with `--network test` which uses the in-process Ganache provider included in `truffle-config.js`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69837afadd748333aaceaebc95aab598)