### PR TITLE
Require employer-only finalize when validators are silent

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -838,13 +838,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
         bool agentWins;
         if (job.validatorApprovals == 0 && job.validatorDisapprovals == 0) {
-            if (msg.sender != job.employer) {
-                if (msg.sender != job.assignedAgent) revert InvalidState();
-                job.disputed = true;
-                job.disputedAt = block.timestamp;
-                emit JobDisputed(_jobId, msg.sender);
-                return;
-            }
+            if (msg.sender != job.employer) revert InvalidState();
             agentWins = true;
         } else {
             agentWins = job.validatorApprovals > job.validatorDisapprovals;

--- a/test/incentiveHardening.test.js
+++ b/test/incentiveHardening.test.js
@@ -139,10 +139,9 @@ contract("AGIJobManager incentive hardening", (accounts) => {
     await manager.requestJobCompletion(jobId, "ipfs-novotes-complete", { from: agentFast });
     await time.increase(2);
 
-    await manager.finalizeJob(jobId, { from: agentFast });
-    const job = await manager.getJobCore(jobId);
-    assert.strictEqual(job.disputed, true, "dispute should be set");
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agentFast }), "InvalidState");
     await expectCustomError(manager.finalizeJob.call(jobId, { from: validator }), "InvalidState");
+    await manager.finalizeJob(jobId, { from: employer });
   });
 
   it("caps validator bonds at payout and prevents rush-to-approve settlement", async () => {

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -152,10 +152,9 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
 
     await advanceTime(120);
 
-    await manager.finalizeJob(jobId, { from: agent });
-    const jobAfterDispute = await manager.getJobCore(jobId);
-    assert.strictEqual(jobAfterDispute.disputed, true, "job should be disputed");
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
     await expectCustomError(manager.finalizeJob.call(jobId, { from: other }), "InvalidState");
+    await manager.finalizeJob(jobId, { from: employer });
   });
 
   it("rejects finalize before the review window elapses", async () => {


### PR DESCRIPTION
### Motivation
- Close the “win-by-silence” incentive hole by preventing the assigned agent (or other third parties) from self-finalizing a job when there are zero validator votes, while preserving liveness by allowing the employer to accept and finalize.

### Description
- Tighten `finalizeJob()` so that when `validatorApprovals == 0 && validatorDisapprovals == 0` the call reverts unless `msg.sender == job.employer`, preserving the employer-as-acceptor pattern and removing the prior agent-self-dispute shortcut; tests updated to reflect this caller rule (`test/incentiveHardening.test.js` and `test/livenessTimeouts.test.js`).

### Testing
- Ran `npm run size` and `npm test`; full test suite and bytecode check passed: runtime bytecode reported `AGIJobManager runtime bytecode: 24484 bytes` (< 24,575) and the test run completed successfully with `193 passing`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e0fb200c8333b3e2b1f5342b25c0)