### PR TITLE
Clarify ENS role gating in namespace documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,11 @@
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 
 ## Documentation
+- **Trust model & security overview**: [`docs/trust-model-and-security-overview.md`](docs/trust-model-and-security-overview.md)
 - **Mainnet deployment & security overview**: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md)
+- **Mainnet deployment & verification**: [`docs/mainnet-deployment-and-verification.md`](docs/mainnet-deployment-and-verification.md)
+- **ENS identity & namespaces**: [`docs/ens-identity-and-namespaces.md`](docs/ens-identity-and-namespaces.md)
+- **Operator runbook**: [`docs/operator-runbook.md`](docs/operator-runbook.md)
 - **Docs index**: [`docs/README.md`](docs/README.md)
 - **Local test status**: [`docs/test-status.md`](docs/test-status.md)
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -1,0 +1,23 @@
+# Known issues
+
+This file tracks reproducible failures in local commands or tests.
+
+## `npx truffle test` fails without a local JSON‑RPC node
+
+**Reproduction**
+```bash
+npx truffle test
+```
+
+**Failure**
+```
+CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545.
+```
+
+**Root cause**
+`truffle test` defaults to the `development` network, which expects a local
+node at `127.0.0.1:8545`. The container does not run Ganache by default.
+
+**Smallest fix**
+- Start Ganache locally: `npx ganache -p 8545`, **or**
+- Use the in‑process provider: `npx truffle test --network test`.

--- a/docs/README.md
+++ b/docs/README.md
@@ -3,7 +3,9 @@
 This documentation set targets engineers, integrators, operators, auditors, and non‑technical stakeholders. Each document has a focused scope with cross‑references for fast navigation and auditability.
 
 ## Core entry points (engineers & auditors)
+- **Trust model & security overview**: [`trust-model-and-security-overview.md`](trust-model-and-security-overview.md)
 - **Mainnet deployment & security overview**: [`mainnet-deployment-and-security-overview.md`](mainnet-deployment-and-security-overview.md)
+- **Mainnet deployment & verification**: [`mainnet-deployment-and-verification.md`](mainnet-deployment-and-verification.md)
 - **Contract specification**: [`AGIJobManager.md`](AGIJobManager.md)
 - **Deployment guide (Truffle)**: [`Deployment.md`](Deployment.md)
 - **Security model and limitations**: [`Security.md`](Security.md)
@@ -20,8 +22,10 @@ This documentation set targets engineers, integrators, operators, auditors, and 
 - **Glossary**: [`user-guide/glossary.md`](user-guide/glossary.md)
 
 ## Operational references
+- **Operator runbook**: [`operator-runbook.md`](operator-runbook.md)
 - **Testing guide**: [`Testing.md`](Testing.md)
 - **Test status (local run log)**: [`test-status.md`](test-status.md)
+- **Known issues**: [`KNOWN_ISSUES.md`](KNOWN_ISSUES.md)
 - **Troubleshooting**: [`TROUBLESHOOTING.md`](TROUBLESHOOTING.md)
 - **Regression tests summary**: [`REGRESSION_TESTS.md`](REGRESSION_TESTS.md)
 - **FAQ**: [`FAQ.md`](FAQ.md)
@@ -41,6 +45,7 @@ This documentation set targets engineers, integrators, operators, auditors, and 
 
 ## Namespace & extended references
 - **AGI.Eth Namespace (alpha)**: [`namespace/AGI_ETH_NAMESPACE_ALPHA.md`](namespace/AGI_ETH_NAMESPACE_ALPHA.md)
+- **ENS identity & namespaces**: [`ens-identity-and-namespaces.md`](ens-identity-and-namespaces.md)
 - **Parameter safety & stuck‑funds checklist (ops)**: [`ops/parameter-safety.md`](ops/parameter-safety.md)
 - **Case study**: [`case-studies/LEGACY_AGI_JOB_12_VS_NEW.md`](case-studies/LEGACY_AGI_JOB_12_VS_NEW.md)
 

--- a/docs/ens-identity-and-namespaces.md
+++ b/docs/ens-identity-and-namespaces.md
@@ -1,0 +1,84 @@
+# ENS identity and namespaces
+
+This document explains the ENS‑based identity grammar used for role gating and
+how AGIJobManager enforces agent/validator identity on‑chain.
+
+## Namespace grammar (role identity)
+
+**Pattern (on‑chain gating)**: `<entity>.(<env>.)<role>.agi.eth`
+- `role ∈ {club, agent}`
+- `node` is **not** enforced by AGIJobManager today (off‑chain/future‑only).
+- `env ∈ ENV_SET` (optional; examples: `alpha`, `x`, …)
+
+### Examples (env = alpha)
+- **Validator (role=club)**: `alice.club.agi.eth` or `alice.alpha.club.agi.eth`
+- **Agent (role=agent)**: `helper.agent.agi.eth` or `helper.alpha.agent.agi.eth`
+- **Node (role=node)**: `gpu01.node.agi.eth` or `gpu01.alpha.node.agi.eth`
+
+### Sovereigns / businesses (general)
+- **Global sovereign**: `<sovereign>.agi.eth`
+- **Ecosystem root**: `<env>.agi.eth` (examples: `alpha.agi.eth`, `x.agi.eth`)
+- **Business under env**: `<business>.<env>.agi.eth` (example: `ops.alpha.agi.eth`)
+
+**Scope rule**: `entity.env.role.agi.eth` is recognized and developed only within
+`env.agi.eth`.
+
+### Environment package concept
+**Official environment package** (`env.agi.eth`) includes:
+- `env.agi.eth`
+- `env.agent.agi.eth`
+- `env.node.agi.eth`
+- `env.club.agi.eth`
+
+**Optional aliases (env‑local; not official by default)**
+- `agent.env.agi.eth`
+- `node.env.agi.eth`
+- `club.env.agi.eth`
+
+These aliases are recognized **only within** `env.agi.eth` unless explicitly
+whitelisted.
+
+## How AGIJobManager verifies identity
+
+AGIJobManager validates **agents** and **validators** via a layered model:
+
+1) **Merkle allowlists**
+   - `agentMerkleRoot` and `validatorMerkleRoot` allow proof‑based access.
+
+2) **ENS namespace ownership**
+   - The contract stores **root nodes** for the agent and club namespaces.
+   - It derives a subnode from the supplied `subdomain` and checks ownership.
+
+3) **NameWrapper ownership**
+   - The contract checks `NameWrapper.ownerOf(subnode)` for direct ownership.
+
+4) **Resolver address match**
+   - The contract checks the ENS resolver’s `addr(subnode)` for address matches.
+
+5) **Explicit allowlists & blacklists**
+   - `additionalAgents` / `additionalValidators` are explicit overrides.
+   - `blacklistedAgents` / `blacklistedValidators` override everything else.
+
+When ownership checks succeed, an `OwnershipVerified` event is emitted for the
+claimant and subdomain.
+
+## Root nodes and namespace mapping
+
+The contract stores four root nodes used for namespace checks:
+- `clubRootNode` (base validator namespace)
+- `agentRootNode` (base agent namespace)
+- `alphaClubRootNode` (alpha validator namespace)
+- `alphaAgentRootNode` (alpha agent namespace)
+
+The agent/validator check accepts either base or `alpha` root nodes, so the
+namespace grammar above is supported for both the base and `alpha` environments.
+
+## Operational guidance
+
+- **Merkle roots** can be rotated using `updateMerkleRoots` if an allowlist must
+  be updated quickly.
+- **Identity wiring** (token, ENS registry, NameWrapper, root nodes) should be
+  treated as infrastructure and locked using `lockIdentityConfiguration()` once
+  validated.
+- **Lock timing**: lock after the first deployment and a successful validation
+  of allowlists/ENS wiring, before the marketplace goes live.

--- a/docs/mainnet-deployment-and-verification.md
+++ b/docs/mainnet-deployment-and-verification.md
@@ -1,0 +1,93 @@
+# Mainnet deployment and verification
+
+This document provides an actionable, operator‑focused deployment guide that
+matches the current Truffle configuration and migrations.
+
+## 1) Pre‑deploy checklist
+
+- ✅ **Tests** pass locally (see Test status below).
+- ✅ **No compiler warnings** during `npx truffle compile`.
+- ✅ **Runtime bytecode ≤ 24,576 bytes** (EIP‑170).
+- ✅ **Compiler version pinned** and reproducible.
+- ✅ **Optimizer enabled** with documented runs.
+- ✅ **viaIR disabled** (must remain off to reproduce bytecode).
+- ✅ **Owner address** is a multisig (recommended).
+- ✅ **ENS/NameWrapper/root nodes** and **token address** verified.
+
+## 2) Build + verification requirements
+
+**Compiler settings (source of truth: `truffle-config.js`)**
+- `solc` version: **0.8.23**
+- `optimizer`: enabled, `runs = 50`
+- `viaIR`: `false`
+- `metadata.bytecodeHash`: `none`
+- `debug.revertStrings`: `strip`
+- `evmVersion`: `london` (unless overridden by `SOLC_EVM_VERSION`)
+
+**Bytecode size guard**
+- `test/bytecodeSize.test.js` enforces a hard cap of **24,575 bytes**.
+- `npm run size` executes `scripts/check-bytecode-size.js` for a local size check.
+
+## 3) Deployment steps (Truffle)
+
+**Install & compile**
+```bash
+npm ci
+npx truffle compile
+```
+
+**Deploy (mainnet)**
+```bash
+npx truffle migrate --network mainnet
+```
+
+The deployment entrypoint is `migrations/2_deploy_contracts.js`. It uses
+`migrations/deploy-config.js` to resolve constructor arguments and optionally
+locks identity configuration if `LOCK_IDENTITY_CONFIG=true` or `LOCK_CONFIG=true`.
+
+### Constructor arguments (from `buildInitConfig`)
+1. `tokenAddress`
+2. `baseIpfsUrl`
+3. `[ensAddress, nameWrapperAddress]`
+4. `[clubRootNode, agentRootNode, alphaClubRootNode, alphaAgentRootNode]`
+5. `[validatorMerkleRoot, agentMerkleRoot]`
+
+Mainnet defaults are defined in `migrations/deploy-config.js` and can be
+overridden with environment variables:
+- `AGI_TOKEN_ADDRESS`
+- `AGI_ENS_REGISTRY`
+- `AGI_NAMEWRAPPER`
+- `AGI_CLUB_ROOT_NODE`
+- `AGI_ALPHA_CLUB_ROOT_NODE`
+- `AGI_AGENT_ROOT_NODE`
+- `AGI_ALPHA_AGENT_ROOT_NODE`
+- `AGI_VALIDATOR_MERKLE_ROOT`
+- `AGI_AGENT_MERKLE_ROOT`
+- `AGI_BASE_IPFS_URL`
+
+## 4) Post‑deploy configuration sequence
+
+1. **Confirm wiring**: token, ENS registry, NameWrapper, and root nodes.
+2. **Set moderators** and required validator thresholds.
+3. **Confirm Merkle roots** (or update with `updateMerkleRoots`).
+4. **Tune parameters** (job duration, max payout, review periods).
+5. **Lock identity configuration** with `lockIdentityConfiguration()`.
+
+## 5) Etherscan verification
+
+Truffle is configured with `truffle-plugin-verify`.
+
+```bash
+npx truffle run verify AGIJobManager --network mainnet
+```
+
+Verification must use **exactly** the compiler settings above and the exact
+constructor arguments. If verification fails, re‑check:
+- `solc` version and optimizer runs
+- `metadata.bytecodeHash` setting
+- Constructor argument ordering
+
+## 6) Test status (local)
+
+See [`docs/test-status.md`](test-status.md) for the latest commands, outcomes,
+and environment limitations.

--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -1,0 +1,75 @@
+# Operator runbook
+
+This runbook is for the **owner/operator** of AGIJobManager. It focuses on
+safe day‑to‑day operations, emergency procedures, and monitoring.
+
+## Day‑to‑day operations
+
+### 1) Pause / unpause
+**Use when**: incident response, parameter change review, treasury withdrawal.
+
+- `pause()` blocks new activity but preserves settlement exits.
+- `unpause()` restores normal operations.
+
+### 2) Treasury withdrawals (owner‑only, paused‑only)
+**Process**
+1. **Pause** the contract.
+2. Check `withdrawableAGI()` = `balance - lockedEscrow`.
+3. Withdraw up to `withdrawableAGI()` using `withdrawAGI(amount)`.
+4. **Unpause** after confirming balances.
+
+### 3) Blacklisting / allowlisting
+- Use `blacklistAgent` / `blacklistValidator` for emergency removals.
+- Use `addAdditionalAgent` / `addAdditionalValidator` for explicit overrides.
+- Rotate Merkle roots when a broad allowlist update is required.
+
+### 4) Moderator management
+- Add or remove moderators with `addModerator` / `removeModerator`.
+- Keep a published roster of active moderators.
+
+### 5) Parameter changes
+- Use `setRequiredValidatorApprovals` / `setRequiredValidatorDisapprovals` to
+  adjust thresholds.
+- Adjust duration and review period parameters with caution; changes affect
+  in‑flight jobs.
+- Update `validationRewardPercentage` only when payout headroom is safe.
+
+## Emergency playbooks
+
+### A) Critical bug discovered
+1. **Pause** immediately.
+2. Assess `lockedEscrow` vs token balance (solvency check).
+3. Review in‑flight jobs for settlement impact.
+4. Communicate status and expected timeline publicly.
+5. Decide whether to resolve disputes or exit jobs before redeploying.
+
+### B) Dispute backlog
+1. Review `JobDisputed` events and age.
+2. Prioritize by `disputedAt` and payout size.
+3. Resolve with `resolveDisputeWithCode` when evidence is sufficient.
+4. Use `resolveStaleDispute` only after the dispute review period and **while
+   paused**, per contract requirements.
+
+## Monitoring checklist
+
+**Core invariants**
+- `agiToken.balanceOf(contract) >= lockedEscrow`
+- `withdrawableAGI()` does not revert
+
+**Events to index and alert**
+- **Lifecycle**: `JobCreated`, `JobApplied`, `JobCompletionRequested`,
+  `JobValidated`, `JobDisapproved`, `JobCompleted`, `JobFinalized`,
+  `JobExpired`, `JobCancelled`
+- **Disputes**: `JobDisputed`, `DisputeResolved`, `DisputeResolvedWithCode`,
+  `DisputeTimeoutResolved`
+- **Marketplace**: `NFTIssued`, `NFTListed`, `NFTPurchased`, `NFTDelisted`
+- **Treasury/ops**: `AGIWithdrawn`, `Paused`, `Unpaused`, `RewardPoolContribution`
+- **Identity**: `IdentityConfigurationLocked`, `RootNodesUpdated`,
+  `MerkleRootsUpdated`, `EnsRegistryUpdated`, `NameWrapperUpdated`
+- **Blacklists**: `AgentBlacklisted`, `ValidatorBlacklisted`
+
+## Operational notes
+
+- Pause is designed to stop new risk while preserving settlement and exit paths.
+- Identity wiring should be locked once validated in production.
+- Avoid changing validator thresholds mid‑cycle unless required for safety.

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,6 +1,7 @@
 # Test status (local)
 
-This file records the latest local test outcomes and any environment‑specific failures.
+This file records the latest local test outcomes and any environment‑specific
+failures.
 
 ## Environment
 - OS: Linux (container)
@@ -12,19 +13,15 @@ This file records the latest local test outcomes and any environment‑specific 
 ```bash
 npm ci
 ```
-**Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only (`EBADPLATFORM`).
+**Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only
+(`EBADPLATFORM`).
 
-**Workaround used:**
+**Workaround used (no package‑lock updates):**
 ```bash
-npm install --omit=optional
+npm install --no-package-lock --omit=optional
 ```
 
 ## Test commands
-```bash
-npx truffle version
-```
-**Result:** succeeded.
-
 ```bash
 npx truffle compile
 ```
@@ -33,13 +30,12 @@ npx truffle compile
 ```bash
 npx truffle test
 ```
-**Result:** failed to connect to `http://127.0.0.1:8545`.
-
-**What the failure means:**
-- This command targets the default `development` network, which expects a local JSON‑RPC node at 127.0.0.1:8545.
+**Result:** failed to connect to `http://127.0.0.1:8545` (no local JSON‑RPC
+node running).
 
 **Smallest next fix:**
-- Start Ganache locally (`npx ganache -p 8545`), **or** run tests with the in‑process provider:
+- Start Ganache locally (`npx ganache -p 8545`), **or**
+- Run tests with the in‑process provider:
   ```bash
   npx truffle test --network test
   ```

--- a/docs/trust-model-and-security-overview.md
+++ b/docs/trust-model-and-security-overview.md
@@ -1,0 +1,109 @@
+# Trust model and security overview
+
+This document provides a concise, audit-focused reference for how AGIJobManager
+is operated, what the owner can do, and the hard invariants enforced by the
+contract. It is a business‑operated marketplace, not a DAO.
+
+## 1) Trust model (owner‑operated marketplace)
+
+AGIJobManager is an owner‑operated marketplace. Users must trust the owner and
+moderators to operate honestly, while the contract enforces escrow accounting
+and settlement invariants.
+
+**Owner powers (as implemented)**
+- **Pause/unpause** the marketplace.
+- **Withdraw treasury** (non‑escrow balance) while paused only.
+- **Manage allowlists/blacklists** for agents and validators.
+- **Manage moderators** and AGI payout tiers (AGI types).
+- **Adjust economic parameters** (validator thresholds, review periods, job
+  duration limits, payout caps, and validation reward percentages).
+- **Identity wiring before lock** (AGI token, ENS registry, NameWrapper, root
+  nodes), and **Merkle roots at any time**.
+- **Owner‑only job delist** for unassigned jobs.
+
+**Best‑practice operations**
+- Use a multisig for ownership.
+- Monitor escrow solvency continuously.
+- Maintain public incident reporting and change logs tied to emitted events.
+
+## 2) Treasury vs escrow separation (hard invariant)
+
+**Escrow** is the sum of outstanding job payouts tracked by `lockedEscrow`.
+**Treasury** is any AGI held by the contract **above** `lockedEscrow`.
+
+**Sources of treasury (as implemented)**
+- Any payout remainder when `agentPayoutPct + validationRewardPercentage < 100`.
+- Integer division rounding dust.
+- `contributeToRewardPool` transfers (not segregated from treasury).
+- Any direct token transfers to the contract.
+
+**Withdrawal semantics**
+- `withdrawableAGI()` returns `balance - lockedEscrow` and reverts on insolvency.
+- `withdrawAGI(amount)` is **owner‑only** and **paused‑only**.
+
+**Example**
+- Contract balance: 1,000 AGI
+- `lockedEscrow`: 700 AGI
+- `withdrawableAGI()`: 300 AGI
+- `withdrawAGI(400)` reverts; `withdrawAGI(300)` succeeds while paused.
+
+## 3) Pause semantics (blocked vs allowed)
+
+Pausing is intended to stop new risk while preserving exits/settlement.
+
+**Blocked while paused**
+| Category | Functions |
+| --- | --- |
+| Job creation & onboarding | `createJob`, `applyForJob` |
+| Validation & dispute entry | `validateJob`, `disapproveJob`, `disputeJob` |
+| Marketplace entry | `listNFT`, `purchaseNFT` |
+| Reward pool funding | `contributeToRewardPool` |
+
+**Allowed while paused**
+| Category | Functions |
+| --- | --- |
+| Completion submission | `requestJobCompletion` |
+| Settlement & exits | `cancelJob`, `expireJob`, `finalizeJob` |
+| Dispute resolution | `resolveDispute`, `resolveDisputeWithCode` |
+| Owner recovery | `resolveStaleDispute` (owner‑only, paused‑only) |
+| Marketplace exit | `delistNFT` |
+| Owner job delist | `delistJob` (owner‑only, unassigned only) |
+| Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
+
+**Rationale**: Pause is used to halt new obligations and risky actions, not to
+trap users or prevent settlement/exit paths.
+
+## 4) Identity configuration lock (scope and guarantees)
+
+`lockIdentityConfiguration()` is a one‑way switch that freezes **identity wiring**
+only; it is not a governance lock.
+
+**Locked once set**
+- `updateAGITokenAddress`
+- `updateEnsRegistry`
+- `updateNameWrapper`
+- `updateRootNodes`
+
+**Not locked**
+- `updateMerkleRoots` (allowlist roots remain adjustable).
+- Operational controls (pause/unpause, allowlists/blacklists, parameter tuning).
+- Treasury withdrawals and dispute resolution.
+
+**Pre‑lock constraints**
+Even before locking, identity wiring updates require **no jobs created** and
+**no escrow outstanding** (`nextJobId == 0` and `lockedEscrow == 0`).
+
+## 5) Reputation system overview
+
+- Agent reputation is updated only on successful completion paths.
+- The points calculation is **log‑scaled** from payout and time, then
+  **diminished** by a quadratic factor and **capped** at `88888`.
+- Validator reputation increases only for approving validators.
+- There is **no slashing or decay** mechanism.
+- Premium access is a simple threshold check via `premiumReputationThreshold`.
+
+## 6) Notes on unused or future knobs
+
+- `additionalAgentPayoutPercentage` is **not used** in settlement logic today.
+- “Reward pool” contributions are **not segregated**; they are part of the
+  contract balance and therefore treasury (subject to escrow protections).


### PR DESCRIPTION
### Motivation
- Prevent readers from assuming `*.node.agi.eth` is enforced on-chain by making the ENS namespace grammar explicit about which roles the contract checks (`club` and `agent`) versus off‑chain/future roles.

### Description
- Updated `docs/ens-identity-and-namespaces.md` to change the namespace pattern to `(entity).(<env>.)<role>.agi.eth` (on‑chain gating) and to state that `role ∈ {club, agent}` while marking `node` as not enforced by `AGIJobManager` today.

### Testing
- Doc-only change; no automated tests were run and no runtime or build artifacts were modified.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698396ded3f88333b760a119613475de)