### PR TITLE
Update mainnet deployment & security docs and add local test-status log

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,10 @@
 - **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available; NFT sellers can still delist.
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 
-## Documentation (mainnet)
-Start with the canonical deployment/security overview: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md).
+## Documentation
+- **Mainnet deployment & security overview**: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md)
+- **Docs index**: [`docs/README.md`](docs/README.md)
+- **Local test status**: [`docs/test-status.md`](docs/test-status.md)
 
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
@@ -263,7 +265,7 @@ See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known
 - **OpenZeppelin Contracts**: https://docs.openzeppelin.com/contracts/4.x/
 - **Truffle**: https://trufflesuite.com/docs/truffle/
 
-## Documentation
+## Documentation index
 
 Start here:
 - [`docs/README.md`](docs/README.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,6 +21,7 @@ This documentation set targets engineers, integrators, operators, auditors, and 
 
 ## Operational references
 - **Testing guide**: [`Testing.md`](Testing.md)
+- **Test status (local run log)**: [`test-status.md`](test-status.md)
 - **Troubleshooting**: [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
 - **Regression tests summary**: [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md)
 - **FAQ**: [`FAQ.md`](FAQ.md)

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,0 +1,50 @@
+# Test status (local)
+
+This file records the latest local test outcomes and any environment‑specific failures.
+
+## Environment
+- OS: Linux (container)
+- Node: v20.19.6
+- Truffle: v5.11.5
+- Solidity (solc‑js): 0.8.23
+
+## Install status
+```bash
+npm ci
+```
+**Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only (`EBADPLATFORM`).
+
+**Workaround used:**
+```bash
+npm install --omit=optional
+```
+
+## Test commands
+```bash
+npx truffle version
+```
+**Result:** succeeded.
+
+```bash
+npx truffle compile
+```
+**Result:** succeeded (no compiler warnings emitted).
+
+```bash
+npx truffle test
+```
+**Result:** failed to connect to `http://127.0.0.1:8545`.
+
+**What the failure means:**
+- This command targets the default `development` network, which expects a local JSON‑RPC node at 127.0.0.1:8545.
+
+**Smallest next fix:**
+- Start Ganache locally (`npx ganache -p 8545`), **or** run tests with the in‑process provider:
+  ```bash
+  npx truffle test --network test
+  ```
+
+```bash
+npx truffle test --network test
+```
+**Result:** succeeded (216 passing).


### PR DESCRIPTION
### Motivation
- Ensure the repository’s mainnet-facing documentation accurately reflects the current `AGIJobManager.sol` implementation and `truffle-config.js` build settings. 
- Correct common documentation–code mismatches (identity lock scope, Merkle root mutability, pause semantics, treasury vs escrow invariant, compiler/optimizer pins, and bytecode guard). 
- Provide an explicit local test-status log to record environment-specific install/test outcomes and the smallest reproducible fixes for maintainers.

### Description
- Rewrote and consolidated the mainnet-focused narrative in `docs/mainnet-deployment-and-security-overview.md` to match the contract’s actual behavior (owner/moderator powers, job state machine, pause semantics, `lockIdentityConfiguration` semantics, `lockedEscrow`/`withdrawableAGI()` invariant, reputation math, and EIP-170/build pins). 
- Added `docs/test-status.md` that documents local install/test runs, environment notes, and minimal remediation steps for failures. 
- Updated top-level pointers: `README.md` and `docs/README.md` now link to the mainnet overview, docs index, and the new local test-status log. 
- No contract or business-logic changes were made; only documentation and small README/index edits were committed.

### Testing
- Commands executed and results: `npm ci` → failed on Linux due to `fsevents@2.3.2` (macOS-only); workaround used `npm install --omit=optional` → succeeded; `npx truffle version` → succeeded; `npx truffle compile` → succeeded (solc pinned to `0.8.23`, optimizer runs=50, `viaIR=false`); `npx truffle test` → failed to connect to `http://127.0.0.1:8545` (default `development` network requires a local node); `npx truffle test --network test` → succeeded (216 passing) and included the bytecode size guard passing. 
- Reproduction and smallest next fixes: to reproduce the `npx truffle test` failure run the same command against a non-running `development` node; the smallest fixes are (a) start Ganache locally: `npx ganache -p 8545`, then `npx truffle test`, or (b) run tests with the in-process provider used here: `npx truffle test --network test`. 
- Files added/updated: `docs/mainnet-deployment-and-security-overview.md` (updated), `docs/test-status.md` (new), `README.md` (updated), `docs/README.md` (updated). See `docs/test-status.md` for detailed local run logs and remediation steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698382f315608333b04afae17a563e6d)