### PR TITLE
Freeze per-job validator bonds, fix bond accounting, and align finalize flow/tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -113,8 +113,18 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint256 public disputeReviewPeriod = 14 days;
     uint256 internal constant MAX_REVIEW_PERIOD = 365 days;
     uint256 public additionalAgentPayoutPercentage = 50;
-    /// @notice Fixed bond required for each validator vote.
-    uint256 public constant validatorBond = 1e18;
+    /**
+     * @notice Validator bond/slashing parameters and challenge window.
+     * @dev Validators post a bond per vote; correct-side validators split rewards + slashed bonds.
+     *      Incorrect-side validators receive only the un-slashed bond portion. After approval
+     *      thresholds are met, a short challenge window prevents instant settlement. When validators
+     *      participate and the employer wins, the refund is reduced by the validator reward pool.
+     */
+    uint256 public validatorBondBps = 50;
+    uint256 public validatorBondMin = 1e18;
+    uint256 public validatorBondMax = 200e18;
+    uint256 public validatorSlashBps = 10_000;
+    uint256 public challengePeriodAfterApproval = 1 days;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -159,6 +169,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         bool expired;
         uint8 agentPayoutPct;
         bool escrowReleased;
+        bool validatorApproved;
+        uint256 validatorApprovedAt;
+        uint256 validatorBondAmount;
+        bool validatorBondSet;
     }
 
     struct AGIType {
@@ -315,12 +329,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (currentCount >= MAX_VALIDATORS_PER_JOB) revert ValidatorLimitReached();
     }
 
-    function _collectValidatorBond(address validator) internal {
-        uint256 bond = validatorBond;
-        _safeERC20TransferFromExact(agiToken, validator, address(this), bond);
-        unchecked {
-            lockedValidatorBonds += bond;
-        }
+    function _computeValidatorBond(uint256 payout) internal view returns (uint256 bond) {
+        bond = (payout * validatorBondBps) / 10_000;
+        if (bond < validatorBondMin) bond = validatorBondMin;
+        if (bond > validatorBondMax) bond = validatorBondMax;
     }
 
     function _maxAGITypePayoutPercentage() internal view returns (uint256) {
@@ -414,14 +426,32 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (job.approvals[msg.sender]) revert InvalidState();
         if (job.disapprovals[msg.sender]) revert InvalidState();
 
-        _collectValidatorBond(msg.sender);
+        uint256 bond = job.validatorBondAmount;
+        if (!job.validatorBondSet) {
+            bond = _computeValidatorBond(job.payout);
+            job.validatorBondAmount = bond;
+            job.validatorBondSet = true;
+        }
+        if (bond > 0) {
+            _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
+            unchecked {
+                lockedValidatorBonds += bond;
+            }
+        }
         _enforceValidatorCapacity(job.validators.length);
         job.validatorApprovals++;
         job.approvals[msg.sender] = true;
         job.validators.push(msg.sender);
         validatorVotedJobs[msg.sender].push(_jobId);
         emit JobValidated(_jobId, msg.sender);
-        if (job.validatorApprovals >= requiredValidatorApprovals) _completeJob(_jobId);
+        if (
+            !job.validatorApproved &&
+            requiredValidatorApprovals > 0 &&
+            job.validatorApprovals >= requiredValidatorApprovals
+        ) {
+            job.validatorApproved = true;
+            job.validatorApprovedAt = block.timestamp;
+        }
     }
 
     function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
@@ -437,7 +467,18 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (job.disapprovals[msg.sender]) revert InvalidState();
         if (job.approvals[msg.sender]) revert InvalidState();
 
-        _collectValidatorBond(msg.sender);
+        uint256 bond = job.validatorBondAmount;
+        if (!job.validatorBondSet) {
+            bond = _computeValidatorBond(job.payout);
+            job.validatorBondAmount = bond;
+            job.validatorBondSet = true;
+        }
+        if (bond > 0) {
+            _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
+            unchecked {
+                lockedValidatorBonds += bond;
+            }
+        }
         _enforceValidatorCapacity(job.validators.length);
         job.validatorDisapprovals++;
         job.disapprovals[msg.sender] = true;
@@ -609,6 +650,22 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         disputeReviewPeriod = _period;
         emit DisputeReviewPeriodUpdated(oldPeriod, _period);
     }
+    function setValidatorBondParams(uint256 bps, uint256 min, uint256 max) external onlyOwner {
+        if (bps > 10_000) revert InvalidParameters();
+        if (min > max) revert InvalidParameters();
+        if (max == 0) revert InvalidParameters();
+        validatorBondBps = bps;
+        validatorBondMin = min;
+        validatorBondMax = max;
+    }
+    function setValidatorSlashBps(uint256 bps) external onlyOwner {
+        if (bps > 10_000) revert InvalidParameters();
+        validatorSlashBps = bps;
+    }
+    function setChallengePeriodAfterApproval(uint256 period) external onlyOwner {
+        if (!(period > 0 && period <= MAX_REVIEW_PERIOD)) revert InvalidParameters();
+        challengePeriodAfterApproval = period;
+    }
     function setAdditionalAgentPayoutPercentage(uint256 _percentage) external onlyOwner {
         if (!(_percentage > 0 && _percentage <= 100)) revert InvalidParameters();
         if (_percentage > 100 - validationRewardPercentage) revert InvalidParameters();
@@ -750,16 +807,18 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         Job storage job = _job(_jobId);
         if (job.completed || job.expired || job.disputed) revert InvalidState();
         if (!job.completionRequested || job.completionRequestedAt == 0) revert InvalidState();
-        if (block.timestamp <= job.completionRequestedAt + completionReviewPeriod) revert InvalidState();
         if (requiredValidatorDisapprovals > 0 && job.validatorDisapprovals >= requiredValidatorDisapprovals) {
             revert InvalidState();
         }
 
-        if (requiredValidatorApprovals > 0 && job.validatorApprovals >= requiredValidatorApprovals) {
+        if (job.validatorApproved) {
+            if (block.timestamp <= job.validatorApprovedAt + challengePeriodAfterApproval) revert InvalidState();
             _completeJob(_jobId);
             emit JobFinalized(_jobId, job.assignedAgent, job.employer, true, job.payout);
             return;
         }
+
+        if (block.timestamp <= job.completionRequestedAt + completionReviewPeriod) revert InvalidState();
 
         bool agentWins;
         if (job.validatorApprovals == 0 && job.validatorDisapprovals == 0) {
@@ -787,14 +846,14 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 agentPayoutPercentage = job.agentPayoutPct;
         if (agentPayoutPercentage == 0) revert InvalidAgentPayoutSnapshot();
         uint256 validatorCount = job.validators.length;
+        uint256 escrowValidatorReward = validatorCount > 0
+            ? (job.payout * validationRewardPercentage) / 100
+            : 0;
         if (agentPayoutPercentage + (validatorCount > 0 ? validationRewardPercentage : 0) > 100) {
             revert InvalidParameters();
         }
         uint256 agentPayout = (job.payout * agentPayoutPercentage) / 100;
-        uint256 totalValidatorPayout = validatorCount > 0
-            ? (job.payout * validationRewardPercentage) / 100
-            : 0;
-        if (agentPayout + totalValidatorPayout > job.payout) revert InvalidParameters();
+        if (agentPayout + escrowValidatorReward > job.payout) revert InvalidParameters();
 
         job.completed = true;
         job.disputed = false;
@@ -805,7 +864,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
         _t(job.assignedAgent, agentPayout);
 
-        _settleValidators(job, true, reputationPoints, totalValidatorPayout);
+        _settleValidators(job, true, reputationPoints, escrowValidatorReward);
         _mintCompletionNFT(job);
 
         emit JobCompleted(_jobId, job.assignedAgent, reputationPoints);
@@ -815,27 +874,61 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         Job storage job,
         bool agentWins,
         uint256 reputationPoints,
-        uint256 totalValidatorPayout
+        uint256 escrowValidatorReward
     ) internal {
-        // Correct-side validators receive rewards + bond refunds; incorrect bonds are slashed.
-        // If no validators are on the correct side, rewards and slashed bonds remain in treasury.
         uint256 vCount = job.validators.length;
-        if (vCount > MAX_VALIDATORS_PER_JOB) revert ValidatorSetTooLarge();
-        uint256 correctCount = agentWins ? job.validatorApprovals : job.validatorDisapprovals;
-        uint256 bond = validatorBond;
-        unchecked {
-            lockedValidatorBonds -= bond * vCount;
+        if (vCount == 0) {
+            return;
         }
-        uint256 slashedTotal = bond * (vCount - correctCount);
-        uint256 validatorPayout = correctCount > 0 ? totalValidatorPayout / correctCount : 0;
+        if (vCount > MAX_VALIDATORS_PER_JOB) revert ValidatorSetTooLarge();
+        uint256 bond = job.validatorBondAmount;
+        if (bond != 0) {
+            unchecked {
+                lockedValidatorBonds -= bond * vCount;
+            }
+            job.validatorBondAmount = 0;
+        }
+        uint256 correctCount = agentWins ? job.validatorApprovals : job.validatorDisapprovals;
+        (uint256 perCorrectReward, uint256 refundWrong) =
+            _computeValidatorRewards(bond, vCount, correctCount, escrowValidatorReward);
+        _applyValidatorPayouts(job, agentWins, bond, perCorrectReward, refundWrong, reputationPoints);
+    }
+
+    function _computeValidatorRewards(
+        uint256 bond,
+        uint256 vCount,
+        uint256 correctCount,
+        uint256 escrowValidatorReward
+    )
+        internal
+        view
+        returns (uint256 perCorrectReward, uint256 refundWrong)
+    {
+        uint256 slashedPerIncorrect = (bond * validatorSlashBps) / 10_000;
+        refundWrong = bond - slashedPerIncorrect;
+        uint256 totalSlashed = slashedPerIncorrect * (vCount - correctCount);
+        uint256 poolForCorrect = escrowValidatorReward + totalSlashed;
+        if (correctCount > 0) {
+            perCorrectReward = poolForCorrect / correctCount;
+        }
+    }
+
+    function _applyValidatorPayouts(
+        Job storage job,
+        bool agentWins,
+        uint256 bond,
+        uint256 perCorrectReward,
+        uint256 refundWrong,
+        uint256 reputationPoints
+    ) internal {
+        uint256 vCount = job.validators.length;
         uint256 validatorReputationGain = (reputationPoints * validationRewardPercentage) / 100;
         for (uint256 i = 0; i < vCount; ) {
             address validator = job.validators[i];
             bool correct = agentWins ? job.approvals[validator] : job.disapprovals[validator];
-            if (correct) {
-                uint256 bondRefund = bond + (slashedTotal / correctCount);
-                uint256 reward = validatorPayout;
-                _t(validator, bondRefund + reward);
+            uint256 payout = correct ? bond + perCorrectReward : refundWrong;
+            _t(validator, payout);
+            if (correct && validatorReputationGain > 0) {
                 enforceReputationGrowth(validator, validatorReputationGain);
             }
             unchecked {
@@ -875,17 +968,27 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         job.disputedAt = 0;
         _releaseEscrow(job);
         uint256 validatorCount = job.validators.length;
-        uint256 totalValidatorPayout = validatorCount > 0
+        uint256 escrowValidatorReward = validatorCount > 0
             ? (job.payout * validationRewardPercentage) / 100
             : 0;
-        uint256 employerRefund = totalValidatorPayout > 0 ? job.payout - totalValidatorPayout : job.payout;
-        uint256 reputationPoints = _computeReputationPoints(job);
-        _settleValidators(job, false, reputationPoints, totalValidatorPayout);
+        uint256 employerRefund = escrowValidatorReward > 0 ? job.payout - escrowValidatorReward : job.payout;
+        uint256 completionTime = job.completionRequestedAt > job.assignedAt
+            ? job.completionRequestedAt - job.assignedAt
+            : 0;
+        uint256 reputationPoints = _computeReputationPointsWithTime(job, completionTime);
+        _settleValidators(job, false, reputationPoints, escrowValidatorReward);
         _t(job.employer, employerRefund);
     }
 
     function _computeReputationPoints(Job storage job) internal view returns (uint256 reputationPoints) {
         uint256 completionTime = block.timestamp - job.assignedAt;
+        return _computeReputationPointsWithTime(job, completionTime);
+    }
+
+    function _computeReputationPointsWithTime(
+        Job storage job,
+        uint256 completionTime
+    ) internal view returns (uint256 reputationPoints) {
         unchecked {
             uint256 scaledPayout = job.payout / 1e18;
             uint256 payoutPoints = scaledPayout ** 3 / 1e5;

--- a/docs/AGIJobManager_Security.md
+++ b/docs/AGIJobManager_Security.md
@@ -20,6 +20,7 @@ The contract explicitly addresses common issues observed in earlier variants:
 - **Division by zero on validator payouts**: validator payouts are only computed if `validators.length > 0`; otherwise, validator payout is zero.
 - **Employer‑win double completion**: `_refundEmployer` marks the job as completed and releases escrow, preventing additional settlement paths.
 - **Unchecked ERC‑20 transfers**: `_callOptionalReturn` and `_safeERC20TransferFromExact` enforce successful transfers and exact amount receipt; fee‑on‑transfer or non‑standard tokens will revert.
+- **Validator bonds & slashing**: bonded voting is accounted via `lockedValidatorBonds` and released on settlement; incorrect votes are slashed, while correct votes receive rewards.
 
 ## Remaining risks and assumptions
 

--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -42,8 +42,8 @@ The job struct encodes the state machine via fields like `assignedAgent`, `compl
 1. `createJob` escrows `payout` (increasing `lockedEscrow`).
 2. `applyForJob` assigns an agent and snapshots `agentPayoutPct`.
 3. `requestJobCompletion` stores completion metadata.
-4. Validators call `validateJob` until `requiredValidatorApprovals` is reached.
-5. `_completeJob` releases escrow, pays agent + approving validators, updates reputation, and mints the completion NFT.
+4. Validators call `validateJob` until `requiredValidatorApprovals` is reached (bonded voting).
+5. After the challenge window, `finalizeJob` releases escrow, pays the agent, settles validators by outcome, and mints the completion NFT.
 
 **Dispute path (example)**
 1. After completion request, validators disapprove or employer/agent calls `disputeJob`.
@@ -131,7 +131,7 @@ Pause is an incident‑response control to halt new activity while preserving ex
 ### Reputation system (as implemented)
 - Agent reputation uses `reputationPoints = log2(1 + payoutPoints * 1e6) + completionTime / 10000`, with `payoutPoints = (scaledPayout^3) / 1e5`.
 - Reputation is then **diminished** by `1 + (newReputation^2 / 88888^2)` and capped at **88888**.
-- Validator payouts/reputation are only for approving validators; disapprovers receive nothing.
+- Validator payouts/reputation are outcome‑aligned: correct‑side voters earn rewards, incorrect‑side voters are slashed.
 - `premiumReputationThreshold` gates `canAccessPremiumFeature(address)` (pure threshold check; no time decay).
 
 ## 8) EIP‑170 bytecode size & build reproducibility

--- a/docs/roles/AGENT.md
+++ b/docs/roles/AGENT.md
@@ -31,7 +31,8 @@ Generate/upload the **job completion metadata** JSON and call `requestJobComplet
 - State: job’s `jobCompletionURI` updated
 
 ### 4) Wait for validator approvals
-Once enough validators approve, the job completes automatically and you are paid.
+Once enough validators approve, a short challenge window opens. After it elapses (and if no dispute is raised),
+anyone can finalize the job to pay the agent.
 
 ## What you receive
 - **AGI payout** (possibly boosted by AGIType NFT holdings)

--- a/docs/roles/VALIDATOR.md
+++ b/docs/roles/VALIDATOR.md
@@ -16,6 +16,7 @@ Call `validateJob(jobId, subdomain, proof)`.
 **On‑chain results**
 - Event: `JobValidated`
 - State: validator approval count increments
+- Bond: the contract transfers the required bond from your wallet (ensure allowance)
 
 ### 2) Disapprove a job (if needed)
 Call `disapproveJob(jobId, subdomain, proof)`.
@@ -24,6 +25,7 @@ Call `disapproveJob(jobId, subdomain, proof)`.
 - Event: `JobDisapproved`
 - State: validator disapproval count increments
 - If disapprovals reach the threshold, the job becomes disputed.
+- Bond: the same per‑job bond is posted for disapprovals.
 
 ## Vote rules (strict)
 - A validator **cannot vote twice**.
@@ -31,8 +33,9 @@ Call `disapproveJob(jobId, subdomain, proof)`.
 
 ## Rewards
 When a job completes:
-- Validators split a fixed percentage of the payout (`validationRewardPercentage`).
-- Validators gain reputation points.
+- Validators whose vote matches the final outcome split the reward pool and any slashed bonds.
+- Validators who vote against the final outcome recover only the un‑slashed portion of their bond.
+- Correct‑side validators gain reputation points.
 
 ## Common mistakes
 - Voting twice → `InvalidState`

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1135,6 +1135,19 @@
     },
     {
       "inputs": [],
+      "name": "challengePeriodAfterApproval",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "clubRootNode",
       "outputs": [
         {
@@ -1652,7 +1665,33 @@
     },
     {
       "inputs": [],
-      "name": "validatorBond",
+      "name": "validatorBondBps",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorBondMax",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorBondMin",
       "outputs": [
         {
           "internalType": "uint256",
@@ -1671,6 +1710,19 @@
           "internalType": "bytes32",
           "name": "",
           "type": "bytes32"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "validatorSlashBps",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -2168,6 +2220,55 @@
         }
       ],
       "name": "setDisputeReviewPeriod",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bps",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "min",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "max",
+          "type": "uint256"
+        }
+      ],
+      "name": "setValidatorBondParams",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bps",
+          "type": "uint256"
+        }
+      ],
+      "name": "setValidatorSlashBps",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "period",
+          "type": "uint256"
+        }
+      ],
+      "name": "setChallengePeriodAfterApproval",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -5,7 +5,7 @@ const keccak256 = require("keccak256");
 const { expectCustomError } = require("./helpers/errors");
 const { rootNode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, computeValidatorBond } = require("./helpers/bonds");
 
 const AGIJobManager = artifacts.require("AGIJobManager");
 const MockERC20 = artifacts.require("MockERC20");
@@ -117,6 +117,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
     await agiTypeNft.mint(agent);
 
     await fundValidators(token, manager, [validatorOne, validatorTwo, validatorThree], owner);
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
   });
 
   describe("deployment & initialization", () => {
@@ -182,7 +183,9 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       await validateWithProof(0, validatorOne);
       await validateWithProof(0, validatorTwo);
-      const completionReceipt = await validateWithProof(0, validatorThree);
+      await validateWithProof(0, validatorThree);
+      await time.increase(2);
+      const completionReceipt = await manager.finalizeJob(0, { from: employer });
       expectEvent(completionReceipt, "JobCompleted", { jobId: new BN(0), agent });
 
       const finalJob = await manager.getJobCore(0);
@@ -191,13 +194,14 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       const validatorPayoutTotal = payout.muln(8).divn(100);
       const validatorPayoutEach = validatorPayoutTotal.divn(3);
       const agentPayout = payout.muln(92).divn(100);
+      const expectedAgentPayout = agentPayout;
 
       const agentBalanceAfter = await token.balanceOf(agent);
       const validatorOneBalanceAfter = await token.balanceOf(validatorOne);
       const validatorTwoBalanceAfter = await token.balanceOf(validatorTwo);
       const validatorThreeBalanceAfter = await token.balanceOf(validatorThree);
 
-      assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), agentPayout.toString());
+      assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expectedAgentPayout.toString());
       assert.equal(
         validatorOneBalanceAfter.sub(validatorOneBalanceBefore).toString(),
         validatorPayoutEach.toString()
@@ -281,6 +285,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.applyForJob(0, "agent", [], { from: agent });
       await requestCompletion(0);
       await manager.validateJob(0, "validator", [], { from: validatorOne });
+      await time.increase(2);
+      await manager.finalizeJob(0, { from: employer });
 
       await expectCustomError(
         manager.validateJob.call(0, "validator", [], { from: validatorOne }),
@@ -304,6 +310,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.applyForJob(0, "agent", [], { from: agent });
       await requestCompletion(0);
       await manager.validateJob(0, "validator", [], { from: validatorOne });
+      await time.increase(2);
+      await manager.finalizeJob(0, { from: employer });
 
       const tokenIdAfterCompletion = await manager.nextTokenId();
       await expectCustomError(
@@ -527,6 +535,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.applyForJob(0, "agent", [], { from: agent });
       await requestCompletion(0);
       await manager.validateJob(0, "validator", [], { from: validatorOne });
+      await time.increase(2);
+      await manager.finalizeJob(0, { from: employer });
       await expectCustomError(manager.disputeJob.call(0, { from: employer }), "InvalidState");
     });
   });
@@ -615,6 +625,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await altManager.addAdditionalAgent(agent, { from: owner });
       await altManager.addAdditionalValidator(validatorOne, { from: owner });
       await altManager.setRequiredValidatorApprovals(1, { from: owner });
+      await altManager.setChallengePeriodAfterApproval(1, { from: owner });
       await altManager.addAGIType(agiTypeNft.address, 92, { from: owner });
       await agiTypeNft.mint(agent);
 
@@ -622,13 +633,15 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await altManager.createJob(jobIpfs, payout, duration, jobDetails, { from: employer });
       await altManager.applyForJob(0, "agent", [], { from: agent });
       await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
-      const bond = await altManager.validatorBond();
+      const bond = await computeValidatorBond(altManager, payout);
       await failingToken.mint(validatorOne, bond, { from: owner });
       await failingToken.approve(altManager.address, bond, { from: validatorOne });
 
+      await altManager.validateJob(0, "validator", [], { from: validatorOne });
       await failingToken.setFailTransfers(true);
+      await time.increase(2);
       await expectCustomError(
-        altManager.validateJob.call(0, "validator", [], { from: validatorOne }),
+        altManager.finalizeJob.call(0, { from: employer }),
         "TransferFailed"
       );
       const job = await altManager.getJobCore(0);
@@ -663,7 +676,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await altManager.addAdditionalValidator(validatorOne, { from: owner });
       await altManager.setRequiredValidatorApprovals(1, { from: owner });
       await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
-      const bond = await altManager.validatorBond();
+      const bond = await computeValidatorBond(altManager, payout);
       await failingToken.mint(validatorOne, bond, { from: owner });
       await failingToken.approve(altManager.address, bond, { from: validatorOne });
       await altManager.validateJob(0, "validator", [], { from: validatorOne });
@@ -782,6 +795,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await assignAgentWithProof(completedJobId);
       await requestCompletion(completedJobId);
       await validateWithProof(completedJobId, validatorOne);
+      await time.increase(2);
+      await manager.finalizeJob(completedJobId, { from: employer });
 
       await manager.pause({ from: owner });
       await expectCustomError(

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -12,7 +12,7 @@ const MockNameWrapper = artifacts.require("MockNameWrapper");
 
 const { rootNode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, computeValidatorBond } = require("./helpers/bonds");
 
 const EMPTY_PROOF = [];
 
@@ -97,6 +97,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       agentMerkleRoot: agentMerkle.root,
       owner,
     });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(1, { from: owner });
@@ -177,6 +178,8 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       const validatorBalanceBefore = await token.balanceOf(validator);
 
       await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
+      await time.increase(2);
+      await manager.finalizeJob(jobId, { from: employer });
 
       const agentBalanceAfter = await token.balanceOf(agent);
       const validatorBalanceAfter = await token.balanceOf(validator);
@@ -218,6 +221,8 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
       await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
       await manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
+      await time.increase(2);
+      await manager.finalizeJob(jobId, { from: employer });
 
       await expectRevert.unspecified(
         manager.validateJob(jobId, "validator", validatorMerkle.proofFor(validatorTwo), { from: validatorTwo })
@@ -366,6 +371,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
         owner,
       });
       await failingManager.setRequiredValidatorApprovals(1, { from: owner });
+      await failingManager.setChallengePeriodAfterApproval(1, { from: owner });
 
       const jobId = await createJob({
         manager: failingManager,
@@ -379,12 +385,14 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await failingManager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
       await failingManager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
-      const bond = await failingManager.validatorBond();
+      const bond = await computeValidatorBond(failingManager, web3.utils.toBN(web3.utils.toWei("50")));
       await failingToken.mint(validator, bond, { from: owner });
       await failingToken.approve(failingManager.address, bond, { from: validator });
+      await failingManager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator });
       await failingToken.setFailTransfers(true, { from: owner });
+      await time.increase(2);
       await expectRevert.unspecified(
-        failingManager.validateJob(jobId, "validator", validatorMerkle.proofFor(validator), { from: validator })
+        failingManager.finalizeJob(jobId, { from: employer })
       );
     });
 

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -11,6 +11,7 @@ const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
 const { fundValidators } = require("./helpers/bonds");
+const { time } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -60,6 +61,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
     await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
   });
@@ -93,6 +95,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
 
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
     const expected = payout.muln(75).divn(100);
@@ -120,6 +124,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
 
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
     const expected = payout.muln(25).divn(100);
@@ -158,6 +164,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
 
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
     const expected = payout.muln(60).divn(100);

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -1,5 +1,5 @@
 const assert = require("assert");
-const { BN, expectEvent, expectRevert } = require("@openzeppelin/test-helpers");
+const { BN, expectEvent, expectRevert, time } = require("@openzeppelin/test-helpers");
 
 const AGIJobManager = artifacts.require("AGIJobManager");
 const MockERC20 = artifacts.require("MockERC20");
@@ -8,7 +8,7 @@ const MockENS = artifacts.require("MockENS");
 const MockResolver = artifacts.require("MockResolver");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, computeValidatorBond } = require("./helpers/bonds");
 
 const ZERO_BYTES32 = "0x" + "0".repeat(64);
 const EMPTY_PROOF = [];
@@ -95,6 +95,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await manager.addAGIType(nft.address, 92, { from: owner });
     await nft.mint(agent, { from: owner });
@@ -161,7 +162,9 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     const validator3Before = await token.balanceOf(validator3);
     await manager.validateJob(jobId, subdomains.validatorPrimary, EMPTY_PROOF, { from: validator1 });
     await manager.validateJob(jobId, subdomains.validator2, EMPTY_PROOF, { from: validator2 });
-    const receipt = await manager.validateJob(jobId, subdomains.validator3, EMPTY_PROOF, { from: validator3 });
+    await manager.validateJob(jobId, subdomains.validator3, EMPTY_PROOF, { from: validator3 });
+    await time.increase(2);
+    const receipt = await manager.finalizeJob(jobId, { from: employer });
 
     expectEvent(receipt, "JobCompleted", {
       jobId: new BN(jobId),
@@ -283,7 +286,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
 
     await manager.setRequiredValidatorApprovals(3, { from: owner });
     await manager.validateJob(jobId, subdomains.validator3, EMPTY_PROOF, { from: validator3 });
-    const bond = await manager.validatorBond();
+    const bond = await computeValidatorBond(manager, payout);
     await token.mint(other, bond, { from: owner });
     await token.approve(manager.address, bond, { from: other });
     await manager.validateJob(jobId, subdomains.validator4, EMPTY_PROOF, { from: other });

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -145,10 +145,14 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
 
   it("mints completion NFTs using the completion metadata URI", async () => {
     const jobId = await createJob(toBN(toWei("9")));
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
-    const tx = await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await advanceTime(2);
+    const tx = await manager.finalizeJob(jobId, { from: employer });
 
     const issued = tx.logs.find((log) => log.event === "NFTIssued");
     assert.ok(issued, "NFTIssued event should be emitted");

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -6,6 +6,7 @@ const MockENS = artifacts.require("MockENS");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
 const MockERC721 = artifacts.require("MockERC721");
 
+const { time } = require("@openzeppelin/test-helpers");
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
@@ -134,8 +135,12 @@ contract("AGIJobManager economic safety", (accounts) => {
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
     const validatorBefore = await token.balanceOf(validator);
     await manager.validateJob(jobId, "validator", EMPTY_PROOF, { from: validator });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalance = await token.balanceOf(agent);
     const validatorBalance = await token.balanceOf(validator);

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -3,6 +3,8 @@ const fs = require('fs');
 const os = require('os');
 const path = require('path');
 
+const { time } = require('@openzeppelin/test-helpers');
+
 const AGIJobManager = artifacts.require('AGIJobManager');
 const MockERC20 = artifacts.require('MockERC20');
 const MockENS = artifacts.require('MockENS');
@@ -74,6 +76,9 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
     await manager.applyForJob(jobId1, 'agent', EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId1, 'ipfs-complete', { from: agent });
     await manager.validateJob(jobId1, 'club', EMPTY_PROOF, { from: validator });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+    await time.increase(2);
+    await manager.finalizeJob(jobId1, { from: employer });
 
     const jobId2 = await createJob();
     await manager.applyForJob(jobId2, 'agent', EMPTY_PROOF, { from: agent });

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -1,11 +1,23 @@
 async function fundValidators(token, manager, validators, owner, multiplier = 5) {
-  const bond = await manager.validatorBond();
-  const amount = bond.muln(multiplier);
+  const bondMax = await manager.validatorBondMax();
+  const amount = bondMax.muln(multiplier);
   for (const validator of validators) {
     await token.mint(validator, amount, { from: owner });
     await token.approve(manager.address, amount, { from: validator });
   }
+  return bondMax;
+}
+
+async function computeValidatorBond(manager, payout) {
+  const [bps, min, max] = await Promise.all([
+    manager.validatorBondBps(),
+    manager.validatorBondMin(),
+    manager.validatorBondMax(),
+  ]);
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
   return bond;
 }
 
-module.exports = { fundValidators };
+module.exports = { fundValidators, computeValidatorBond };

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -84,6 +84,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.setRequiredValidatorDisapprovals(2, { from: owner });
     await manager.setCompletionReviewPeriod(100, { from: owner });
     await manager.setDisputeReviewPeriod(100, { from: owner });
+    await manager.setChallengePeriodAfterApproval(100, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
   });

--- a/test/merkleAllowlist.test.js
+++ b/test/merkleAllowlist.test.js
@@ -10,6 +10,7 @@ const MockResolver = artifacts.require("MockResolver");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
 const MockERC721 = artifacts.require("MockERC721");
 
+const { time } = require("@openzeppelin/test-helpers");
 const { buildInitConfig } = require("./helpers/deploy");
 const { expectCustomError } = require("./helpers/errors");
 const { fundValidators } = require("./helpers/bonds");
@@ -89,6 +90,9 @@ contract("AGIJobManager Merkle allowlists", (accounts) => {
 
     const before = await token.balanceOf(agent);
     await manager.validateJob(jobId, "ignored", tree.getHexProof(validatorLeaf), { from: validator });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
     const after = await token.balanceOf(agent);
 
     const expected = payout.muln(payoutTier).divn(100);

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -11,7 +11,7 @@ const FailingERC20 = artifacts.require("FailingERC20");
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, computeValidatorBond } = require("./helpers/bonds");
 const { time } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
@@ -337,10 +337,10 @@ contract("AGIJobManager security regressions", (accounts) => {
     await managerFailing.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await managerFailing.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
-    const bond = await managerFailing.validatorBond();
+    const bond = await computeValidatorBond(managerFailing, toBN(toWei("10")));
     await failing.mint(validator, bond, { from: owner });
     await failing.approve(managerFailing.address, bond, { from: validator });
-    await failing.setFailTransfers(true, { from: owner });
+    await failing.setFailTransferFroms(true, { from: owner });
     await expectCustomError(
       managerFailing.validateJob.call(jobId, "validator", EMPTY_PROOF, { from: validator }),
       "TransferFailed"


### PR DESCRIPTION
### Motivation
- Prevent locked validator bond underflow when global bond params change mid‑flight by freezing per‑job bond values once a validator first votes. 
- Ensure validator settlement leaves rounding/remainder amounts in treasury rather than accidentally double‑paying or underflowing escrow accounting. 
- Make settlement deterministic by separating instantaneous approval from final settlement via a short challenge window and updating tests to use the `finalizeJob` flow.

### Description
- Freeze per‑job bond: added `validatorBondSet` to `Job` and compute/store a per‑job `validatorBondAmount` on the first `validateJob`/`disapproveJob` call to avoid mixed‑epoch accounting. 
- Safe bond accounting: only subtract `lockedValidatorBonds` for the actual per‑job collected bonds and clear `job.validatorBondAmount` during settlement. 
- Reward plumbing: changed `_computeValidatorRewards` to return `(perCorrectReward, refundWrong)` and altered `_settleValidators`/_apply payouts so any distribution remainder stays in treasury. 
- Config & finalize window: introduced `validatorBondBps`, `validatorBondMin`, `validatorBondMax`, `validatorSlashBps`, `challengePeriodAfterApproval`, and setters `setValidatorBondParams`, `setValidatorSlashBps`, `setChallengePeriodAfterApproval`; moved to explicit `finalizeJob` flow that enforces the challenge window. 
- Tests & helpers: updated many tests to set `challengePeriodAfterApproval` and call `finalizeJob` (or advance time) where approvals require the challenge window, added `computeValidatorBond` and adjusted `fundValidators` in `test/helpers/bonds.js`, and exported updated ABI at `docs/ui/abi/AGIJobManager.json`.

### Testing
- Ran the full test suite via `npm run test` (Truffle compile + truffle tests + ABI smoke + size checks), which completed successfully with `187 passing` tests. 
- Verified ABI export with `npm run ui:abi` and updated `docs/ui/abi/AGIJobManager.json`. 
- Confirmed runtime deployed bytecode size remains under EIP‑170 limits (`AGIJobManager deployedBytecode size: 24526 bytes`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6983f8cf309c8333907b3688ccf8955d)