### PR TITLE
Harden job bonding, validator stakes, liveness, and reputation incentives

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -119,13 +119,15 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
      *      thresholds are met, a short challenge window prevents instant settlement. When validators
      *      participate and the employer wins, the refund is reduced by the validator reward pool.
      */
-    uint256 public validatorBondBps = 50;
+    uint256 public validatorBondBps = 200;
     uint256 public validatorBondMin = 1e18;
-    uint256 public validatorBondMax = 200e18;
+    uint256 public validatorBondMax = 4888e18;
     uint256 public validatorSlashBps = 10_000;
     uint256 public challengePeriodAfterApproval = 1 days;
     /// @dev Validator incentives are final-outcome aligned; bonds + challenge windows mitigate bribery but do not eliminate it.
     uint256 public agentBond = 1e18;
+    uint256 public agentBondBps = 500;
+    uint256 public agentBondMax = 4888e18;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -341,11 +343,32 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function _computeValidatorBond(uint256 payout) internal view returns (uint256 bond) {
+        if (validatorBondBps == 0 && validatorBondMin == 0 && validatorBondMax == 0) {
+            return 0;
+        }
         unchecked {
             bond = (payout * validatorBondBps) / 10_000;
         }
         if (bond < validatorBondMin) bond = validatorBondMin;
         if (bond > validatorBondMax) bond = validatorBondMax;
+        if (bond > payout) bond = payout;
+    }
+
+    function _computeAgentBond(uint256 payout, uint256 duration) internal view returns (uint256 bond) {
+        if (agentBondBps == 0 && agentBond == 0 && agentBondMax == 0) {
+            return 0;
+        }
+        unchecked {
+            bond = (payout * agentBondBps) / 10_000;
+        }
+        if (bond < agentBond) bond = agentBond;
+        if (agentBondMax != 0 && bond > agentBondMax) bond = agentBondMax;
+        if (jobDurationLimit != 0) {
+            unchecked {
+                bond = (bond * (jobDurationLimit + duration)) / jobDurationLimit;
+            }
+        }
+        if (agentBondMax != 0 && bond > agentBondMax) bond = agentBondMax;
         if (bond > payout) bond = payout;
     }
 
@@ -408,8 +431,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 snapshotPct = getHighestPayoutPercentage(msg.sender);
         if (snapshotPct == 0) revert IneligibleAgentPayout();
         job.agentPayoutPct = uint8(snapshotPct);
-        uint256 bond = agentBond;
-        if (bond > job.payout) bond = job.payout;
+        uint256 bond = _computeAgentBond(job.payout, job.duration);
         _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
         unchecked {
             lockedAgentBonds += bond;
@@ -583,16 +605,17 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit DisputeResolvedWithCode(_jobId, msg.sender, resolutionCode, reason);
     }
 
-    function resolveStaleDispute(uint256 _jobId, bool employerWins) external onlyOwner whenPaused nonReentrant {
+    function resolveStaleDispute(uint256 _jobId, bool employerWins) external onlyOwner nonReentrant {
         Job storage job = _job(_jobId);
         if (!job.disputed || job.expired) revert InvalidState();
         if (job.disputedAt == 0) revert InvalidState();
         if (block.timestamp <= job.disputedAt + disputeReviewPeriod) revert InvalidState();
 
+        job.disputed = false;
+        job.disputedAt = 0;
         if (employerWins) {
             _refundEmployer(_jobId, job);
         } else {
-            job.disputed = false;
             _completeJob(_jobId);
         }
     }
@@ -689,6 +712,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
     function setAgentBond(uint256 bond) external onlyOwner {
         agentBond = bond;
+    }
+    function setAgentBondParams(uint256 bps, uint256 max) external onlyOwner {
+        if (bps > 10_000) revert InvalidParameters();
+        agentBondBps = bps;
+        agentBondMax = max;
     }
     function setValidatorSlashBps(uint256 bps) external onlyOwner {
         if (bps > 10_000) revert InvalidParameters();
@@ -991,12 +1019,17 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             : 0;
         unchecked {
             uint256 scaledPayout = job.payout / 1e18;
-            uint256 payoutPoints = scaledPayout ** 3 / 1e5;
+            uint256 payoutCube = scaledPayout * scaledPayout * scaledPayout;
+            uint256 payoutPoints = payoutCube * 10;
             uint256 timeBonus;
             if (job.duration > completionTime) {
                 timeBonus = (job.duration - completionTime) / 10000;
             }
-            reputationPoints = Math.log2(1 + payoutPoints * 1e6) + timeBonus;
+            uint256 base = Math.log2(1 + payoutPoints);
+            if (timeBonus > base) {
+                timeBonus = base;
+            }
+            reputationPoints = base + timeBonus;
         }
     }
 

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -196,7 +196,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       const validatorPayoutEach = validatorPayoutTotal.divn(3);
       const validatorRemainder = validatorPayoutTotal.sub(validatorPayoutEach.muln(3));
       const agentPayout = payout.muln(92).divn(100);
-      const agentBond = await computeAgentBond(manager, payout);
+      const agentBond = await computeAgentBond(manager, payout, duration);
       const expectedAgentPayout = agentPayout.add(validatorRemainder).add(agentBond);
 
       const agentBalanceAfter = await token.balanceOf(agent);
@@ -339,7 +339,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.resolveDispute(0, "employer win", { from: moderator });
       const employerBalanceAfter = await token.balanceOf(employer);
 
-      const agentBond = await computeAgentBond(manager, payout);
+      const agentBond = await computeAgentBond(manager, payout, duration);
       assert.equal(employerBalanceAfter.sub(employerBalanceBefore).toString(), payout.add(agentBond).toString());
 
       const job = await manager.getJobCore(0);
@@ -368,7 +368,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.resolveDispute(0, "agent win", { from: moderator });
       const agentBalanceAfter = await token.balanceOf(agent);
 
-      const agentBond = await computeAgentBond(manager, payout);
+      const agentBond = await computeAgentBond(manager, payout, duration);
       const expectedPayout = payout.muln(92).divn(100).add(agentBond);
       assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expectedPayout.toString());
       const job = await manager.getJobCore(0);
@@ -516,7 +516,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       const resolutionReceipt = await manager.resolveDisputeWithCode(0, 1, "agent win", { from: moderator });
       expectEvent(resolutionReceipt, "DisputeResolvedWithCode", { jobId: new BN(0), resolver: moderator });
       const agentBalanceAfter = await token.balanceOf(agent);
-      const agentBond = await computeAgentBond(manager, payout);
+      const agentBond = await computeAgentBond(manager, payout, duration);
       const expectedPayout = payout.muln(92).divn(100).add(agentBond);
       assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expectedPayout.toString());
 

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -155,7 +155,8 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
   describe("Job lifecycle happy path", () => {
     it("creates, assigns, completes, pays out, and mints NFT", async () => {
       const payout = web3.utils.toWei("100");
-      const jobId = await createJob({ manager, token, employer, payout });
+      const duration = 1000;
+      const jobId = await createJob({ manager, token, employer, payout, duration });
       const contractBalance = await token.balanceOf(manager.address);
       assert.equal(contractBalance.toString(), payout.toString());
 
@@ -186,7 +187,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       const validatorBalanceAfter = await token.balanceOf(validator);
       const employerBalanceAfter = await token.balanceOf(employer);
 
-      const agentBond = await computeAgentBond(manager, web3.utils.toBN(payout));
+      const agentBond = await computeAgentBond(manager, web3.utils.toBN(payout), duration);
       assert.equal(employerBalanceAfter.toString(), employerBalanceBefore.toString());
       assert.equal(
         agentBalanceAfter.sub(agentBalanceBefore).toString(),
@@ -321,7 +322,8 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
 
     it("settles agent win via resolveDisputeWithCode", async () => {
       const payout = web3.utils.toWei("22");
-      const jobId = await createJob({ manager, token, employer, payout });
+      const duration = 1000;
+      const jobId = await createJob({ manager, token, employer, payout, duration });
 
       await manager.applyForJob(jobId, "agent", agentMerkle.proofFor(agent), { from: agent });
       await manager.addModerator(moderator, { from: owner });
@@ -332,7 +334,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
       const agentBalanceAfter = web3.utils.toBN(await token.balanceOf(agent));
 
-      const agentBond = await computeAgentBond(manager, web3.utils.toBN(payout));
+      const agentBond = await computeAgentBond(manager, web3.utils.toBN(payout), duration);
       const expectedPayout = web3.utils.toBN(payout).div(web3.utils.toBN(100)).add(agentBond);
       assert(agentBalanceAfter.sub(agentBalanceBefore).eq(expectedPayout));
 

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -16,6 +16,7 @@ const { time } = require("@openzeppelin/test-helpers");
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
 const { toBN, toWei } = web3.utils;
+const DEFAULT_DURATION = 1000;
 
 contract("AGIJobManager agent payout snapshots", (accounts) => {
   const [owner, employer, agent, validator, other] = accounts;
@@ -30,7 +31,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
   const createJob = async (payout) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
-    const receipt = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const receipt = await manager.createJob("ipfs", payout, DEFAULT_DURATION, "details", { from: employer });
     return receipt.logs[0].args.jobId.toNumber();
   };
 
@@ -100,7 +101,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, DEFAULT_DURATION);
     const expected = payout.muln(75).divn(100).add(agentBond);
     assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expected.toString());
   });
@@ -130,7 +131,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, DEFAULT_DURATION);
     const expected = payout.muln(25).divn(100).add(agentBond);
     assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expected.toString());
   });
@@ -171,7 +172,7 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     await manager.finalizeJob(jobId, { from: employer });
 
     const agentBalanceAfter = await token.balanceOf(agent);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, DEFAULT_DURATION);
     const expected = payout.muln(60).divn(100).add(agentBond);
     assert.equal(agentBalanceAfter.sub(agentBalanceBefore).toString(), expected.toString());
   });

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -185,7 +185,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     const validatorPayout = totalValidatorPayout.divn(3);
     const agentPayout = payout.muln(92).divn(100);
 
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     assert.equal(
       (await token.balanceOf(agent)).sub(agentBefore).toString(),
       agentPayout.add(agentBond).toString()

--- a/test/completionSettlementInvariant.test.js
+++ b/test/completionSettlementInvariant.test.js
@@ -125,7 +125,6 @@ contract("AGIJobManager completion settlement invariants", (accounts) => {
     const jobId = await setupDisputedJob(toBN(toWei("7")));
 
     await advanceTime(50);
-    await manager.pause({ from: owner });
 
     await expectCustomError(manager.resolveStaleDispute.call(jobId, false, { from: owner }), "InvalidState");
   });

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -13,6 +13,7 @@ const { fundValidators, fundAgents, computeAgentBond } = require("./helpers/bond
 const ZERO_ROOT = "0x" + "00".repeat(32);
 const EMPTY_PROOF = [];
 const { toBN, toWei } = web3.utils;
+const JOB_DURATION = 1000;
 
 async function advanceTime(seconds) {
   await new Promise((resolve, reject) => {
@@ -92,7 +93,7 @@ contract("AGIJobManager dispute hardening", (accounts) => {
   async function createJob(payout) {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
-    const tx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
+    const tx = await manager.createJob("ipfs-job", payout, JOB_DURATION, "details", { from: employer });
     return tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
   }
 
@@ -187,13 +188,12 @@ contract("AGIJobManager dispute hardening", (accounts) => {
 
     await manager.disputeJob(jobId, { from: employer });
     await advanceTime(120);
-    await manager.pause({ from: owner });
 
     const agentBefore = await token.balanceOf(agent);
     await manager.resolveStaleDispute(jobId, false, { from: owner });
     const agentAfter = await token.balanceOf(agent);
 
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, JOB_DURATION);
     const expected = payout.muln(90).divn(100).add(agentBond);
     assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid");
 
@@ -201,19 +201,16 @@ contract("AGIJobManager dispute hardening", (accounts) => {
     assert.strictEqual(resolvedJob.completed, true, "job should be completed");
     assert.strictEqual(resolvedJob.disputed, false, "dispute should be cleared");
 
-    await manager.unpause({ from: owner });
-
     const payoutRefund = toBN(toWei("9"));
     const refundJobId = await setupCompletion(payoutRefund);
     await manager.disputeJob(refundJobId, { from: employer });
     await advanceTime(120);
-    await manager.pause({ from: owner });
 
     const employerBefore = await token.balanceOf(employer);
     await manager.resolveStaleDispute(refundJobId, true, { from: owner });
     const employerAfter = await token.balanceOf(employer);
 
-    const refundBond = await computeAgentBond(manager, payoutRefund);
+    const refundBond = await computeAgentBond(manager, payoutRefund, JOB_DURATION);
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
       payoutRefund.add(refundBond).toString(),
@@ -249,7 +246,7 @@ contract("AGIJobManager dispute hardening", (accounts) => {
     const lockedAfter = await manager.lockedEscrow();
     const job = await manager.getJobCore(jobId);
     const jobValidation = await manager.getJobValidation(jobId);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, JOB_DURATION);
 
     assert.strictEqual(job.completed, true, "job should be marked completed");
     assert.strictEqual(job.disputed, false, "dispute should be cleared");

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -131,7 +131,8 @@ contract("AGIJobManager economic safety", (accounts) => {
     const payout = toBN(toWei("10"));
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
-    const createTx = await manager.createJob("ipfs-job", payout, 1000, "details", { from: employer });
+    const duration = 1000;
+    const createTx = await manager.createJob("ipfs-job", payout, duration, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
@@ -147,7 +148,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     const agentBalance = await token.balanceOf(agent);
     const validatorBalance = await token.balanceOf(validator);
     const contractBalance = await token.balanceOf(manager.address);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     const agentPayout = payout.muln(80).divn(100);
     const expectedAgentPayout = agentPayout.add(agentBond);
     const expectedValidatorPayout = payout.muln(10).divn(100);

--- a/test/happyPath.test.js
+++ b/test/happyPath.test.js
@@ -71,7 +71,8 @@ contract("AGIJobManager happy path", (accounts) => {
     await token.mint(employer, payout, { from: owner });
 
     await token.approve(manager.address, payout, { from: employer });
-    const createTx = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+    const duration = 3600;
+    const createTx = await manager.createJob("ipfs-job", payout, duration, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
@@ -94,7 +95,7 @@ contract("AGIJobManager happy path", (accounts) => {
 
     const agentBalance = await token.balanceOf(agent);
     const agentExpected = payout.muln(92).divn(100);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     assert.equal(
       agentBalance.sub(agentBalanceBefore).toString(),
       agentExpected.add(agentBond).toString(),

--- a/test/incentiveHardening.test.js
+++ b/test/incentiveHardening.test.js
@@ -91,9 +91,10 @@ contract("AGIJobManager incentive hardening", (accounts) => {
     await token.mint(employer, payout, { from: owner });
 
     await token.approve(manager.address, payout, { from: employer });
-    const jobId = (await manager.createJob("ipfs-bond", payout, 100, "details", { from: employer })).logs[0].args.jobId.toNumber();
+    const duration = 100;
+    const jobId = (await manager.createJob("ipfs-bond", payout, duration, "details", { from: employer })).logs[0].args.jobId.toNumber();
 
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     const agentBefore = await token.balanceOf(agentFast);
     await manager.applyForJob(jobId, "agent-fast", EMPTY_PROOF, { from: agentFast });
     const agentAfterApply = await token.balanceOf(agentFast);
@@ -115,9 +116,10 @@ contract("AGIJobManager incentive hardening", (accounts) => {
     const payoutTwo = toBN(toWei("5"));
     await token.mint(employer, payoutTwo, { from: owner });
     await token.approve(manager.address, payoutTwo, { from: employer });
-    const jobExpire = (await manager.createJob("ipfs-expire", payoutTwo, 1, "details", { from: employer })).logs[0].args.jobId.toNumber();
+    const expireDuration = 1;
+    const jobExpire = (await manager.createJob("ipfs-expire", payoutTwo, expireDuration, "details", { from: employer })).logs[0].args.jobId.toNumber();
     await manager.applyForJob(jobExpire, "agent-fast", EMPTY_PROOF, { from: agentFast });
-    const agentBondExpire = await computeAgentBond(manager, payoutTwo);
+    const agentBondExpire = await computeAgentBond(manager, payoutTwo, expireDuration);
     await time.increase(2);
     const employerBeforeExpire = await token.balanceOf(employer);
     await manager.expireJob(jobExpire, { from: employer });
@@ -126,6 +128,91 @@ contract("AGIJobManager incentive hardening", (accounts) => {
       employerAfterExpire.sub(employerBeforeExpire).eq(payoutTwo.add(agentBondExpire)),
       "employer should receive payout plus slashed bond on expiry"
     );
+  });
+
+  it("scales agent bonds with payout/duration and snapshots per job", async () => {
+    const payoutSmall = toBN(toWei("5"));
+    const payoutLarge = toBN(toWei("50"));
+    const durationShort = 100;
+    const durationLong = 1000;
+    const total = payoutSmall.add(payoutLarge);
+
+    await token.mint(employer, total, { from: owner });
+    await token.approve(manager.address, total, { from: employer });
+
+    const jobSmall = (await manager.createJob("ipfs-small", payoutSmall, durationShort, "details", { from: employer }))
+      .logs[0].args.jobId.toNumber();
+    const jobLarge = (await manager.createJob("ipfs-large", payoutLarge, durationLong, "details", { from: employer }))
+      .logs[0].args.jobId.toNumber();
+
+    const bondSmall = await computeAgentBond(manager, payoutSmall, durationShort);
+    const bondLarge = await computeAgentBond(manager, payoutLarge, durationLong);
+
+    const agentFastBefore = await token.balanceOf(agentFast);
+    await manager.applyForJob(jobSmall, "agent-fast", EMPTY_PROOF, { from: agentFast });
+    const agentFastAfter = await token.balanceOf(agentFast);
+    assert.strictEqual(agentFastBefore.sub(agentFastAfter).toString(), bondSmall.toString());
+
+    const agentSlowBefore = await token.balanceOf(agentSlow);
+    await manager.applyForJob(jobLarge, "agent-slow", EMPTY_PROOF, { from: agentSlow });
+    const agentSlowAfter = await token.balanceOf(agentSlow);
+    assert.strictEqual(agentSlowBefore.sub(agentSlowAfter).toString(), bondLarge.toString());
+    assert(bondLarge.gt(bondSmall), "larger payout/duration should require a larger bond");
+
+    await manager.setAgentBond(0, { from: owner });
+    await manager.setAgentBondParams(0, 0, { from: owner });
+
+    await manager.requestJobCompletion(jobSmall, "ipfs-small-complete", { from: agentFast });
+    await time.increase(2);
+    const agentBeforeFinalize = await token.balanceOf(agentFast);
+    await manager.finalizeJob(jobSmall, { from: employer });
+    const agentAfterFinalize = await token.balanceOf(agentFast);
+
+    const expected = payoutSmall.muln(90).divn(100).add(bondSmall);
+    assert(agentAfterFinalize.sub(agentBeforeFinalize).eq(expected), "snapshot bond should refund on win");
+  });
+
+  it("keeps reputation payout-dependent and caps time bonuses", async () => {
+    const payoutSmall = toBN(toWei("1"));
+    const payoutLarge = toBN(toWei("10"));
+    const duration = 100000;
+    const total = payoutSmall.add(payoutLarge);
+
+    await token.mint(employer, total, { from: owner });
+    await token.approve(manager.address, total, { from: employer });
+
+    const jobSmall = (await manager.createJob("ipfs-rep-small", payoutSmall, duration, "details", { from: employer }))
+      .logs[0].args.jobId.toNumber();
+    const jobLarge = (await manager.createJob("ipfs-rep-large", payoutLarge, duration, "details", { from: employer }))
+      .logs[0].args.jobId.toNumber();
+
+    await manager.applyForJob(jobSmall, "agent-fast", EMPTY_PROOF, { from: agentFast });
+    await manager.applyForJob(jobLarge, "agent-slow", EMPTY_PROOF, { from: agentSlow });
+
+    await manager.requestJobCompletion(jobSmall, "ipfs-rep-small-complete", { from: agentFast });
+    await manager.requestJobCompletion(jobLarge, "ipfs-rep-large-complete", { from: agentSlow });
+    await time.increase(2);
+    await manager.finalizeJob(jobSmall, { from: employer });
+    await manager.finalizeJob(jobLarge, { from: employer });
+
+    const repSmall = await manager.reputation(agentFast);
+    const repLarge = await manager.reputation(agentSlow);
+    assert(repLarge.gt(repSmall), "higher payout should yield higher reputation");
+
+    const baseSmall = Math.floor(Math.log2(1 + 10));
+    assert(repSmall.lte(toBN(baseSmall * 2)), "time bonus should not exceed payout signal");
+  });
+
+  it("scales validator bond for large payouts without low max caps", async () => {
+    const payout = toBN(toWei("4000"));
+    const maxBond = await manager.maxJobPayout();
+    await manager.setValidatorBondParams(1000, 0, maxBond, { from: owner });
+
+    const validatorBond = await computeValidatorBond(manager, payout);
+    const expected = payout.muln(1000).divn(10000);
+    assert(validatorBond.eq(expected), "validator bond should scale with payout");
+    assert(validatorBond.gt(toBN(toWei("200"))), "validator bond should not be capped by legacy max");
+    assert(validatorBond.lte(payout), "validator bond should never exceed payout");
   });
 
   it("requires the employer to finalize when there are no validator votes", async () => {

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -101,7 +101,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("10"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 100);
+    const duration = 100;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
 
     await advanceTime(120);
@@ -109,7 +110,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const employerBefore = await token.balanceOf(employer);
     await manager.expireJob(jobId, { from: other });
     const employerAfter = await token.balanceOf(employer);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     assert.equal(
       employerAfter.toString(),
       employerBefore.add(payout).add(agentBond).toString(),
@@ -135,7 +136,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("3"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 500);
+    const duration = 500;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
 
     await advanceTime(100);
@@ -146,7 +148,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("25"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 1000);
+    const duration = 1000;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
@@ -161,7 +164,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("4"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 1000);
+    const duration = 1000;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
@@ -173,7 +177,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("5"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 1000);
+    const duration = 1000;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
@@ -183,7 +188,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const agentBefore = await token.balanceOf(agent);
     await manager.finalizeJob(jobId, { from: other });
     const agentAfter = await token.balanceOf(agent);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     const expected = payout.muln(90).divn(100).add(agentBond);
     assert.equal(agentAfter.sub(agentBefore).toString(), expected.toString(), "agent should be paid");
   });
@@ -192,7 +197,8 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const payout = toBN(toWei("6"));
     await token.mint(employer, payout, { from: owner });
 
-    const jobId = await createJob(payout, 1000);
+    const duration = 1000;
+    const jobId = await createJob(payout, duration);
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
 
@@ -205,7 +211,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const employerAfter = await token.balanceOf(employer);
     const validationPct = await manager.validationRewardPercentage();
     const validatorReward = payout.mul(validationPct).divn(100);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
       payout.sub(validatorReward).add(agentBond).toString(),
@@ -247,14 +253,13 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
     await manager.disputeJob(jobId, { from: employer });
 
-    await manager.pause({ from: owner });
     await advanceTime(120);
 
     const employerBefore = await token.balanceOf(employer);
     await manager.resolveStaleDispute(jobId, true, { from: owner });
     const employerAfter = await token.balanceOf(employer);
 
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
       payout.add(agentBond).toString(),

--- a/test/merkleAllowlist.test.js
+++ b/test/merkleAllowlist.test.js
@@ -62,7 +62,8 @@ contract("AGIJobManager Merkle allowlists", (accounts) => {
   });
 
   it("keeps allowlists as access-only (no payout boost)", async () => {
-    const jobId = (await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer }))
+    const duration = 3600;
+    const jobId = (await manager.createJob("ipfs-job", payout, duration, "details", { from: employer }))
       .logs[0]
       .args.jobId.toNumber();
 
@@ -96,7 +97,7 @@ contract("AGIJobManager Merkle allowlists", (accounts) => {
     await manager.finalizeJob(jobId, { from: employer });
     const after = await token.balanceOf(agent);
 
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     const expected = payout.muln(payoutTier).divn(100).add(agentBond);
     assert.equal(after.sub(before).toString(), expected.toString(), "payout should match AGIType tier");
   });

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -86,7 +86,8 @@ contract("AGIJobManager security regressions", (accounts) => {
     const payout = toBN(toWei("10"));
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
-    const createTx = await manager.createJob("ipfs", payout, 1000, "details", { from: employer });
+    const duration = 1000;
+    const createTx = await manager.createJob("ipfs", payout, duration, "details", { from: employer });
     const jobId = createTx.logs[0].args.jobId.toNumber();
 
     await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
@@ -133,7 +134,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await manager.resolveDispute(jobId, "agent win", { from: moderator });
 
     const agentBalance = await token.balanceOf(agent);
-    const agentBond = await computeAgentBond(manager, payout);
+    const agentBond = await computeAgentBond(manager, payout, duration);
     const expectedPayout = payout.muln(92).divn(100).add(agentBond);
     assert.equal(
       agentBalance.sub(agentBefore).toString(),


### PR DESCRIPTION
### Motivation
- Make agent bonds and validator stakes meaningfully scale with job payout (and modestly with duration) so capture/stall, low-effort completions, and validator-bribery become expensive relative to payout. 
- Improve dispute liveness so stale disputes can be resolved without halting the whole system while preserving owner/moderator-centered trust and withdraw safety. 
- Remove reputation truncation/time-bonus exploits so reputation is payout-driven and time bonuses cannot dominate payout signal. 
- Preserve existing trust model, ENS/allowlist semantics, pause invariants for `requestJobCompletion()` and `withdrawAGI()`, validator caps, and ERC721 NFT behavior.

### Description
- Agent bonds: added `agentBondBps` and `agentBondMax`, implemented `_computeAgentBond(uint256 payout, uint256 duration)` that computes bond = max(min, payout * bps / 10_000) with optional small duration scaling, caps <= payout, and returns 0 only when all agent-bond params disabled; snapshot bond at `applyForJob()` into `job.agentBondAmount` and increment `lockedAgentBonds`. (contracts/AGIJobManager.sol)
- Validator bonds: raised default `validatorBondBps` and increased `validatorBondMax`, and added a clean disable condition in `_computeValidatorBond()` so zeroing params disables bond computation while still clamping to min/max and to payout. (contracts/AGIJobManager.sol)
- Liveness: removed the `whenPaused` requirement from `resolveStaleDispute()` and now clear `disputed`/`disputedAt` deterministically before calling settlement branches, enabling owner recovery without pausing the whole contract. (contracts/AGIJobManager.sol)
- Reputation: replaced the previous payout/time formula with a payout-weighted base and capped time bonus so `timeBonus` cannot exceed the payout-derived base; used safer arithmetic to avoid truncation that previously created farming vectors. (contracts/AGIJobManager.sol)
- Small admin API: added `setAgentBondParams(uint256 bps, uint256 max)` to tune agent-bond scaling while keeping the original `setAgentBond(uint256)` unchanged. (contracts/AGIJobManager.sol)
- Tests & helpers updated: `test/helpers/bonds.js` extended to compute the new scaled bonds and returned params; many tests updated to pass job `duration` into `computeAgentBond(...)` and new unit tests added in `test/incentiveHardening.test.js` covering bond-scaling, reputation behavior, and validator bond scaling. (multiple files under test/)
- Storage / invariants preserved: `lockedEscrow`, `lockedAgentBonds`, and `lockedValidatorBonds` maintained; `withdrawableAGI()` left intact to exclude all locked obligations.

### Testing
- Attempted full test run with `npm test`, but execution failed due to missing environment dependencies (no `truffle` binary available), so tests were not executed in this environment; `truffle` not found. (automated run failed)
- `npm ci` failed in this environment due to an optional dependency (`fsevents`) not supported on Linux, so CI install did not complete here. (automated run failed)
- `node scripts/check-contract-sizes.js` could not run because compiled Truffle artifacts are missing in this environment, so runtime bytecode size was not measured here. (automated run failed)
- Changes include updated and new unit tests (many files under `test/` and `test/helpers/bonds.js`) that exercise: agent bond scaling & snapshotting, validator bond scaling and cap behavior, reputation anti-farming, stale-dispute owner resolution without pause, and escrow/solvency invariants; these tests should be run in a CI environment with `truffle` available and `npm ci` successful. 

Notes: I preserved the public `agentBond` and `setAgentBond(uint256)` interfaces as required, kept `MAX_VALIDATORS_PER_JOB` unchanged, and avoided large new code paths to respect the contract-size constraint; please run the full `npm test` and the repository contract-size check locally/CI to produce runtime bytecode measurements and verify the updated test suite passes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984f01e480c83338d4a49a7fc9b6e2e)