### PR TITLE
Update UI contract selection to avoid legacy defaults and add deployments lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,7 @@ node scripts/check-bytecode-size.js
 ## Web UI (GitHub Pages)
 
 - Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)
-- Usage guide: [`docs/agijobmanager_ui.md`](docs/agijobmanager_ui.md)
+- Usage guide: [`docs/ui/README.md`](docs/ui/README.md)
 - Expected Pages URL pattern: `https://<org>.github.io/<repo>/ui/agijobmanager.html`
 - GitHub Pages setup: Settings → Pages → Source “Deploy from branch” → Branch `main` → Folder `/docs`.
 - The contract address is user-configurable and must be provided until the new mainnet deployment is finalized.

--- a/docs/agijobmanager_ui.md
+++ b/docs/agijobmanager_ui.md
@@ -21,13 +21,17 @@ You can set the contract address in four ways (the UI uses the first one it find
 
 2) **LocalStorage** (the UI stores the last saved address automatically)
 
-3) **Config file** (`docs/ui/agijobmanager.config.json`)
+3) **Deployments record** (`docs/deployments/mainnet.json`)
+   - `agiJobManager` is intentionally blank until the new deployment is finalized.
+
+4) **Config file** (`docs/ui/agijobmanager.config.json`)
    - `preferredContract` is intentionally blank until the new deployment is finalized.
 
-4) **Manual input**
+5) **Manual input**
 Use the “Contract address” input and click **Save address**.
 
-If none of the above are set, the UI will fall back to the **legacy v0** address (explicitly labeled “Legacy fallback”).
+If none of the above are set, the UI leaves the contract address empty until you explicitly choose one.
+The **legacy v0** address is shown as a reference and must be selected manually.
 
 > The new AGIJobManager mainnet address is not yet known. This UI is designed to work with **any** valid deployment.
 > A helper button is available to prefill the **legacy v0** mainnet address, which is clearly labeled as legacy.

--- a/docs/ui/README.md
+++ b/docs/ui/README.md
@@ -31,7 +31,8 @@ npx http-server docs/ui
 The UI does **not** assume a default deployment. Provide a contract address explicitly:
 
 - Query param: `?contract=0x...`
-- Config file: `docs/ui/agijobmanager.config.json` (`preferredContract`)
+- Deployments record: `docs/deployments/mainnet.json` (`agiJobManager`, if set)
+- Config file: `docs/ui/agijobmanager.config.json` (`preferredContract`, if set)
 - Manual entry in the “Contract address” field
 - Save button: persists to `localStorage` under the key `agijobmanager_contract`
 
@@ -40,7 +41,8 @@ To reset:
 - Click **Clear** in the UI, or
 - Remove `localStorage` key `agijobmanager_contract` in your browser’s dev tools.
 
-If none of the above are set, the UI falls back to the legacy v0 address, which is clearly labeled as legacy.
+If none of the above are set, the UI leaves the contract address empty until you explicitly choose one.
+The legacy v0 address is shown as a reference and is **opt-in** only.
 
 ## ABI export + drift guardrails
 
@@ -72,6 +74,11 @@ indexed events. Expiration is based on the on-chain `expired` flag and the job t
 - **Sepolia** or local dev chains are supported only if you supply a compatible contract address.
 - On unsupported chains, the UI will show a warning (chainId mismatch) and interactions may revert.
   The UI does not generate chain-specific explorer links.
+
+## Known limitations
+
+- Merkle proofs are user-supplied (`bytes32[]` JSON). The UI only verifies membership off-chain; on-chain checks still enforce authorization.
+- ENS checks mirror the contract’s fallback logic (Merkle → NameWrapper.ownerOf → Resolver.addr).
 
 ## Marketplace filters + approval status
 

--- a/docs/ui/agijobmanager.html
+++ b/docs/ui/agijobmanager.html
@@ -312,14 +312,15 @@
           <div class="inline">
             <button id="saveContract">Save address</button>
             <button id="clearContract" class="secondary">Clear</button>
-            <button id="legacyContract" class="secondary">Use legacy fallback (v0)</button>
+            <button id="legacyContract" class="secondary">Use legacy v0 (opt-in)</button>
           </div>
           <p class="muted">
-            Preferred mainnet deployment (config): <span id="mainnetDeployment">TBD</span>. Legacy fallback:
+            Preferred mainnet deployment (config/deployments): <span id="mainnetDeployment">TBD</span>. Legacy reference:
             <code id="legacyAddress">0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477</code> (opt-in only).
           </p>
           <p class="muted">Active source: <span id="contractSource">—</span></p>
-          <p class="muted">Supported sources: query param <code>?contract=0x...</code>, localStorage, config file, or legacy fallback.</p>
+          <p class="muted">Supported sources: query param <code>?contract=0x...</code>, localStorage, deployments/config file, or manual legacy selection.</p>
+          <p class="muted">No contract is selected by default until you explicitly choose one.</p>
         </div>
       </div>
       <div class="panel-row">
@@ -993,6 +994,7 @@
       contractAddress: null,
       contractSource: null,
       config: null,
+      deployments: null,
       legacyAddress: null,
       agiTokenAddress: null,
       agiTokenDecimals: 18,
@@ -1197,7 +1199,8 @@
       query: "Query param",
       localStorage: "LocalStorage",
       config: "Config file",
-      legacy: "Legacy fallback",
+      deployments: "Deployments registry",
+      legacy: "Legacy v0 (opt-in)",
       manual: "Manual entry",
     };
 
@@ -3731,19 +3734,31 @@
           logEvent(`⚠️ Config preferredContract invalid: ${error.message}`);
         }
       }
-      let legacy = "";
-      if (config.legacyContract) {
+      let deployments = null;
+      let deploymentPreferred = "";
+      try {
+        const response = await fetch("../deployments/mainnet.json", { cache: "no-store" });
+        if (response.ok) {
+          const data = await response.json();
+          deployments = data || null;
+        }
+      } catch (error) {
+        deployments = null;
+      }
+      if (deployments?.agiJobManager) {
         try {
-          legacy = setLegacyAddress(config.legacyContract);
+          deploymentPreferred = parseAddress(deployments.agiJobManager, "Deployments contract address");
         } catch (error) {
-          logEvent(`⚠️ Config legacyContract invalid: ${error.message}`);
+          logEvent(`⚠️ Deployments agiJobManager invalid: ${error.message}`);
         }
       }
-      if (!legacy) {
+      let legacy = "";
+      const legacyCandidate = config.legacyContract || deployments?.legacyV0 || legacyAddress;
+      if (legacyCandidate) {
         try {
-          legacy = setLegacyAddress(legacyAddress);
+          legacy = setLegacyAddress(legacyCandidate);
         } catch (error) {
-          legacy = "";
+          logEvent(`⚠️ Legacy contract invalid: ${error.message}`);
         }
       }
 
@@ -3752,7 +3767,8 @@
         preferredContract: preferred,
         legacyContract: legacy,
       };
-      setText("mainnetDeployment", preferred || "TBD");
+      state.deployments = deployments;
+      setText("mainnetDeployment", preferred || deploymentPreferred || "TBD");
       if (!legacy) {
         state.legacyAddress = null;
         setText("legacyAddress", "Unavailable");
@@ -3791,11 +3807,16 @@
         }
       }
 
-      if (state.legacyAddress) {
-        applyContractAddress(state.legacyAddress, { source: "legacy" });
-      } else {
-        updateContractSourceDisplay();
+      if (state.deployments?.agiJobManager) {
+        try {
+          applyContractAddress(state.deployments.agiJobManager, { source: "deployments" });
+          return;
+        } catch (error) {
+          logEvent(`⚠️ Deployments agiJobManager invalid: ${error.message}`);
+        }
       }
+
+      updateContractSourceDisplay();
     }
 
     async function handleSaveContract() {


### PR DESCRIPTION
### Motivation

- Prevent the UI from silently defaulting to the legacy v0 address and make contract selection explicit and auditable. 
- Allow the UI to surface a canonical deployments record so a future verified mainnet address can be auto-prefilled (best-effort) without embedding secrets. 
- Clarify documentation and labels so users understand override precedence, storage keys, supported networks, and known limitations. 

### Description

- Change the single-file UI (`docs/ui/agijobmanager.html`) so the initial contract-selection flow prefers (in order) query param `?contract=…`, `localStorage`, UI config `preferredContract`, then `docs/deployments/mainnet.json` (if set), and otherwise leaves the contract unset; legacy v0 is shown as an explicit opt-in. 
- Add a `deployments` lookup and new contract source label (`Deployments registry`) and wire `state.deployments` into startup display (`mainnetDeployment`) and selection logic. 
- Update UI copy/buttons to emphasize “legacy v0 (opt-in)”, add a note that no contract is selected by default, and clarify supported sources and behavior. 
- Update docs: `docs/ui/README.md` (contract-selection flows, known limitations), `docs/agijobmanager_ui.md` (reflect deployments record precedence and legacy opt-in), and root `README.md` (point Web UI guide to `docs/ui/README.md`). 

### Testing

- `npm ci` (automated dependency install) failed due to platform-conditional optional dependency `fsevents` (EBADPLATFORM on Linux). 
- `npm ci --omit=optional` also failed for the same optional-platform issue in this environment. 
- `npx truffle compile` failed because dependencies were not installed and `dotenv` could not be resolved. 
- `npx truffle test` failed for the same dependency/environment reasons. 
- Local static serve + automated browser load (Playwright script that opened `http://127.0.0.1:8000/ui/agijobmanager.html` and captured a screenshot) succeeded and produced a UI screenshot, confirming the page loads over HTTP and the updated copy/controls render.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983ba9b023883339d6b8d89d40c364a)