### PR TITLE
Dispute silent finalization to preserve liveness

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -63,11 +63,6 @@
     },
     {
       "inputs": [],
-      "name": "InvalidAgentPayoutSnapshot",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "InvalidParameters",
       "type": "error"
     },
@@ -1095,6 +1090,19 @@
           "internalType": "bool",
           "name": "",
           "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "agentBond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
         }
       ],
       "stateMutability": "view",
@@ -2363,6 +2371,19 @@
         }
       ],
       "name": "setValidatorBondParams",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bond",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgentBond",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -8,19 +8,12 @@ async function fundValidators(token, manager, validators, owner, multiplier = 5)
   return bondMax;
 }
 
-const AGENT_BOND_BPS = 500;
-
 async function resolveAgentBond(manager) {
-  return web3.utils.toBN(web3.utils.toWei("1"));
+  return web3.utils.toBN(await manager.agentBond());
 }
 
 async function fundAgents(token, manager, agents, owner, multiplier = 5) {
-  const [maxPayout, min] = await Promise.all([
-    manager.maxJobPayout(),
-    resolveAgentBond(manager),
-  ]);
-  let bond = maxPayout.muln(AGENT_BOND_BPS).divn(10000);
-  if (bond.lt(min)) bond = min;
+  const bond = await resolveAgentBond(manager);
   const amount = bond.muln(multiplier);
   for (const agent of agents) {
     await token.mint(agent, amount, { from: owner });
@@ -43,9 +36,7 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeAgentBond(manager, payout) {
-  const min = await resolveAgentBond(manager);
-  let bond = payout.muln(AGENT_BOND_BPS).divn(10000);
-  if (bond.lt(min)) bond = min;
+  const bond = await resolveAgentBond(manager);
   if (bond.gt(payout)) return payout;
   return bond;
 }

--- a/test/incentiveHardening.test.js
+++ b/test/incentiveHardening.test.js
@@ -128,6 +128,25 @@ contract("AGIJobManager incentive hardening", (accounts) => {
     );
   });
 
+  it("requires the employer to finalize when there are no validator votes", async () => {
+    const payout = toBN(toWei("10"));
+    await token.mint(employer, payout, { from: owner });
+
+    await token.approve(manager.address, payout, { from: employer });
+    const jobId = (await manager.createJob("ipfs-novotes", payout, 100, "details", { from: employer })).logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobId, "agent-fast", EMPTY_PROOF, { from: agentFast });
+    await manager.requestJobCompletion(jobId, "ipfs-novotes-complete", { from: agentFast });
+    await time.increase(2);
+
+    const agentFinalize = await manager.finalizeJob(jobId, { from: agentFast });
+    assert.strictEqual(agentFinalize.logs[0].event, "JobDisputed", "agent finalize should trigger a dispute");
+    const jobAfterDispute = await manager.getJobCore(jobId);
+    assert.strictEqual(jobAfterDispute.disputed, true, "job should be disputed after agent finalize");
+
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: employer }), "InvalidState");
+  });
+
   it("caps validator bonds at payout and prevents rush-to-approve settlement", async () => {
     const payout = toBN(toWei("0.5"));
     await token.mint(employer, payout, { from: owner });

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -153,7 +153,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await advanceTime(120);
 
     const agentBefore = await token.balanceOf(agent);
-    await manager.finalizeJob(jobId, { from: agent });
+    await manager.finalizeJob(jobId, { from: employer });
     const agentAfter = await token.balanceOf(agent);
 
     const agentBond = await computeAgentBond(manager, payout);


### PR DESCRIPTION
### Motivation
- Prevent a liveness regression where a non-employer caller finalizing a job with zero validator votes could permanently lock escrow and block agent settlement.
- Keep the employer-driven acceptance path intact while keeping the contract size within the EIP-170 safety margin.

### Description
- When `finalizeJob` is called and there are zero validator votes, non-employer callers now mark the job disputed and emit `JobDisputed` (setting `disputedAt`) and return, while the employer can still finalize and complete the job via `finalizeJob`.
- Simplified `finalizeJob` control flow with early returns for the validator-approved branch and agent/employer outcome branches to reduce bytecode size and clarify logic.
- Replaced inline agent bond constants with a public, owner-configurable `agentBond` and added `setAgentBond(uint256)`; `applyForJob` now snapshots `agentBond` (capped to `job.payout`) into `job.agentBondAmount` and increments `lockedAgentBonds` on apply.
- Adjusted small invariants: removed `job.completionRequestedAt == 0` guard in `finalizeJob`, replaced `InvalidAgentPayoutSnapshot` with `InvalidState`, and updated the reputation time bonus formula to be monotone-decreasing with delay.
- Updated UI ABI to expose the new `agentBond` getter and `setAgentBond` setter and updated tests/helpers to use the new `agentBond` semantics.

### Testing
- Ran `npm run build` (Truffle compile) and compilation succeeded with warnings; contract runtime bytecode size reported `24568` bytes via `npm run size`.
- Ran full test suite with `npm test` and observed all tests passing (`193 passing`).
- Updated and ran: `test/incentiveHardening.test.js`, `test/livenessTimeouts.test.js`, and `test/helpers/bonds.js` to cover the silent-vote dispute path and the new `agentBond` behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984c4d5bbb48333b2d53f8fea3be195)