### PR TITLE
Adjust reputation time bonus to reward faster completion

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1007,11 +1007,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         Job storage job,
         uint256 completionTime
     ) internal view returns (uint256 reputationPoints) {
-        completionTime;
         unchecked {
             uint256 scaledPayout = job.payout / 1e18;
             uint256 payoutPoints = scaledPayout ** 3 / 1e5;
-            uint256 timeBonus = job.duration / 10000;
+            uint256 timeBonus = (job.duration - completionTime) / 10000;
             reputationPoints = Math.log2(1 + payoutPoints * 1e6) + timeBonus;
         }
     }


### PR DESCRIPTION
### Motivation
- Fix a reputation-incentive bug so agents are rewarded for faster completion rather than for delaying `requestJobCompletion`, removing the delay-reward vector.

### Description
- Change `_computeReputationPointsWithTime` in `contracts/AGIJobManager.sol` to compute `timeBonus` as `(job.duration - completionTime) / 10000` instead of `job.duration / 10000`, so reputation uses completion speed (completionRequestedAt - assignedAt) and faster completion yields higher bonus while preserving all other logic and role semantics.

### Testing
- Ran the repository's automated checks with `npm test` (192 passing) and the size script `npm run size`, both succeeding, and observed final `AGIJobManager` runtime bytecode size `24,553` bytes which is below the 24,575 byte cap; `truffle-config.js` remained unchanged and solc viaIR remained off.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b331362c8333be4e0a577357ba00)