### PR TITLE
Docs: mainnet deployment & security updates, ENS, architecture, and test-status fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,11 +29,15 @@
 - **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available; NFT sellers can still delist.
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 
+**Trust model summary**: owner‑operated marketplace; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
+
 ## Documentation
 - **Trust model & security overview**: [`docs/trust-model-and-security-overview.md`](docs/trust-model-and-security-overview.md)
 - **Mainnet deployment & security overview**: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md)
 - **Mainnet deployment & verification**: [`docs/mainnet-deployment-and-verification.md`](docs/mainnet-deployment-and-verification.md)
 - **ENS identity & namespaces**: [`docs/ens-identity-and-namespaces.md`](docs/ens-identity-and-namespaces.md)
+- **Architecture & state machine**: [`docs/architecture.md`](docs/architecture.md)
+- **Deployments & bridging safety**: [`docs/deployments-and-bridging.md`](docs/deployments-and-bridging.md)
 - **Operator runbook**: [`docs/operator-runbook.md`](docs/operator-runbook.md)
 - **Docs index**: [`docs/README.md`](docs/README.md)
 - **Local test status**: [`docs/test-status.md`](docs/test-status.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -6,6 +6,8 @@ This documentation set targets engineers, integrators, operators, auditors, and 
 - **Trust model & security overview**: [`trust-model-and-security-overview.md`](trust-model-and-security-overview.md)
 - **Mainnet deployment & security overview**: [`mainnet-deployment-and-security-overview.md`](mainnet-deployment-and-security-overview.md)
 - **Mainnet deployment & verification**: [`mainnet-deployment-and-verification.md`](mainnet-deployment-and-verification.md)
+- **Architecture & state machine**: [`architecture.md`](architecture.md)
+- **Deployments & bridging safety**: [`deployments-and-bridging.md`](deployments-and-bridging.md)
 - **Contract specification**: [`AGIJobManager.md`](AGIJobManager.md)
 - **Deployment guide (Truffle)**: [`Deployment.md`](Deployment.md)
 - **Security model and limitations**: [`Security.md`](Security.md)

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -1,0 +1,69 @@
+# Architecture & state machine
+
+This document summarizes the on-chain modules inside the monolithic
+`AGIJobManager` contract and the job lifecycle it enforces.
+
+## Contract modules (single-contract composition)
+- **Job escrow & state machine**: `createJob`, `applyForJob`, `requestJobCompletion`,
+  `finalizeJob`, `expireJob`, `cancelJob`, `delistJob`, plus internal settlement.
+- **Validation & dispute handling**: validator approvals/disapprovals,
+  dispute opening, moderator resolution, and stale-dispute owner recovery.
+- **ERC‑721 completion NFTs**: minted on job completion; URI points to completion
+  metadata.
+- **Internal marketplace**: listing/purchase/delist for completion NFTs, settled
+  in the same ERC‑20 token used for job payouts.
+- **Reputation system**: on-chain reputation updates for agents and approving
+  validators with diminishing returns and a hard cap.
+- **Identity verification**: ENS/NameWrapper checks plus Merkle allowlists and
+  explicit allow/deny overrides.
+
+## Job lifecycle (plain English)
+1. **Open**: employer creates a job and escrows the payout.
+2. **InProgress**: an eligible agent applies and is assigned.
+3. **CompletionRequested**: the agent submits completion metadata.
+4. **Completed**: validators approve to threshold, or completion review period
+   elapses and `finalizeJob` is called.
+5. **Disputed**: validators disapprove to threshold or parties call `disputeJob`.
+6. **Expired**: duration elapses without completion request and anyone calls
+   `expireJob`.
+7. **Cancelled/Delisted**: employer cancels an unassigned job or owner delists it.
+
+## State transition diagram (Mermaid)
+```mermaid
+stateDiagram-v2
+    [*] --> Open: createJob
+    Open --> InProgress: applyForJob
+    InProgress --> CompletionRequested: requestJobCompletion
+
+    CompletionRequested --> Completed: validateJob (approvals)
+    CompletionRequested --> Completed: finalizeJob (review timeout)
+
+    CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
+    CompletionRequested --> Disputed: disputeJob (manual)
+
+    Disputed --> Completed: resolveDisputeWithCode(AGENT_WIN)
+    Disputed --> Completed: resolveDisputeWithCode(EMPLOYER_WIN)
+    Disputed --> Completed: resolveStaleDispute (owner, paused, timeout)
+
+    InProgress --> Expired: expireJob (duration elapsed)
+    Open --> Cancelled: cancelJob (employer)
+    Open --> Cancelled: delistJob (owner)
+```
+
+## Liveness and finality timeouts
+- **Job duration** (`jobDurationLimit`, per-job `duration`):
+  - If the duration elapses without a completion request, anyone can call
+    `expireJob` to refund the employer.
+- **Completion review period** (`completionReviewPeriod`):
+  - After completion is requested, anyone can call `finalizeJob` once the review
+    window has passed.
+  - `finalizeJob` selects the outcome based on validator approvals vs
+    disapprovals or defaults to an agent win when no validators acted.
+- **Dispute review period** (`disputeReviewPeriod`):
+  - If a dispute remains unresolved past the review window, the owner can call
+    `resolveStaleDispute` **only while paused** to force resolution.
+
+## Why this matters
+The state machine guarantees that escrowed funds are released only through
+defined settlement paths and that every completion payout has a recorded
+completion metadata URI.

--- a/docs/deployments-and-bridging.md
+++ b/docs/deployments-and-bridging.md
@@ -1,0 +1,31 @@
+# Deployments, addresses, and bridging safety
+
+This document records legacy reference artifacts and onboarding safety notes.
+All addresses below are **historical/reference** unless explicitly stated
+otherwise.
+
+## Legacy / reference artifacts
+- **Legacy AGIJobManager (Ethereum)**: `0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477`
+- **Deployer ENS**: `deployer.agi.eth`
+- **“AGI Jobs” collection on OpenSea**: reference surface for historical
+  listings (verify current URLs and ownership off-chain before use).
+
+## Bridging / onboarding safety (SOL ↔ ETH)
+**Always verify domains and addresses before signing.** Prefer:
+- small test amounts,
+- limited allowances,
+- explicit destination checks.
+
+**Decimals mismatch warning**
+- **Transitory token (6 decimals)**: `0x2e8fb54c3ec41f55f06c1f082c081a609eaa4ebe`
+- **Final token (18 decimals, v2)**: `0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA`
+- **Mint/vault**: `AGIALPHAEqualMinterVault` at `0x27d6fE8668c6f652Ac26fFaE020D949f03aF80D8`
+
+## ENS schema recap (namespace grammar alignment)
+- **Validators**: `*.alpha.club.agi.eth` or `*.club.agi.eth`
+- **Agents**: `*.alpha.agent.agi.eth` or `*.agent.agi.eth`
+- **Nodes**: `*.alpha.node.agi.eth` or `*.node.agi.eth`
+- **Sovereigns**: `*.alpha.agi.eth` or `*.agi.eth`
+
+**Scope reminder**: `entity.env.role.agi.eth` is recognized only within
+`env.agi.eth` unless explicitly whitelisted.

--- a/docs/ens-identity-and-namespaces.md
+++ b/docs/ens-identity-and-namespaces.md
@@ -6,9 +6,10 @@ how AGIJobManager enforces agent/validator identity on‑chain.
 ## Namespace grammar (role identity)
 
 **Pattern (on‑chain gating)**: `<entity>.(<env>.)<role>.agi.eth`
-- `role ∈ {club, agent}`
-- `node` is **not** enforced by AGIJobManager today (off‑chain/future‑only).
+- `role ∈ {club, agent, node}`
 - `env ∈ ENV_SET` (optional; examples: `alpha`, `x`, …)
+
+**Contract scope note**: AGIJobManager currently enforces **club** (validators) and **agent** roles only. `node` names are part of the wider namespace grammar and are not consumed by the contract today.
 
 ### Examples (env = alpha)
 - **Validator (role=club)**: `alice.club.agi.eth` or `alice.alpha.club.agi.eth`
@@ -24,7 +25,7 @@ how AGIJobManager enforces agent/validator identity on‑chain.
 `env.agi.eth`.
 
 ### Environment package concept
-**Official environment package** (`env.agi.eth`) includes:
+**Official environment package (issued by AGI King)** (`env.agi.eth`) includes:
 - `env.agi.eth`
 - `env.agent.agi.eth`
 - `env.node.agi.eth`
@@ -72,6 +73,12 @@ The contract stores four root nodes used for namespace checks:
 
 The agent/validator check accepts either base or `alpha` root nodes, so the
 namespace grammar above is supported for both the base and `alpha` environments.
+
+## Contract wiring references
+- **ENS registry**: `ens` is used to resolve the resolver for a node.
+- **NameWrapper**: `nameWrapper` is queried first for ownership of the subnode.
+- **Roots**: `clubRootNode`/`alphaClubRootNode` for validators and `agentRootNode`/`alphaAgentRootNode` for agents.
+- **Allowlist overrides**: `additionalAgents` and `additionalValidators` bypass Merkle/ENS checks, while `blacklistedAgents`/`blacklistedValidators` override everything else.
 
 ## Operational guidance
 

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -14,33 +14,24 @@ failures.
 npm ci
 ```
 **Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only
-(`EBADPLATFORM`).
-
-**Workaround used (no package‑lock updates):**
-```bash
-npm install --no-package-lock --omit=optional
-```
+(`EBADPLATFORM`). No dependency install succeeded, so Truffle config dependencies
+(`dotenv`) were unavailable.
 
 ## Test commands
 ```bash
 npx truffle compile
 ```
-**Result:** succeeded (no compiler warnings emitted).
+**Result:** failed with `Error: Cannot find module 'dotenv'` because dependencies
+were not installed. The `npx` bootstrap also emitted multiple `npm warn` deprecation
+messages while installing Truffle, which should be treated as warnings.
 
 ```bash
 npx truffle test
 ```
-**Result:** failed to connect to `http://127.0.0.1:8545` (no local JSON‑RPC
-node running).
+**Result:** failed with `Error: Cannot find module 'dotenv'` because dependencies
+were not installed.
 
 **Smallest next fix:**
-- Start Ganache locally (`npx ganache -p 8545`), **or**
-- Run tests with the in‑process provider:
-  ```bash
-  npx truffle test --network test
-  ```
-
-```bash
-npx truffle test --network test
-```
-**Result:** succeeded (216 passing).
+- Install dependencies without the macOS‑only optional package (e.g., via an
+  `npm install` workflow that omits optional deps), then rerun `npx truffle compile`
+  and `npx truffle test --network test`.


### PR DESCRIPTION
### Motivation
- Make the repository documentation mainnet‑deployment grade, security/audit friendly, and strictly aligned with the actual behavior of `AGIJobManager.sol` (owner powers, identity lock, pause semantics, escrow invariants, reputation math). 
- Reduce ambiguity for auditors/operators by centralizing trust/identity/treasury guidance and adding a concise architecture/state‑machine doc. 

### Description
- Updated `docs/mainnet-deployment-and-security-overview.md` to add a code‑accurate pause policy table, clarify the identity wiring lock (boolean `lockIdentityConfig` and the one‑time action `lockIdentityConfiguration()`), expand treasury vs escrow semantics (including `lockedEscrow` and `withdrawableAGI()`), and note unused fields like `additionalAgentPayoutPercentage`. 
- Added `docs/architecture.md` summarizing contract modules and the job lifecycle and `docs/deployments-and-bridging.md` for legacy addresses and bridging/onboarding safety; linked both from `README.md` and `docs/README.md`. 
- Clarified ENS namespace grammar and contract enforcement in `docs/ens-identity-and-namespaces.md` (which roots are checked, NameWrapper/Resolver order, Merkle allowlist behavior, and which roots remain rotatable), and emitted guidance on locking identity wiring. 
- Updated local test/status and known issues docs (`docs/test-status.md`, `docs/KNOWN_ISSUES.md`) to record exact environment failures and the smallest remediation steps for running Truffle locally. 

### Testing
- Ran `npm ci` which failed with `EBADPLATFORM` due to the macOS‑only optional dependency `fsevents@2.3.2`, preventing installation of `dotenv` and other deps. 
- Ran `npx truffle compile` which failed with `Error: Cannot find module 'dotenv'` because dependencies were not installed; the transcript shows `truffle` bootstrap emitted multiple `npm warn` deprecation messages while attempting to install. 
- Ran `npx truffle test` which also failed with `Error: Cannot find module 'dotenv'` for the same dependency/install problem; docs now recommend installing dependencies while omitting macOS‑only optional packages and/or running tests with the in‑process provider via `npx truffle test --network test` as the smallest next steps.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a188df508333b62a4ba2a131766f)