### PR TITLE
Clarify marketplace scope & dispute model in deployment doc; record local install/test failures

### DIFF
--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -198,5 +198,5 @@ See [`docs/test-status.md`](test-status.md) for the latest local test results an
 
 ## 13) Additional notes (required clarifications)
 - **additionalAgentPayoutPercentage**: present but currently unused in payout math; changing it does not affect settlement.
-- **Marketplace scope**: the internal marketplace lists/purchases the job completion NFTs and settles in the same ERC‑20 used for job payouts.
-- **Not a decentralized court/DAO**: dispute resolution is handled by moderators/owner actions and is transparent via on‑chain events.
+- **Marketplace scope**: the NFT marketplace is internal to AGIJobManager and settles listings in the same ERC‑20 token used for job payouts (the configured AGI token).
+- **Dispute model**: dispute outcomes are centralized (moderators/owner), with all resolutions emitted as on-chain events; this is not a decentralized court/DAO.

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -14,22 +14,23 @@ failures.
 npm ci
 ```
 **Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only
-(`EBADPLATFORM`). No dependency install succeeded, so Truffle config dependencies
-(`dotenv`) were unavailable.
+(`EBADPLATFORM`). The command also emitted `npm warn Unknown env config "http-proxy"`.
+No dependency install succeeded, so Truffle config dependencies (`dotenv`) were unavailable.
 
 ## Test commands
 ```bash
 npx truffle compile
 ```
 **Result:** failed with `Error: Cannot find module 'dotenv'` because dependencies
-were not installed. The `npx` bootstrap also emitted multiple `npm warn` deprecation
-messages while installing Truffle, which should be treated as warnings.
+were not installed. The `npx` bootstrap also emitted `npm warn` deprecation
+messages and `npm warn Unknown env config "http-proxy"` while installing Truffle,
+which should be treated as warnings.
 
 ```bash
 npx truffle test
 ```
 **Result:** failed with `Error: Cannot find module 'dotenv'` because dependencies
-were not installed.
+were not installed. The command also emitted `npm warn Unknown env config "http-proxy"`.
 
 **Smallest next fix:**
 - Install dependencies without the macOS‑only optional package (e.g., via an


### PR DESCRIPTION
### Motivation
- Make the mainnet deployment & security overview explicit about the internal NFT marketplace settlement token and the centralized dispute model so auditors/operators see the contract's actual behavior. 
- Capture the exact local install/compile/test failures observed when attempting the repo's CI workflow so the Test Status doc is accurate for contributors running in Linux CI containers.

### Description
- Updated `docs/mainnet-deployment-and-security-overview.md` to state that the NFT marketplace is internal to `AGIJobManager` and lists/purchases settle in the configured AGI ERC‑20 token, and to clarify that dispute resolution is centralized (moderators/owner) with on‑chain events (not a DAO/court). 
- Updated `docs/test-status.md` to record the observed `npm ci` failure (`EBADPLATFORM` for `fsevents@2.3.2`), the `npm warn Unknown env config "http-proxy"` messages, and the resulting `npx truffle compile` / `npx truffle test` failures (`Error: Cannot find module 'dotenv'`). 
- Committed the two small docs updates (no contract or test code changes).

### Testing
- Ran `npm ci`; result: failed on Linux with `EBADPLATFORM` due to `fsevents@2.3.2` (macOS‑only) and emitted `npm warn Unknown env config "http-proxy"`. (Failure recorded in `docs/test-status.md`.)
- Ran `npx truffle compile`; result: failed with `Error: Cannot find module 'dotenv'` because dependencies were not installed during `npm ci` (failure recorded in `docs/test-status.md`).
- Ran `npx truffle test`; result: failed with the same missing `dotenv` error (recorded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983a9eaac788333be41b91dfce85479)