### PR TITLE
Harden incentive bonds and reputation timing

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,13 @@
 
 ## Important trust notes
 - **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
-- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`) and only while paused; escrowed funds are not withdrawable.
+- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, `lockedAgentBonds`, and `lockedValidatorBonds`) and only while paused; escrowed funds and bonds are not withdrawable.
 - **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available.
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 - **Validator incentives**: validators post a bond per vote, earn rewards when their vote matches the final outcome, and are slashed when they are wrong.
+- **Agent incentives**: agents post a payout‑scaled bond on assignment; bonds are returned on agent‑win and slashed to the employer on employer‑win/expiry. Reputation gains are based on payout and job duration (not completion delays).
 
-**Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
+**Trust model summary**: owner‑operated escrow; escrows and bonds protected by `lockedEscrow` + locked bond counters; owner withdraws only non‑escrow funds under defined conditions.
 
 ## NFT trading
 
@@ -132,7 +133,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled**; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to stay under the EIP‑170 runtime bytecode cap; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
 
 ## Contract documentation
 

--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -125,7 +125,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint256 public validatorBondMax = 200e18;
     uint256 public validatorSlashBps = 10_000;
     uint256 public challengePeriodAfterApproval = 1 days;
+    /// @notice Minimum agent bond floor; bond scales with payout and caps.
     uint256 public agentBond = 1e18;
+    uint256 internal constant AGENT_BOND_BPS = 500;
+    uint256 internal constant AGENT_BOND_MAX = 200e18;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -350,6 +353,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         }
         if (bond < validatorBondMin) bond = validatorBondMin;
         if (bond > validatorBondMax) bond = validatorBondMax;
+        if (bond > payout) bond = payout;
     }
 
     function _maxAGITypePayoutPercentage() internal view returns (uint256) {
@@ -411,7 +415,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 snapshotPct = getHighestPayoutPercentage(msg.sender);
         if (snapshotPct == 0) revert IneligibleAgentPayout();
         job.agentPayoutPct = uint8(snapshotPct);
-        uint256 bond = agentBond > job.payout ? job.payout : agentBond;
+        uint256 bond = (job.payout * AGENT_BOND_BPS) / 10_000;
+        uint256 minBond = agentBond;
+        if (bond < minBond) bond = minBond;
+        if (bond > AGENT_BOND_MAX) bond = AGENT_BOND_MAX;
+        if (bond > job.payout) bond = job.payout;
         _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
         unchecked {
             lockedAgentBonds += bond;
@@ -987,20 +995,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function _computeReputationPoints(Job storage job) internal view returns (uint256 reputationPoints) {
-        uint256 completionTime = job.completionRequestedAt > job.assignedAt
-            ? job.completionRequestedAt - job.assignedAt
-            : 0;
-        return _computeReputationPointsWithTime(job, completionTime);
-    }
-
-    function _computeReputationPointsWithTime(
-        Job storage job,
-        uint256 completionTime
-    ) internal view returns (uint256 reputationPoints) {
         unchecked {
             uint256 scaledPayout = job.payout / 1e18;
             uint256 payoutPoints = scaledPayout ** 3 / 1e5;
-            reputationPoints = Math.log2(1 + payoutPoints * 1e6) + completionTime / 10000;
+            reputationPoints = Math.log2(1 + payoutPoints * 1e6) + job.duration / 10000;
         }
     }
 


### PR DESCRIPTION
### Motivation
- Fix reputation incentive bug where delaying `requestJobCompletion` increased rep by removing the completion-time term and using job duration as the time basis. 
- Strengthen agent-side incentives so posted bonds scale with job payout and are snapshotted per-job to prevent griefing and inconsistent deterrence. 
- Prevent validator bond requirements from exceeding tiny job payouts so participation is rational and accounting remains sound.

### Description
- Adjusted reputation math so reputation is computed from `job.duration` instead of the agent-controlled completion delay, by changing `_computeReputationPoints` to use `job.duration` as the time component. 
- Reworked agent bond to be payout-scaled and snapshotted at apply time: new internal constants `AGENT_BOND_BPS = 500` and `AGENT_BOND_MAX = 200e18`, compute bond = `min(max(agentBondFloor, (payout * AGENT_BOND_BPS)/10000), AGENT_BOND_MAX, payout)` and store it in `job.agentBondAmount` on `applyForJob`; settlement reads the snapshot via `_settleAgentBond`. 
- Capped validator bond to never exceed the job `payout` in `_computeValidatorBond` to avoid requiring absurd deposits for tiny escrows. 
- Ensured bond accounting is included in withdrawal safety by keeping `lockedAgentBonds` and `lockedValidatorBonds` part of `withdrawableAGI()` calculations and updated documentation to reflect that the owner can only withdraw `balance - (lockedEscrow + lockedAgentBonds + lockedValidatorBonds)`. 
- Kept all public APIs intact and preserved existing pause, ENS/Merkle gating, NFT minting, and moderator trust model; changes are localized and gas-aware (constants used instead of additional owner-setters). 
- Tests and helper scripts updated to reflect the new bond and reputation logic (`test/helpers/bonds.js`, `test/economicSafety.test.js`, `test/validatorCap.test.js`) and README/docs updated to document the new accounting rules.

### Testing
- Ran the full test suite with `npm test`; results: `191 passing` (all tests passed). 
- Verified runtime bytecode with `node scripts/check-bytecode-size.js`: `AGIJobManager runtime bytecode size: 24,572 bytes` which is under the 24,575 byte cap. 
- Additional automated checks run as part of `npm test`: ABI smoke checks and the repository bytecode size guard all passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69849e0ffa508333b8a71d73cd5cebd1)