### PR TITLE
Align reputation bonus with faster completion

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1007,11 +1007,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         Job storage job,
         uint256 completionTime
     ) internal view returns (uint256 reputationPoints) {
-        completionTime;
         unchecked {
             uint256 scaledPayout = job.payout / 1e18;
             uint256 payoutPoints = scaledPayout ** 3 / 1e5;
-            uint256 timeBonus = job.duration / 10000;
+            uint256 timeBonus = job.duration > completionTime
+                ? (job.duration - completionTime) / 10000
+                : 0;
             reputationPoints = Math.log2(1 + payoutPoints * 1e6) + timeBonus;
         }
     }


### PR DESCRIPTION
### Motivation
- Prevent agents from increasing reputation by delaying completion requests by making the reputation time bonus reward faster completion rather than absolute elapsed time.

### Description
- Replace the previous unconditional `timeBonus = job.duration / 10000` with `timeBonus = job.duration > completionTime ? (job.duration - completionTime) / 10000 : 0` in `_computeReputationPointsWithTime` so reputation uses `completionRequestedAt - assignedAt` as the time basis.

### Testing
- Ran `npm test` (Truffle suite and JS checks) which completed successfully (all tests passed); ran `npm run size` and verified `AGIJobManager` runtime bytecode size is 24,572 bytes which is under the 24,575 byte cap.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984b331362c8333be4e0a577357ba00)