### PR TITLE
Add fixed agent bond incentives & fix reputation timing

### DIFF
--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -13,7 +13,7 @@ const MockERC721 = artifacts.require("MockERC721");
 const { rootNode, setNameWrapperOwnership } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, fundAgents } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -61,6 +61,7 @@ contract("AGIJobManager admin ops", (accounts) => {
     await agiTypeNft.mint(agent, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
+    await fundAgents(token, manager, [agent, other], owner);
   });
 
   it("pauses and unpauses sensitive actions", async () => {

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -8,7 +8,7 @@ const MockERC721 = artifacts.require("MockERC721");
 
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, fundAgents } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -83,6 +83,7 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
     await manager.setDisputeReviewPeriod(100, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
+    await fundAgents(token, manager, [agent], owner);
   });
 
   async function createJob(payout) {

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -14,7 +14,7 @@ const MockNameWrapper = artifacts.require('MockNameWrapper');
 
 const { runExportMetrics } = require('../scripts/erc8004/export_metrics');
 const { buildInitConfig } = require('./helpers/deploy');
-const { fundValidators } = require('./helpers/bonds');
+const { fundValidators, fundAgents } = require('./helpers/bonds');
 
 const ZERO_ROOT = '0x' + '00'.repeat(32);
 const EMPTY_PROOF = [];
@@ -69,6 +69,7 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
     await manager.addModerator(moderator, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
+    await fundAgents(token, manager, [agent], owner);
   });
 
   it('exports deterministic metrics and expected aggregates', async () => {

--- a/test/jobStatus.test.js
+++ b/test/jobStatus.test.js
@@ -9,6 +9,7 @@ const MockNameWrapper = artifacts.require("MockNameWrapper");
 
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -46,6 +47,7 @@ contract("AGIJobManager jobStatus", (accounts) => {
 
     await manager.addAdditionalAgent(agent, { from: owner });
     await manager.addModerator(moderator, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
   });
 
   it("tracks canonical job lifecycle flags", async () => {

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -9,7 +9,7 @@ const MockNameWrapper = artifacts.require("MockNameWrapper");
 const { rootNode } = require("./helpers/ens");
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, fundAgents, computeAgentBond } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -87,6 +87,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.setChallengePeriodAfterApproval(100, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
+    await fundAgents(token, manager, [agent], owner);
   });
 
   async function createJob(payout, duration = 1000) {
@@ -108,7 +109,12 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const employerBefore = await token.balanceOf(employer);
     await manager.expireJob(jobId, { from: other });
     const employerAfter = await token.balanceOf(employer);
-    assert.equal(employerAfter.toString(), employerBefore.add(payout).toString(), "employer should be refunded");
+    const agentBond = await computeAgentBond(manager, payout);
+    assert.equal(
+      employerAfter.toString(),
+      employerBefore.add(payout).add(agentBond).toString(),
+      "employer should be refunded"
+    );
 
     const job = await manager.getJobCore(jobId);
     assert.strictEqual(job.expired, true, "job should be marked expired");
@@ -150,7 +156,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.finalizeJob(jobId, { from: agent });
     const agentAfter = await token.balanceOf(agent);
 
-    const expected = payout.muln(90).divn(100);
+    const agentBond = await computeAgentBond(manager, payout);
+    const expected = payout.muln(90).divn(100).add(agentBond);
     assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid after finalization");
 
     const job = await manager.getJobCore(jobId);
@@ -186,7 +193,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const agentBefore = await token.balanceOf(agent);
     await manager.finalizeJob(jobId, { from: other });
     const agentAfter = await token.balanceOf(agent);
-    const expected = payout.muln(90).divn(100);
+    const agentBond = await computeAgentBond(manager, payout);
+    const expected = payout.muln(90).divn(100).add(agentBond);
     assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid");
   });
 
@@ -207,9 +215,10 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const employerAfter = await token.balanceOf(employer);
     const validationPct = await manager.validationRewardPercentage();
     const validatorReward = payout.mul(validationPct).divn(100);
+    const agentBond = await computeAgentBond(manager, payout);
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(validatorReward).toString(),
+      payout.sub(validatorReward).add(agentBond).toString(),
       "employer should be refunded minus validator reward"
     );
     const validatorAfter = await token.balanceOf(validator);
@@ -255,7 +264,12 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.resolveStaleDispute(jobId, true, { from: owner });
     const employerAfter = await token.balanceOf(employer);
 
-    assert.equal(employerAfter.sub(employerBefore).toString(), payout.toString(), "employer should be refunded");
+    const agentBond = await computeAgentBond(manager, payout);
+    assert.equal(
+      employerAfter.sub(employerBefore).toString(),
+      payout.add(agentBond).toString(),
+      "employer should be refunded"
+    );
     const job = await manager.getJobCore(jobId);
     assert.strictEqual(job.completed, true, "job should be completed after timeout resolution");
     assert.strictEqual(job.disputed, false, "job should no longer be disputed");

--- a/test/namespaceAlpha.test.js
+++ b/test/namespaceAlpha.test.js
@@ -11,7 +11,7 @@ const { MerkleTree } = require("merkletreejs");
 const keccak256 = require("keccak256");
 const { namehash, subnode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, fundAgents } = require("./helpers/bonds");
 const { expectRevert, time } = require("@openzeppelin/test-helpers");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
@@ -73,6 +73,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
     await agiTypeNft.mint(agent, { from: owner });
 
     await fundValidators(token, manager, [validator], owner);
+    await fundAgents(token, manager, [agent], owner);
   });
 
   it("authorizes an agent via NameWrapper ownership under alpha.agent", async () => {
@@ -178,6 +179,7 @@ contract("AGIJobManager alpha namespace gating", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(merkleManager.address, payout, { from: employer });
     await fundValidators(token, merkleManager, [validator], owner);
+    await fundAgents(token, merkleManager, [agent], owner);
     const jobId = (await merkleManager.nextJobId()).toNumber();
     await merkleManager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
 

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -6,7 +6,7 @@ const MockERC20 = artifacts.require("MockERC20");
 const FailTransferToken = artifacts.require("FailTransferToken");
 const MockERC721 = artifacts.require("MockERC721");
 const { buildInitConfig } = require("./helpers/deploy");
-const { fundValidators } = require("./helpers/bonds");
+const { fundValidators, fundAgents } = require("./helpers/bonds");
 
 const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const EMPTY_PROOF = [];
@@ -81,6 +81,10 @@ async function createAssignedJob(manager, token, employer, agent, payout) {
   return jobId;
 }
 
+async function fundAgentBondIfSupported(token, manager, agents, owner) {
+  await fundAgents(token, manager, agents, owner);
+}
+
 contract("AGIJobManager better-only regressions", (accounts) => {
   const [owner, employer, agent, validator, attacker, moderator] = accounts;
 
@@ -92,6 +96,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     const original = await deployManager(AGIJobManagerOriginal, token.address, attacker, validator, owner);
     const current = await deployManager(AGIJobManager, token.address, attacker, validator, owner);
     await fundValidators(token, current, [validator], owner);
+    await fundAgentBondIfSupported(token, current, [attacker], owner);
 
     await original.applyForJob(0, "attacker", EMPTY_PROOF, { from: attacker });
     await token.approve(original.address, payout, { from: employer });
@@ -129,6 +134,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await fundValidators(token, current, [validator], owner);
+    await fundAgentBondIfSupported(token, current, [agent], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
@@ -161,6 +167,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await fundValidators(token, current, [validator], owner);
+    await fundAgentBondIfSupported(token, current, [agent], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });
@@ -192,6 +199,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await fundValidators(token, current, [validator], owner);
+    await fundAgentBondIfSupported(token, current, [agent], owner);
     const nft = await MockERC721.new({ from: owner });
     await nft.mint(agent, { from: owner });
     await current.addAGIType(nft.address, 92, { from: owner });
@@ -232,6 +240,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
 
     const current = await deployManager(AGIJobManager, token.address, agent, validator, owner);
     await fundValidators(token, current, [validator], owner);
+    await fundAgentBondIfSupported(token, current, [agent], owner);
     await current.addAGIType(nft.address, 92, { from: owner });
     const currentJobId = await createAssignedJob(current, token, employer, agent, payout);
     await current.requestJobCompletion(currentJobId, "ipfs-complete", { from: agent });

--- a/test/validatorCap.test.js
+++ b/test/validatorCap.test.js
@@ -10,7 +10,7 @@ const MockNameWrapper = artifacts.require("MockNameWrapper");
 
 const { expectCustomError } = require("./helpers/errors");
 const { buildInitConfig } = require("./helpers/deploy");
-const { computeValidatorBond } = require("./helpers/bonds");
+const { fundAgents, computeValidatorBond } = require("./helpers/bonds");
 
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
@@ -71,6 +71,7 @@ contract("AGIJobManager validator cap", (accounts) => {
     await manager.addAGIType(agiType.address, 40, { from: owner });
 
     await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
   });
 
   it("rejects validator thresholds that exceed the cap", async () => {


### PR DESCRIPTION
### Motivation
- Prevent zero-cost job capture and give agents skin-in-the-game by requiring a small bond at assignment that is refunded on agent-win and slashed on employer-win/expiry. 
- Make reputation reflect the agent’s submission time (submission -> validators/disputes should not inflate reputation). 
- Keep changes minimal and bytecode-friendly to stay under the deployed runtime size budget and avoid expanding public ABI surface.

### Description
- Introduced an internal fixed bond `AGENT_BOND` and a tiny helper `_agentBond(uint256 payout)` to cap bond at the job payout; bond is collected during `applyForJob` via `_safeERC20TransferFromExact` and accounted for by folding into existing `lockedValidatorBonds` to avoid new public state.
- Added `_settleAgentBond(Job storage, bool agentWon)` and wired it into all terminal flows (`_completeJob`, `_refundEmployer`, `expireJob`) so agent bonds are refunded to the agent on agent-win and sent to the employer on employer-win/expiry.
- Replaced completion-time usage in reputation computations so `_computeReputationPoints` uses `job.completionRequestedAt - job.assignedAt` (submission time) instead of `block.timestamp - job.assignedAt` (validator/dispute delays).
- Kept the public surface minimal (no new public variables/getters), removed a `JobFinalized` emission site to shave bytecode, and added a small internal helper `_agentBond` to encapsulate bond logic.
- Updated test tooling and helpers: added `fundAgents` and `computeAgentBond` in `test/helpers/bonds.js`, and updated tests across the suite to fund/approve agent bonds and assert bond refund/slash behavior and withdrawableAGI accounting.

### Testing
- Commands executed: `npm install`, `npx truffle compile`, `npm run size`, `npm run ui:abi`, and full test run via `npm test` (which runs `truffle test` + ABI smoke checks + size checks). 
- Runtime bytecode size: recorded `AGIJobManager` deployed/runtime bytecode 24,481 bytes before changes and 24,480 bytes after changes, which is under the 24,575 bytes limit.
- Test results: ran the full automated test suite (`npm test`); final run shows the test suite passing (189 passing) and the bytecode size check passing. All updated tests that validate bond posting, refunding, slashing, and withdrawable accounting were executed and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69842786f8808333838c12dba105dae5)