### PR TITLE
Scale agent bonds and harden validator staking

### DIFF
--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -8,18 +8,14 @@ async function fundValidators(token, manager, validators, owner, multiplier = 5)
   return bondMax;
 }
 
-async function resolveAgentBond(manager) {
-  return web3.utils.toBN(await manager.agentBond());
-}
-
 async function fundAgents(token, manager, agents, owner, multiplier = 5) {
-  const bond = await resolveAgentBond(manager);
-  const amount = bond.muln(multiplier);
+  const bondMax = web3.utils.toBN(web3.utils.toWei("200"));
+  const amount = bondMax.muln(multiplier);
   for (const agent of agents) {
     await token.mint(agent, amount, { from: owner });
     await token.approve(manager.address, amount, { from: agent });
   }
-  return bond;
+  return bondMax;
 }
 
 async function computeValidatorBond(manager, payout) {
@@ -36,8 +32,16 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeAgentBond(manager, payout) {
-  const bond = await resolveAgentBond(manager);
-  if (bond.gt(payout)) return payout;
+  const bps = web3.utils.toBN(100);
+  const min = web3.utils.toBN(web3.utils.toWei("1"));
+  const max = web3.utils.toBN(web3.utils.toWei("200"));
+  const disabled = bps.eqn(0) && min.eqn(0) && max.eqn(0);
+  if (disabled) return web3.utils.toBN(0);
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
+  if (bond.isZero() && payout.gt(web3.utils.toBN(0))) bond = web3.utils.toBN(1);
+  if (bond.gt(payout)) bond = payout;
   return bond;
 }
 


### PR DESCRIPTION
### Motivation
- Make on‑chain economic incentives scale with job payout so agents face meaningful skin in the game while preserving the owner/moderator centralized trust model and keeping minimal diffs.
- Harden validator staking defaults so validator stakes are payout‑scaled and non‑zero for non‑disabled configurations to raise bribery costs.

### Description
- Add payout‑proportional agent bond constants `AGENT_BOND_BPS`, `AGENT_BOND_MIN`, `AGENT_BOND_MAX` and `AGENT_SLASH_BPS`, leaving the legacy `agentBond` and `setAgentBond` unchanged for compatibility.
- Introduce a compact `_computeBond(payout,bps,min,max)` helper and use it for both validators and agents to compute clamped, payout‑capped bonds.
- Snapshot and collect the agent bond at `applyForJob()` into `job.agentBondAmount` and increment `lockedAgentBonds`, and make agent bond settlement idempotent in `_settleAgentBond` (refund on agent win; slash per `AGENT_SLASH_BPS` and refund remainder on employer win/expiry).
- Increase validator defaults (`validatorBondBps`/`validatorBondMin`) and tighten `setValidatorBondParams` validation; reuse `_computeBond` in validator voting paths without changing loop shapes or MAX_VALIDATORS_PER_JOB.
- Update `test/helpers/bonds.js` to fund agents/compute expected bonds using the proportional bond semantics.

### Testing
- Commands run: `npm install --omit=optional` then the full test pipeline via `npm test` (which runs `truffle compile --all`, the Truffle test suite, `node test/AGIJobManager.test.js`, and `node scripts/check-contract-sizes.js`).
- Result: test suite passed: `193 passing` (all automated tests green).
- Contract size: `AGIJobManager` deployed bytecode = `24,567` bytes, which is below the EIP‑170 cap (`< 24,575`), and the project contract size checker was executed as part of `npm test`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e92248f0833386bf25940a34bc90)