### PR TITLE
Docs: clarify incentives and bytecode cap

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,12 @@
 
 ## Important trust notes
 - **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
-- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, `lockedAgentBonds`, and `lockedValidatorBonds`) and only while paused; escrowed funds and bonds are not withdrawable.
+- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, `lockedAgentBonds`, and `lockedValidatorBonds`) and only while paused; escrowed funds and bonds are never withdrawable.
 - **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available.
 - **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
 - **Validator incentives**: validators post a bond per vote (capped at payout), earn rewards when their vote matches the final outcome, and are slashed when they are wrong.
 - **Agent incentives**: agents post a payout‑proportional bond (minimum floor, capped at payout) at apply time; bonds are returned on agent wins and fully slashed to employers on employer wins/expiry.
-- **Reputation**: reputation increases with payout size and *faster* completion requests (delays do not increase scores).
+- **Reputation**: reputation increases with payout size and *faster* completion requests (delays do not increase scores); validators accrue reputation on the same payout/time basis scaled by `validationRewardPercentage`.
 
 **Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
 
@@ -134,7 +134,7 @@ npm run build
 npm test
 ```
 
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to keep runtime bytecode under the EIP‑170 cap; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
+**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to keep runtime bytecode under the EIP‑170 cap (≤ 24,575 bytes, enforced by tests); the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
 
 ## Contract documentation
 

--- a/docs/AGIJobManager.md
+++ b/docs/AGIJobManager.md
@@ -6,7 +6,7 @@ This document provides a comprehensive, code‑accurate overview of the `AGIJobM
 
 **What AGIJobManager is**
 - An on‑chain **job escrow manager** where employers fund jobs in ERC‑20, agents perform work, validators approve/disapprove completion, and moderators resolve disputes.
-- A **reputation tracker** for agents and validators, awarding points based on job payout and completion time.
+- A **reputation tracker** for agents and validators, awarding points based on job payout and earlier completion requests (delays do not increase reputation).
 - An **ERC‑721 job NFT issuer**: when a job completes, the employer receives an NFT that points to the completion metadata URI.
 - A **role‑gated system** that enforces access via allowlists (explicit) or Merkle proofs and ENS/NameWrapper/Resolver ownership checks.
 
@@ -129,7 +129,9 @@ The contract uses custom errors for gas‑efficient reverts. Common triggers:
 ## Token & escrow semantics
 
 - **Funding**: `createJob` transfers the job payout into the contract and increments `lockedEscrow`.
+- **Agent bond**: `applyForJob` posts a payout‑proportional bond (minimum floor, capped at payout) that is returned on agent wins and fully slashed to the employer on employer wins or expiry.
 - **Agent payout**: on completion, the agent receives `job.payout * agentPayoutPct / 100`, where `agentPayoutPct` is snapshotted on `applyForJob` based on the highest `AGIType` NFT percentage the agent holds.
+- **Validator bond**: each validator posts a per‑job bond that is capped at the job payout; correct‑side validators split the validator reward pool and slashed bonds.
 - **Validator payout**: on completion, validators split `job.payout * validationRewardPercentage / 100` equally **only if** there is at least one validator.
 - **Refunds**:
   - `cancelJob`/`delistJob` return the full escrow to the employer if no agent was assigned.


### PR DESCRIPTION
### Motivation
- Clarify owner/treasury/escrow separation, agent/validator bond and reputation timing semantics, and call out the enforced runtime bytecode cap so documentation matches the contract economics and CI checks.

### Description
- Minor documentation edits to `README.md` and `docs/AGIJobManager.md` to (1) state that escrowed funds and bonds are never withdrawable by the owner, (2) document that validators accrue reputation on the same payout/time basis scaled by `validationRewardPercentage`, (3) document the agent/validator bond behavior (payout‑proportional agent bonds snapshotted at apply time and validator bonds capped at payout), and (4) call out the enforced bytecode cap (≤ 24,575 bytes) in the compiler note.

### Testing
- Ran the full test suite with `npm test` (which includes compilation, Truffle tests, and the bytecode size guard); all tests passed (`192 passing`) and the `AGIJobManager` runtime bytecode size reported `24,572` bytes (within the enforced ≤ `24,575` bytes limit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984aa0ba98c8333be5e911d3b402761)