### PR TITLE
Align validator bonds and settlement with job outcomes

### DIFF
--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -14,6 +14,9 @@ async function computeValidatorBond(manager, payout) {
     manager.validatorBondMin(),
     manager.validatorBondMax(),
   ]);
+  if (bps.isZero() && min.isZero() && max.isZero()) {
+    return payout.muln(0);
+  }
   let bond = payout.mul(bps).divn(10000);
   if (bond.lt(min)) bond = min;
   if (bond.gt(max)) bond = max;


### PR DESCRIPTION
### Motivation
- Reduce approval race incentives and make validator economics symmetric so validators are rewarded when they vote with the final outcome and suffer on-chain slashing when they vote against it.
- Preserve the existing owner/moderator trust model, ENS identity checks, pause semantics, escrow safety, and bounded validator loops while keeping changes minimal and bytecode-conscious.
- Add a short challenge window to avoid instant settlement when approval thresholds are reached and allow disputes during that window.

### Description
- Introduced per-job validator bond snapshotting (`job.validatorBondAmount`), required bond transfers in `validateJob` and `disapproveJob`, and `ValidatorBonded` events for compact auditability.
- Replaced instant settlement on reaching approval threshold with a flag/timestamp (`validatorApproved`, `validatorApprovedAt`) and a challenge window (`challengePeriodAfterApproval`) with owner-setter and event emissions.
- Implemented outcome-aligned validator settlement in `_settleValidators` that: unblocks/updates `lockedValidatorBonds`, computes slashing per incorrect vote, combines slashed bonds with the `validationRewardPercentage` escrow to form a pool for correct validators, pays correct/incorrect validators accordingly, forwards any remainder to the winning party, grants reputation only to correct-side validators, and emits `ValidatorsSettled`.
- Updated completion/refund flows to call the symmetric settlement routine: `_completeJob` and `_refundEmployer` now invoke `_settleValidators` and adjust employer refunds to exclude validator reward pool when validators participated.
- Added compact owner-configurable parameters and events: `setValidatorBondParams`, `setValidatorSlashBps`, `setChallengePeriodAfterApproval` with safety checks and events `ValidatorBondParamsUpdated`, `ValidatorSlashBpsUpdated`, `ChallengePeriodAfterApprovalUpdated`.
- Kept ENS/merkle checks, pause semantics, escrow accounting, MAX_VALIDATORS_PER_JOB, and ERC721 NFT minting behavior unchanged; only the minimal plumbing for bonding/slashing/settlement was appended and reused existing structures to limit bytecode growth.
- Tests: updated `test/helpers/bonds.js` to handle the disabled-bonds edge case, and adjusted `test/escrowAccounting.test.js` to assert multi-validator splits and added a validator in that scenario.

### Testing
- Attempted to run the repository scripts: `npm run build`, `npm run size`, and `npm run test` to compile and execute the test-suite, but the environment lacks Truffle and compiled artifacts so these commands failed (errors: `truffle: not found` and missing Truffle artifacts). No on-chain tests executed locally as a result.
- Unit-test changes were added (`test/escrowAccounting.test.js`, `test/helpers/bonds.js`) to cover: bond posting/allowance, correct-side rewards and slashing behavior, locked validator bonds blocking `withdrawAGI`, approval threshold no longer causing instant completion, and challenge-window enforcement; these tests are intended to run in CI where Truffle is available.
- All code changes are limited to `contracts/AGIJobManager.sol` and small test helper/test updates; CI bytecode-size checks should be run in the project CI to confirm contract remains under EIP-170 in the repository build environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984147df0ac83339b23d91b809396d6)