### PR TITLE
Add agent performance bond accounting and exclude bonds from withdrawable AGI

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1102,6 +1102,19 @@
     },
     {
       "inputs": [],
+      "name": "agentBond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "agentMerkleRoot",
       "outputs": [
         {
@@ -1406,6 +1419,19 @@
           "internalType": "bool",
           "name": "",
           "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "lockedAgentBonds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -2376,6 +2402,19 @@
         }
       ],
       "name": "setChallengePeriodAfterApproval",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bond",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgentBond",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"


### PR DESCRIPTION
### Motivation
- Prevent zero-cost job capture and add skin-in-the-game by requiring a fixed agent performance bond on assignment and slashing/refunding it on terminal flows.  
- Keep the changes minimal and bytecode-conscious while preserving existing public APIs, escrow invariants, and pause semantics.  
- Ensure owner cannot withdraw agent bonds by excluding them from `withdrawableAGI()`.

### Description
- Introduce a configurable fixed bond: `uint256 public agentBond` with owner setter `setAgentBond(uint256)`.  
- Track global and per-job bond accounting via `uint256 public lockedAgentBonds` and `Job.agentBondAmount`, and lock funds when an agent is assigned (in `applyForJob`).  
- Implement `_settleAgentBond(Job storage job, bool agentWon)` to idempotently refund the agent on agent-win or transfer the bond to the employer on agent-loss (100% slash).  
- Exclude agent bonds from owner withdrawable funds by updating `withdrawableAGI()` to include `lockedAgentBonds` in the locked total.  
- Minor refactors to keep bytecode small: inlined bond computation (cap bond at `job.payout`) instead of an extra pure helper; avoided additional events or public config surface beyond the single bond var and `lockedAgentBonds`.  
- Adjusted employer-win reputation computation to reuse existing `_computeReputationPoints(job)` (keeps reputation timing using `completionRequestedAt - assignedAt`).  
- Updated tests (`test/escrowAccounting.test.js`) and refreshed exported UI ABI (`docs/ui/abi/AGIJobManager.json`) to reflect new getters and behavior.

### Testing
- Ran the full test suite with `npm test`; all tests passed: `189 passing`.  
- Verified runtime bytecode size with `npm run size` (script `scripts/check-bytecode-size.js`): before change `AGIJobManager` runtime = `24480` bytes; after change = `24529` bytes (under the 24,575 byte limit).  
- Commands executed during verification: `npm install`, `npx truffle compile`, `npm run size`, and `npm test`; all completed successfully.  
- Updated/added assertions in `test/escrowAccounting.test.js` to confirm `lockedAgentBonds` is increased on assignment and `withdrawableAGI()` excludes `_lockedAgentBonds` (tests exercised agent-win/employer-win/expiry flows and passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69844becf44c8333a26bd16bde8569e1)