### PR TITLE
Add agent performance bonds, per-agent active-job cap, and abandon flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,10 +25,11 @@
 
 ## Important trust notes
 - **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
-- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`) and only while paused; escrowed funds are not withdrawable.
+- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, validator bonds, and agent bonds) and only while paused; escrowed and bonded funds are not withdrawable.
 - **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available.
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 - **Validator incentives**: validators post a bond per vote, earn rewards when their vote matches the final outcome, and are slashed when they are wrong.
+- **Agent bonds**: assigned agents post a performance bond (percentage of payout, with min/max). Bonds are refunded on agent wins; they are slashed to the employer (plus any configured refund to the agent) on employer wins, expiry, or abandonment. Agents must approve AGI for the bond before applying.
 
 **Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
 
@@ -112,7 +113,7 @@ flowchart LR
 
 | Role | Capabilities | Trust considerations |
 | --- | --- | --- |
-| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw surplus ERC‑20 (balance minus locked escrow). | Highly privileged. Compromise or misuse can override operational safety. |
+| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw surplus ERC‑20 (balance minus locked escrow and bonded funds). | Highly privileged. Compromise or misuse can override operational safety. |
 | **Moderator** | Resolve disputes via `resolveDispute`. | Central dispute authority; outcomes depend on moderator integrity. |
 | **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
 | **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -106,6 +106,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await token.mint(employer, payout.muln(5));
     await token.mint(agent, payout);
@@ -560,6 +562,12 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
           agentTree.root,
         )
       );
+      await altManager.setAgentBondParams(0, 0, 0, { from: owner });
+      await altManager.setMaxActiveJobsPerAgent(50, { from: owner });
+      await altManager.setAgentBondParams(0, 0, 0, { from: owner });
+      await altManager.setMaxActiveJobsPerAgent(50, { from: owner });
+      await altManager.setAgentBondParams(0, 0, 0, { from: owner });
+      await altManager.setMaxActiveJobsPerAgent(50, { from: owner });
 
       await failingToken.approve(altManager.address, payout, { from: employer });
       await expectCustomError(
@@ -586,6 +594,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
           agentTree.root,
         )
       );
+      await altManager.setAgentBondParams(0, 0, 0, { from: owner });
+      await altManager.setMaxActiveJobsPerAgent(50, { from: owner });
       await altManager.addAdditionalAgent(agent, { from: owner });
       await altManager.addAGIType(agiTypeNft.address, 92, { from: owner });
       await agiTypeNft.mint(agent);

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -43,7 +43,7 @@ async function deployManager({
 }) {
   const resolvedAlphaValidatorRootNode = alphaValidatorRootNode || validatorRootNode;
   const resolvedAlphaAgentRootNode = alphaAgentRootNode || agentRootNode;
-  return AGIJobManager.new(...buildInitConfig(
+  const manager = await AGIJobManager.new(...buildInitConfig(
       token.address,
       "ipfs://base",
       ens.address,
@@ -57,6 +57,9 @@ async function deployManager({
     ),
     { from: owner }
   );
+  await manager.setAgentBondParams(0, 0, 0, { from: owner });
+  await manager.setMaxActiveJobsPerAgent(50, { from: owner });
+  return manager;
 }
 
 async function createJob({ manager, token, employer, payout, duration = 1000, ipfsHash = "job1" }) {

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -179,6 +179,8 @@ contract("AGIJobManager comprehensive", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
     await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await token.mint(employer, web3.utils.toWei("500"), { from: owner });
@@ -671,6 +673,12 @@ contract("AGIJobManager comprehensive", (accounts) => {
         ),
         { from: owner }
       );
+      await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+      await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
+      await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+      await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
+      await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+      await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
 
       await failing.setFailTransferFroms(true, { from: owner });
       await failing.approve(managerFailing.address, web3.utils.toWei("5"), { from: employer });
@@ -972,6 +980,8 @@ contract("AGIJobManager comprehensive", (accounts) => {
         ),
         { from: owner }
       );
+      await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+      await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
 
       await failTransferToken.approve(managerFailing.address, payout, { from: employer });
       await managerFailing.createJob("ipfs", payout, 1000, "details", { from: employer });

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -53,6 +53,8 @@ contract("AGIJobManager admin ops", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
@@ -178,6 +180,8 @@ contract("AGIJobManager admin ops", (accounts) => {
       ),
       { from: owner }
     );
+    await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+    await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await failing.transfer(managerFailing.address, toBN(toWei("2")), { from: owner });
     await failing.setFailTransfers(true, { from: owner });

--- a/test/agentIncentives.test.js
+++ b/test/agentIncentives.test.js
@@ -1,0 +1,154 @@
+const assert = require("assert");
+
+const { expectRevert, time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { computeAgentBond } = require("./helpers/bonds");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager agent incentives", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 80, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+  });
+
+  const createJob = async (payout) => {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const receipt = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    return receipt.logs[0].args.jobId.toNumber();
+  };
+
+  const fundAgentBond = async (payout) => {
+    const bond = await computeAgentBond(manager, payout);
+    if (bond.gt(toBN(0))) {
+      await token.mint(agent, bond, { from: owner });
+      await token.approve(manager.address, bond, { from: agent });
+    }
+    return bond;
+  };
+
+  it("refunds agent bonds on agent wins and clears active job count", async () => {
+    const payout = toBN(toWei("10"));
+    const jobId = await createJob(payout);
+    const bond = await fundAgentBond(payout);
+
+    const agentBalanceBefore = await token.balanceOf(agent);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    const agentBalanceAfterApply = await token.balanceOf(agent);
+    assert.equal(
+      agentBalanceBefore.sub(agentBalanceAfterApply).toString(),
+      bond.toString(),
+      "bond should be transferred on assignment"
+    );
+
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
+
+    const locked = await manager.lockedAgentBonds();
+    assert.equal(locked.toString(), "0", "agent bonds should be unlocked on completion");
+    assert.equal((await manager.activeJobsByAgent(agent)).toString(), "0", "active jobs should decrement");
+
+    const agentPayout = payout.muln(80).divn(100);
+    const agentBalanceAfterFinalize = await token.balanceOf(agent);
+    assert.equal(
+      agentBalanceAfterFinalize.sub(agentBalanceAfterApply).toString(),
+      agentPayout.add(bond).toString(),
+      "agent should receive payout plus bond refund"
+    );
+  });
+
+  it("slashes bonds and refunds escrow when agents abandon jobs", async () => {
+    const payout = toBN(toWei("12"));
+    const jobId = await createJob(payout);
+    const bond = await fundAgentBond(payout);
+
+    const employerBefore = await token.balanceOf(employer);
+    const agentBefore = await token.balanceOf(agent);
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+
+    await manager.abandonJob(jobId, { from: agent });
+
+    const employerAfter = await token.balanceOf(employer);
+    const agentAfter = await token.balanceOf(agent);
+    assert.equal(
+      employerAfter.sub(employerBefore).toString(),
+      payout.add(bond).toString(),
+      "employer should receive escrow plus slashed bond"
+    );
+    assert.equal(
+      agentBefore.sub(agentAfter).toString(),
+      bond.toString(),
+      "agent should lose the slashed bond"
+    );
+    assert.equal((await manager.lockedAgentBonds()).toString(), "0", "bond should be cleared");
+    assert.equal((await manager.activeJobsByAgent(agent)).toString(), "0", "active jobs should decrement");
+  });
+
+  it("enforces the per-agent active job cap", async () => {
+    const payout = toBN(toWei("5"));
+    const jobIdOne = await createJob(payout);
+    const jobIdTwo = await createJob(payout);
+    await fundAgentBond(payout);
+
+    await manager.applyForJob(jobIdOne, "agent", EMPTY_PROOF, { from: agent });
+    await expectCustomError(
+      manager.applyForJob.call(jobIdTwo, "agent", EMPTY_PROOF, { from: agent }),
+      "InvalidState"
+    );
+  });
+
+  it("prevents abandoning after completion is requested", async () => {
+    const payout = toBN(toWei("6"));
+    const jobId = await createJob(payout);
+    await fundAgentBond(payout);
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+
+    await expectCustomError(manager.abandonJob.call(jobId, { from: agent }), "InvalidState");
+  });
+
+  it("rejects abandon attempts by non-assigned callers", async () => {
+    const payout = toBN(toWei("6"));
+    const jobId = await createJob(payout);
+    await expectRevert.unspecified(manager.abandonJob(jobId, { from: employer }));
+  });
+});

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -57,6 +57,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -95,6 +95,8 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
     await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
     await manager.addAGIType(nft.address, 92, { from: owner });

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -70,6 +70,8 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -70,6 +70,8 @@ contract("AGIJobManager dispute hardening", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -16,6 +16,11 @@ const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
 const { toBN, toWei } = web3.utils;
 
+async function configureManager(manager, owner) {
+  await manager.setAgentBondParams(0, 0, 0, { from: owner });
+  await manager.setMaxActiveJobsPerAgent(50, { from: owner });
+}
+
 contract("AGIJobManager economic safety", (accounts) => {
   const [owner, employer, agent, validator] = accounts;
   let token;
@@ -48,6 +53,8 @@ contract("AGIJobManager economic safety", (accounts) => {
       ),
       { from: owner }
     );
+    await configureManager(manager, owner);
+    await configureManager(manager, owner);
 
     await manager.setValidationRewardPercentage(40, { from: owner });
 
@@ -73,6 +80,7 @@ contract("AGIJobManager economic safety", (accounts) => {
       ),
       { from: owner }
     );
+    await configureManager(manager, owner);
 
     const agiType = await MockERC721.new({ from: owner });
     await manager.addAGIType(agiType.address, 75, { from: owner });
@@ -94,6 +102,7 @@ contract("AGIJobManager economic safety", (accounts) => {
       ),
       { from: owner }
     );
+    await configureManager(manager, owner);
 
     await manager.setAdditionalAgentPayoutPercentage(90, { from: owner });
     await manager.setValidationRewardPercentage(90, { from: owner });
@@ -115,6 +124,7 @@ contract("AGIJobManager economic safety", (accounts) => {
       ),
       { from: owner }
     );
+    await configureManager(manager, owner);
 
     await manager.setValidationRewardPercentage(10, { from: owner });
     await manager.setRequiredValidatorApprovals(1, { from: owner });

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -57,6 +57,8 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/happyPath.test.js
+++ b/test/happyPath.test.js
@@ -50,6 +50,8 @@ contract("AGIJobManager happy path", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -20,4 +20,20 @@ async function computeValidatorBond(manager, payout) {
   return bond;
 }
 
-module.exports = { fundValidators, computeValidatorBond };
+async function computeAgentBond(manager, payout) {
+  const [bps, min, max] = await Promise.all([
+    manager.agentBondBps(),
+    manager.agentBondMin(),
+    manager.agentBondMax(),
+  ]);
+  if (bps.isZero()) {
+    return payout.muln(0);
+  }
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
+  if (bond.gt(payout)) bond = payout;
+  return bond;
+}
+
+module.exports = { fundValidators, computeValidatorBond, computeAgentBond };

--- a/test/jobStatus.test.js
+++ b/test/jobStatus.test.js
@@ -39,6 +39,8 @@ contract("AGIJobManager jobStatus", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -71,6 +71,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/merkleAllowlist.test.js
+++ b/test/merkleAllowlist.test.js
@@ -52,6 +52,8 @@ contract("AGIJobManager Merkle allowlists", (accounts) => {
       ),
       { from: owner },
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await token.mint(employer, payout, { from: owner });

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -65,6 +65,8 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setChallengePeriodAfterApproval(1, { from: owner });
@@ -172,6 +174,8 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
       ),
       { from: owner }
     );
+    await merkleManager.setAgentBondParams(0, 0, 0, { from: owner });
+    await merkleManager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await merkleManager.addAGIType(agiTypeNft.address, 1, { from: owner });
     await merkleManager.setRequiredValidatorApprovals(1, { from: owner });

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -46,7 +46,7 @@ async function deployManager(Contract, tokenAddress, agent, validator, owner) {
   ];
   const merkleArgs = [leaf(validator), leaf(agent)];
   if (Contract.contractName === "AGIJobManager") {
-    return Contract.new(
+    const manager = await Contract.new(
       ...buildInitConfig(
         tokenAddress,
         "ipfs://base",
@@ -60,6 +60,9 @@ async function deployManager(Contract, tokenAddress, agent, validator, owner) {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
+    return manager;
   }
   return Contract.new(
     ...baseArgs,

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -40,6 +40,8 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -52,6 +52,8 @@ contract("AGIJobManager security regressions", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
@@ -293,6 +295,8 @@ contract("AGIJobManager security regressions", (accounts) => {
       ),
       { from: owner }
     );
+    await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+    await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
@@ -323,6 +327,8 @@ contract("AGIJobManager security regressions", (accounts) => {
       ),
       { from: owner }
     );
+    await managerFailing.setAgentBondParams(0, 0, 0, { from: owner });
+    await managerFailing.setMaxActiveJobsPerAgent(50, { from: owner });
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);

--- a/test/validatorCap.test.js
+++ b/test/validatorCap.test.js
@@ -65,6 +65,8 @@ contract("AGIJobManager validator cap", (accounts) => {
       ),
       { from: owner }
     );
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.setMaxActiveJobsPerAgent(50, { from: owner });
 
     const agiType = await MockERC721.new({ from: owner });
     await agiType.mint(agent, { from: owner });


### PR DESCRIPTION
### Motivation

- Prevent zero-cost job capture and improve on-chain incentives by requiring a refundable performance bond from assigned agents and limiting concurrent active jobs per agent. 
- Provide an escape hatch to preserve liveness (agents can abandon before submission) and ensure employer funds are not indefinitely locked. 
- Reduce reputation misattribution by measuring agent completion latency from submission time rather than settlement time.

### Description

- Added agent bond configuration and accounting: `agentBondBps`, `agentBondMin`, `agentBondMax`, `agentSlashBps`, `lockedAgentBonds`, events `AgentBondParamsUpdated`, `AgentSlashBpsUpdated`, `AgentBonded`, and `AgentBondSettled`, and owner setters `setAgentBondParams` and `setAgentSlashBps` (with validation and disabling semantics via `bps==0 && min==0 && max==0`).
- Added per-agent concurrency cap: `maxActiveJobsPerAgent` and `activeJobsByAgent`, events `MaxActiveJobsPerAgentUpdated` and `AgentActiveJobsUpdated`, and setter `setMaxActiveJobsPerAgent`.
- Extended `Job` struct with `agentBondAmount` (appended only). 
- Implemented compact helpers: `_computeAgentBond`, `_incActiveJobs`, `_decActiveJobs`, and `_settleAgentBond` (idempotent by zeroing `agentBondAmount`).
- Enforced bond + cap in `applyForJob`: check active job cap, pull bond via `_safeERC20TransferFromExact`, increment `lockedAgentBonds`, emit `AgentBonded`, assign job, and call `_incActiveJobs`.
- Settled bonds on all terminal paths: refunded on agent-win in `_completeJob`, slashed/refunded on employer-win via new `_refundEmployerWithId`, slashed on `expireJob`, and slashed + escrow refunded on new `abandonJob`; all terminal branches call `_decActiveJobs` to maintain active-job accounting.
- Added `abandonJob(uint256)` (agent-only, pre-submission), which marks the job terminal, releases escrow, settles/slashes the bond, decrements active count, and refunds employer.
- Adjusted withdrawable accounting: `withdrawableAGI()` now subtracts `lockedEscrow + lockedValidatorBonds + lockedAgentBonds` to prevent owner withdrawal of bonded funds.
- Reputation timing fix: `_computeReputationPoints` now uses `job.completionRequestedAt - job.assignedAt` (bounded) instead of settlement time to attribute agent performance to submission latency.
- Tests & docs: added `test/agentIncentives.test.js` and updated many existing tests to disable agent bonds (call `setAgentBondParams(0,0,0)`) in test setup or to fund agent bonds where needed; updated `test/helpers/bonds.js` with `computeAgentBond`; updated `README.md` to document agent bonds and treasury/escrow semantics.

### Testing

- Ran `npm test` (which invokes `truffle compile` and the test suite) but it failed in this environment with `truffle: not found`, so the full test-suite could not be executed here. (Failure: `sh: 1: truffle: not found`).
- Ran size-check `npm run size` but it failed due to missing Truffle artifacts (`Missing Truffle artifacts directory: build/contracts`), so contract bytecode size checks were not executed.
- Test adjustments included adding `test/agentIncentives.test.js` and updating existing tests to either disable agent bonds in setup (`setAgentBondParams(0,0,0)`) or to pre-fund agents where bonds are expected; these test changes are present in the patch to keep the suite runnable in CI where Truffle/build artifacts are available.

Commands run (local CI/dev): `npm test` (failed: truffle missing), `npm run size` (failed: missing artifacts), plus various `rg`, `sed`, and `git` commands used during patching and verification.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698418dad2548333b190bf6683fe299a)