### PR TITLE
Scale agent and validator bonds with per-job agent bond snapshot and slashing

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -119,13 +119,17 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
      *      thresholds are met, a short challenge window prevents instant settlement. When validators
      *      participate and the employer wins, the refund is reduced by the validator reward pool.
      */
-    uint256 public validatorBondBps = 50;
-    uint256 public validatorBondMin = 1e18;
+    uint256 public validatorBondBps = 200;
+    uint256 public validatorBondMin = 5e18;
     uint256 public validatorBondMax = 200e18;
     uint256 public validatorSlashBps = 10_000;
     uint256 public challengePeriodAfterApproval = 1 days;
     /// @dev Validator incentives are final-outcome aligned; bonds + challenge windows mitigate bribery but do not eliminate it.
     uint256 public agentBond = 1e18;
+    uint256 internal constant AGENT_BOND_BPS = 100;
+    uint256 internal constant AGENT_BOND_MIN = 1e18;
+    uint256 internal constant AGENT_BOND_MAX = 200e18;
+    uint256 internal constant AGENT_SLASH_BPS = 10_000;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -318,12 +322,14 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function _settleAgentBond(Job storage job, bool agentWon) internal {
         uint256 bond = job.agentBondAmount;
-        if (bond == 0) return;
         job.agentBondAmount = 0;
         unchecked {
             lockedAgentBonds -= bond;
         }
-        _t(agentWon ? job.assignedAgent : job.employer, bond);
+        uint256 slashed = agentWon ? 0 : (bond * AGENT_SLASH_BPS) / 10_000;
+        uint256 refund = bond - slashed;
+        _t(job.employer, slashed);
+        _t(job.assignedAgent, refund);
     }
 
     function _validateValidatorThresholds(uint256 approvals, uint256 disapprovals) internal pure {
@@ -340,13 +346,17 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (currentCount >= MAX_VALIDATORS_PER_JOB) revert ValidatorLimitReached();
     }
 
-    function _computeValidatorBond(uint256 payout) internal view returns (uint256 bond) {
+    function _computeBond(uint256 payout, uint256 bps, uint256 min, uint256 max) internal pure returns (uint256 bond) {
         unchecked {
-            bond = (payout * validatorBondBps) / 10_000;
+            bond = (payout * bps) / 10_000;
         }
-        if (bond < validatorBondMin) bond = validatorBondMin;
-        if (bond > validatorBondMax) bond = validatorBondMax;
+        if (bond < min) bond = min;
+        if (bond > max) bond = max;
         if (bond > payout) bond = payout;
+    }
+
+    function _computeAgentBond(uint256 payout) internal pure returns (uint256 bond) {
+        return _computeBond(payout, AGENT_BOND_BPS, AGENT_BOND_MIN, AGENT_BOND_MAX);
     }
 
     function _maxAGITypePayoutPercentage() internal view returns (uint256) {
@@ -408,8 +418,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 snapshotPct = getHighestPayoutPercentage(msg.sender);
         if (snapshotPct == 0) revert IneligibleAgentPayout();
         job.agentPayoutPct = uint8(snapshotPct);
-        uint256 bond = agentBond;
-        if (bond > job.payout) bond = job.payout;
+        uint256 bond = _computeAgentBond(job.payout);
         _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
         unchecked {
             lockedAgentBonds += bond;
@@ -449,7 +458,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
         uint256 bond = job.validatorBondAmount;
         if (bond == 0) {
-            bond = _computeValidatorBond(job.payout);
+            bond = _computeBond(job.payout, validatorBondBps, validatorBondMin, validatorBondMax);
             job.validatorBondAmount = bond + 1;
         } else {
             unchecked {
@@ -494,7 +503,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
         uint256 bond = job.validatorBondAmount;
         if (bond == 0) {
-            bond = _computeValidatorBond(job.payout);
+            bond = _computeBond(job.payout, validatorBondBps, validatorBondMin, validatorBondMax);
             job.validatorBondAmount = bond + 1;
         } else {
             unchecked {
@@ -680,7 +689,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (bps > 10_000) revert InvalidParameters();
         if (min > max) revert InvalidParameters();
         if (!(bps == 0 && min == 0 && max == 0)) {
-            if (max == 0) revert InvalidParameters();
+            if (max == 0 || min == 0) revert InvalidParameters();
         }
         validatorBondBps = bps;
         validatorBondMin = min;


### PR DESCRIPTION
### Motivation
- Prevent low fixed agent bonds becoming cheap attack vectors by making agent bonds scale with job payout and snapshot per-job.  
- Make validator stakes more economically meaningful to raise bribery cost without changing settlement shapes or trust assumptions.  
- Preserve existing owner/moderator model, pause/withdraw semantics, escrow accounting, and NFT behavior while closing silent-settlement paths.

### Description
- Add proportional bond parameters as internal constants and a shared bond helper: `_computeBond(payout,bps,min,max)` and ` _computeAgentBond(payout)` to compute clamped, payout-capped bonds.  
- Snapshot agent bond at `applyForJob()` using `uint256 bond = _computeAgentBond(job.payout)` and update `lockedAgentBonds` and `job.agentBondAmount` accordingly.  
- Replace old agent-settlement with slashing/refund logic in `_settleAgentBond(Job,bool agentWon)` that idempotently zeros `job.agentBondAmount`, decrements `lockedAgentBonds` once, and sends slashed portion to employer and remainder to agent.  
- Increase default validator stake parameters (`validatorBondBps` and `validatorBondMin`) and tighten validation in `setValidatorBondParams` to avoid degenerate configs; reuse `_computeBond` for validator bond computation.  
- Keep all existing flows, allowlists, pause rules, and NFT minting unchanged; `withdrawableAGI()` continues to exclude `lockedEscrow`, `lockedValidatorBonds`, and `lockedAgentBonds`.  
- Update test helpers (`test/helpers/bonds.js`) to reflect proportional agent bond schedule and validator bond behavior used by the test suite.

### Testing
- Ran dependency setup (`npm ci` which failed due to `fsevents` platform optional dependency), then `npm install --omit=optional` to proceed.  
- Compiled and exercised the full test pipeline using `npx truffle compile --all` and `npm test` (which runs the Truffle tests and internal checks).  
- Ran the bytecode checker `node scripts/check-bytecode-size.js`.  
- Result: full test suite passed (`193 passing`), and runtime bytecode size is `24,565` bytes (under the EIP-170 cap of `24,575`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e92248f0833386bf25940a34bc90)