### PR TITLE
Harden incentives for silent finalization and agent bond accounting

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1102,6 +1102,19 @@
     },
     {
       "inputs": [],
+      "name": "agentBond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "agentMerkleRoot",
       "outputs": [
         {
@@ -2402,6 +2415,19 @@
         }
       ],
       "name": "setAdditionalAgentPayoutPercentage",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgentBond",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -8,20 +8,13 @@ async function fundValidators(token, manager, validators, owner, multiplier = 5)
   return bondMax;
 }
 
-const AGENT_BOND_BPS = 500;
-
 async function resolveAgentBond(manager) {
-  return web3.utils.toBN(web3.utils.toWei("1"));
+  return manager.agentBond();
 }
 
 async function fundAgents(token, manager, agents, owner, multiplier = 5) {
-  const [maxPayout, min] = await Promise.all([
-    manager.maxJobPayout(),
-    resolveAgentBond(manager),
-  ]);
-  let bond = maxPayout.muln(AGENT_BOND_BPS).divn(10000);
-  if (bond.lt(min)) bond = min;
-  const amount = bond.muln(multiplier);
+  const bond = await resolveAgentBond(manager);
+  const amount = web3.utils.toBN(bond).muln(multiplier);
   for (const agent of agents) {
     await token.mint(agent, amount, { from: owner });
     await token.approve(manager.address, amount, { from: agent });
@@ -43,9 +36,7 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeAgentBond(manager, payout) {
-  const min = await resolveAgentBond(manager);
-  let bond = payout.muln(AGENT_BOND_BPS).divn(10000);
-  if (bond.lt(min)) bond = min;
+  const bond = web3.utils.toBN(await resolveAgentBond(manager));
   if (bond.gt(payout)) return payout;
   return bond;
 }

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -152,8 +152,10 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
 
     await advanceTime(120);
 
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
+
     const agentBefore = await token.balanceOf(agent);
-    await manager.finalizeJob(jobId, { from: agent });
+    await manager.finalizeJob(jobId, { from: employer });
     const agentAfter = await token.balanceOf(agent);
 
     const agentBond = await computeAgentBond(manager, payout);


### PR DESCRIPTION
### Motivation
- Prevent agents from "winning by silence" when no validators vote by ensuring only employers can finalize unpaid/no-vote completions. 
- Remove time-based reputation incentives that reward delay and instead favor faster completion. 
- Make agent bonds simple, configurable, snapshot at apply time, and correctly accounted so they are economically meaningful and excluded from owner withdrawals.

### Description
- Require employer-only finalization when `validatorApprovals == 0 && validatorDisapprovals == 0` by checking `msg.sender == job.employer` in `finalizeJob()` so agents cannot self-finalize on silence. 
- Replace the previous time term with a monotone speed bonus computed from `completionRequestedAt - assignedAt` in `_computeReputationPointsWithTime()` so faster completions strictly increase reputation (no underflow). 
- Introduce a single owner-configurable `agentBond` (`uint256 public agentBond`) with setter `setAgentBond(uint256)` and snapshot the bond per job at `applyForJob()` into `job.agentBondAmount`, collecting it with `_safeERC20TransferFromExact` and incrementing `lockedAgentBonds`. 
- Keep `lockedAgentBonds` accounting and ensure `_settleAgentBond()` decrements the locked bucket and clears the snapshot (`job.agentBondAmount = 0`) before transfers to preserve idempotency and escrow invariants. 
- Verify and preserve existing validator bond cap to `payout` in `_computeValidatorBond()` and keep challenge/approval windows and dispute/modeled trust semantics unchanged. 
- Small test and helper updates: adapt `test/helpers/bonds.js` to read the new `agentBond`, add a no-votes finalization test, and update `livenessTimeouts.test.js` to reflect employer-only finalization for silent votes. 
- UI ABI exported/updated to include the new `agentBond` getter and `setAgentBond` setter and no ENS/Merkle or ERC721 mint/tokenURI behavior was changed.

### Testing
- Ran the full test suite via `npm test` (compiled and executed Truffle mocha tests) and all tests passed (193 passing). 
- Exported UI ABI with `npm run ui:abi` and re-ran the ABI sync tests to resolve the interface change. 
- Checked runtime bytecode size with `npm run size` and confirmed `AGIJobManager` runtime bytecode is `24574 bytes`, which is below the EIP-170 safety margin of `24575 bytes`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c4d5bbb48333b2d53f8fea3be195)