### PR TITLE
Add validator bond accounting, adjust settlement logic, and update tests/UI ABI

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2,7 +2,7 @@
   "contractName": "AGIJobManager",
   "compiler": {
     "name": "solc",
-    "version": "0.8.19+commit.7dd6d404.Emscripten.clang"
+    "version": "0.8.23+commit.f704f362.Emscripten.clang"
   },
   "abi": [
     {
@@ -1379,6 +1379,19 @@
     },
     {
       "inputs": [],
+      "name": "lockedValidatorBonds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "maxJobPayout",
       "outputs": [
         {
@@ -1724,6 +1737,19 @@
     {
       "inputs": [],
       "name": "validationRewardPercentage",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorBond",
       "outputs": [
         {
           "internalType": "uint256",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@openzeppelin/test-helpers": "^0.5.16",
         "@playwright/test": "^1.49.1",
         "@truffle/hdwallet-provider": "^2.1.15",
-        "dotenv": "^16.4.5",
+        "dotenv": "^16.6.1",
         "ganache": "^7.9.2",
         "keccak256": "^1.0.6",
         "merkletreejs": "^0.6.0",

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@openzeppelin/test-helpers": "^0.5.16",
     "@playwright/test": "^1.49.1",
     "@truffle/hdwallet-provider": "^2.1.15",
-    "dotenv": "^16.4.5",
+    "dotenv": "^16.6.1",
     "ganache": "^7.9.2",
     "keccak256": "^1.0.6",
     "merkletreejs": "^0.6.0",

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -13,6 +13,7 @@ const MockERC721 = artifacts.require("MockERC721");
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -58,6 +59,8 @@ contract("AGIJobManager admin ops", (accounts) => {
     agiTypeNft = await MockERC721.new({ from: owner });
     await manager.addAGIType(agiTypeNft.address, 92, { from: owner });
     await agiTypeNft.mint(agent, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("pauses and unpauses sensitive actions", async () => {

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -10,6 +10,7 @@ const MockERC721 = artifacts.require("MockERC721");
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -59,6 +60,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
     await manager.setRequiredValidatorApprovals(1, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("rejects agents with a 0% payout tier", async () => {

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -8,6 +8,7 @@ const MockERC721 = artifacts.require("MockERC721");
 
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -80,6 +81,8 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setDisputeReviewPeriod(100, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   async function createJob(payout) {

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -8,6 +8,7 @@ const MockERC721 = artifacts.require("MockERC721");
 
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -83,6 +84,8 @@ contract("AGIJobManager dispute hardening", (accounts) => {
     await manager.setRequiredValidatorApprovals(2, { from: owner });
     await manager.setRequiredValidatorDisapprovals(2, { from: owner });
     await manager.setDisputeReviewPeriod(100, { from: owner });
+
+    await fundValidators(token, manager, [validatorA, validatorB, validatorC], owner);
   });
 
   async function createJob(payout) {

--- a/test/erc20Compatibility.noReturn.test.js
+++ b/test/erc20Compatibility.noReturn.test.js
@@ -8,6 +8,7 @@ const MockNameWrapper = artifacts.require("MockNameWrapper");
 
 const { rootNode } = require("./helpers/ens");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 const { expectRevert } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
@@ -40,6 +41,8 @@ contract("AGIJobManager ERC20 compatibility", (accounts) => {
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });
     await manager.addAGIType(agiType.address, 60, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("accepts ERC20 tokens that return no data on transfer/transferFrom", async () => {

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -12,6 +12,7 @@ const MockNameWrapper = artifacts.require('MockNameWrapper');
 
 const { runExportMetrics } = require('../scripts/erc8004/export_metrics');
 const { buildInitConfig } = require('./helpers/deploy');
+const { fundValidators } = require('./helpers/bonds');
 
 const ZERO_ROOT = '0x' + '00'.repeat(32);
 const EMPTY_PROOF = [];
@@ -64,6 +65,8 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
     await manager.addAdditionalAgent(agent, { from: owner });
     await manager.addAdditionalValidator(validator, { from: owner });
     await manager.addModerator(moderator, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it('exports deterministic metrics and expected aggregates', async () => {

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -1,0 +1,11 @@
+async function fundValidators(token, manager, validators, owner, multiplier = 5) {
+  const bond = await manager.validatorBond();
+  const amount = bond.muln(multiplier);
+  for (const validator of validators) {
+    await token.mint(validator, amount, { from: owner });
+    await token.approve(manager.address, amount, { from: validator });
+  }
+  return bond;
+}
+
+module.exports = { fundValidators };

--- a/test/merkleAllowlist.test.js
+++ b/test/merkleAllowlist.test.js
@@ -12,6 +12,7 @@ const MockERC721 = artifacts.require("MockERC721");
 
 const { buildInitConfig } = require("./helpers/deploy");
 const { expectCustomError } = require("./helpers/errors");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const { toBN, toWei } = web3.utils;
@@ -54,6 +55,8 @@ contract("AGIJobManager Merkle allowlists", (accounts) => {
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("keeps allowlists as access-only (no payout boost)", async () => {

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -11,6 +11,7 @@ const { MerkleTree } = require("merkletreejs");
 const keccak256 = require("keccak256");
 const { namehash, subnode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 const { expectRevert } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
@@ -69,6 +70,8 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
     agiTypeNft = await MockERC721.new({ from: owner });
     await manager.addAGIType(agiTypeNft.address, 1, { from: owner });
     await agiTypeNft.mint(agent, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("authorizes an agent via NameWrapper ownership under alpha.agent", async () => {
@@ -169,6 +172,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
 
     await merkleManager.addAGIType(agiTypeNft.address, 1, { from: owner });
     await merkleManager.setRequiredValidatorApprovals(1, { from: owner });
+    await fundValidators(token, merkleManager, [validator], owner);
     await token.mint(employer, payout, { from: owner });
     await token.approve(merkleManager.address, payout, { from: employer });
     const jobId = (await merkleManager.nextJobId()).toNumber();

--- a/test/purchaseNFT.reentrancy.truffle.js
+++ b/test/purchaseNFT.reentrancy.truffle.js
@@ -6,6 +6,7 @@ const MockERC721 = artifacts.require("MockERC721");
 const ReentrantERC20 = artifacts.require("ReentrantERC20");
 
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -52,6 +53,8 @@ contract("AGIJobManager purchaseNFT reentrancy", (accounts) => {
     await manager.addAdditionalAgent(agent, { from: owner });
     await manager.addAdditionalValidator(validator, { from: owner });
     await manager.setRequiredValidatorApprovals(1, { from: owner });
+
+    await fundValidators(token, manager, [validator], owner);
   });
 
   it("allows purchases when reentrancy is disabled", async () => {

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -6,6 +6,7 @@ const MockERC20 = artifacts.require("MockERC20");
 const FailTransferToken = artifacts.require("FailTransferToken");
 const MockERC721 = artifacts.require("MockERC721");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const EMPTY_PROOF = [];
@@ -90,6 +91,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
 
     const original = await deployManager(AGIJobManagerOriginal, token.address, attacker, validator, owner);
     const current = await deployManager(AGIJobManager, token.address, attacker, validator, owner);
+    await fundValidators(token, current, [validator], owner);
 
     await original.applyForJob(0, "attacker", EMPTY_PROOF, { from: attacker });
     await token.approve(original.address, payout, { from: employer });
@@ -126,6 +128,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     assert.equal((await original.nextTokenId()).toNumber(), 2, "original should mint twice after dispute resolution");
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
+    await fundValidators(token, current, [validator], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
@@ -157,6 +160,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     assert.equal((await original.nextTokenId()).toNumber(), 0, "original should not mint on div-by-zero");
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
+    await fundValidators(token, current, [validator], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
@@ -187,6 +191,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     assert.equal(disapproveThenApproveJob.validatorDisapprovals.toNumber(), 1, "original should track disapprovals");
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
+    await fundValidators(token, current, [validator], owner);
     const nft = await MockERC721.new({ from: owner });
     await nft.mint(agent, { from: owner });
     await current.addAGIType(nft.address, 92, { from: owner });
@@ -226,6 +231,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     assert.equal((await original.nextTokenId()).toNumber(), 1, "original should still complete after employer win");
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
+    await fundValidators(token, current, [validator], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -10,6 +10,7 @@ const MockERC721 = artifacts.require("MockERC721");
 const { rootNode } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -50,6 +51,8 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await manager.addModerator(moderator, { from: owner });
     await manager.setRequiredValidatorApprovals(2, { from: owner });
     await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+
+    await fundValidators(token, manager, [validatorA, validatorB], owner);
   });
 
   async function createJob(payout, ipfsHash = "ipfs-job") {
@@ -121,12 +124,12 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     assert.equal(balancesAfter.agent.toString(), agentExpected.toString(), "agent payout should match expected share");
     assert.equal(
       balancesAfter.validatorA.toString(),
-      validatorExpected.toString(),
+      balancesBefore.validatorA.add(validatorExpected).toString(),
       "validator A payout should match expected share"
     );
     assert.equal(
       balancesAfter.validatorB.toString(),
-      validatorExpected.toString(),
+      balancesBefore.validatorB.add(validatorExpected).toString(),
       "validator B payout should match expected share"
     );
     assert.equal(balancesAfter.contract.toString(), "0", "escrow should clear after completion");
@@ -240,9 +243,8 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     assert.strictEqual(jobAfterAgentWin.disputed, false, "dispute flag should clear after resolution");
     const agentPayoutPct = toBN(jobAfterAgentWin.agentPayoutPct);
     const expectedAgentPayout = payout.mul(agentPayoutPct).divn(100);
-    const validationPct = toBN(await manager.validationRewardPercentage());
-    const expectedValidatorPayout = payout.mul(validationPct).divn(100);
-    const expectedRemaining = payout.sub(expectedAgentPayout).sub(expectedValidatorPayout);
+    const bond = await manager.validatorBond();
+    const expectedRemaining = payout.sub(expectedAgentPayout).add(bond.muln(2));
     assert.equal(
       (await token.balanceOf(manager.address)).toString(),
       expectedRemaining.toString(),
@@ -272,16 +274,33 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await manager.applyForJob(jobIdTwo, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobIdTwo, "ipfs-employer-win-complete", { from: agent });
 
-    await manager.disputeJob(jobIdTwo, { from: employer });
+    const validatorABefore = await token.balanceOf(validatorA);
+    const validatorBBefore = await token.balanceOf(validatorB);
+    await manager.disapproveJob(jobIdTwo, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await manager.disapproveJob(jobIdTwo, "validator-b", EMPTY_PROOF, { from: validatorB });
     await expectCustomError(manager.resolveDispute.call(jobIdTwo, "agent win", { from: other }), "NotModerator");
 
     const employerBefore = await token.balanceOf(employer);
     await manager.resolveDispute(jobIdTwo, "employer win", { from: moderator });
     const employerAfter = await token.balanceOf(employer);
+    const validatorRewardTotal = payoutTwo.mul(await manager.validationRewardPercentage()).divn(100);
+    const validatorReward = validatorRewardTotal.divn(2);
     assert.equal(
       employerAfter.toString(),
-      employerBefore.add(payoutTwo).toString(),
-      "employer should be refunded on employer win"
+      employerBefore.add(payoutTwo.sub(validatorRewardTotal)).toString(),
+      "employer should be refunded minus validator rewards on employer win"
+    );
+    const validatorAAfter = await token.balanceOf(validatorA);
+    const validatorBAfter = await token.balanceOf(validatorB);
+    assert.equal(
+      validatorAAfter.sub(validatorABefore).toString(),
+      validatorReward.toString(),
+      "disapproving validator A should earn rewards on employer win"
+    );
+    assert.equal(
+      validatorBAfter.sub(validatorBBefore).toString(),
+      validatorReward.toString(),
+      "disapproving validator B should earn rewards on employer win"
     );
     assert.equal((await manager.nextTokenId()).toNumber(), 1, "no NFT should mint on employer win");
     const jobAfterEmployerWin = await manager.getJobCore(jobIdTwo);


### PR DESCRIPTION
### Motivation

- Ensure validators have economic skin-in-the-game by collecting a fixed per-vote bond and accounting for locked bonds during settlement and owner withdrawals.  
- Update test expectations and fixtures to reflect bond locking/refunds/slashing and keep the exported UI ABI in sync with the contract surface.  

### Description

- Introduce a fixed `validatorBond` and `lockedValidatorBonds` in `AGIJobManager`, collect bonds on `validateJob`/`disapproveJob`, and include locked bonds in `withdrawableAGI()` calculations.  
- Implement bond-aware settlement: refund correct-side validators (bond + share of slashed bonds), slash incorrect validators' bonds, distribute validator rewards only to correct-side voters, and keep rewards in treasury if no correct-side validators exist.  
- Extract helper logic for reputation and validator settlement into `_computeReputationPoints` and `_settleValidators`, and add `_collectValidatorBond` for bond transfers.  
- Add `test/helpers/bonds.js` with `fundValidators()` and update many tests to mint/approve validator bond balances and adjust expected balances/escrow assertions accordingly.  
- Refresh UI ABI (`docs/ui/abi/AGIJobManager.json`) to include the new ABI entries and update `package.json`/`package-lock.json` metadata after installing `dotenv` for the test environment.  

### Testing

- Ran the full automated test suite via `npm run test` (which runs `truffle compile --all`, `truffle test --network test`, and other checks) and the run completed successfully with all tests passing (`217 passing`).  
- Executed targeted Truffle tests while iterating on fixes (e.g. dispute/economic scenario tests) and verified the updated ABI export (`npm run ui:abi`) completed successfully.  
- Verified bytecode size guard and ABI smoke tests as part of the test run and they passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983bf903cbc833381baf8a0416460fd)