### PR TITLE
Expose agent bond quote, add payout-scaled agent bonds & slashing, and trim bytecode

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -119,13 +119,17 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
      *      thresholds are met, a short challenge window prevents instant settlement. When validators
      *      participate and the employer wins, the refund is reduced by the validator reward pool.
      */
-    uint256 public validatorBondBps = 50;
-    uint256 public validatorBondMin = 1e18;
+    uint256 public validatorBondBps = 100;
+    uint256 public validatorBondMin = 2e18;
     uint256 public validatorBondMax = 200e18;
     uint256 public validatorSlashBps = 10_000;
     uint256 public challengePeriodAfterApproval = 1 days;
     /// @dev Validator incentives are final-outcome aligned; bonds + challenge windows mitigate bribery but do not eliminate it.
     uint256 public agentBond = 1e18;
+    uint256 internal constant agentBondBps = 100;
+    uint256 internal constant agentBondMin = 1e18;
+    uint256 internal constant agentBondMax = 200e18;
+    uint256 internal constant agentSlashBps = 10_000;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -296,12 +300,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function _safeERC20Transfer(IERC20 token, address to, uint256 amount) internal {
-        if (amount == 0) return;
         _callOptionalReturn(token, abi.encodeWithSelector(token.transfer.selector, to, amount));
     }
 
     function _safeERC20TransferFromExact(IERC20 token, address from, address to, uint256 amount) internal {
-        if (amount == 0) return;
         uint256 balanceBefore = token.balanceOf(to);
         _callOptionalReturn(token, abi.encodeWithSelector(token.transferFrom.selector, from, to, amount));
         uint256 balanceAfter = token.balanceOf(to);
@@ -318,12 +320,20 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function _settleAgentBond(Job storage job, bool agentWon) internal {
         uint256 bond = job.agentBondAmount;
-        if (bond == 0) return;
         job.agentBondAmount = 0;
         unchecked {
             lockedAgentBonds -= bond;
         }
-        _t(agentWon ? job.assignedAgent : job.employer, bond);
+        if (agentWon) {
+            _t(job.assignedAgent, bond);
+        } else {
+            uint256 slashed;
+            unchecked {
+                slashed = (bond * agentSlashBps) / 10_000;
+            }
+            _t(job.employer, slashed);
+            _t(job.assignedAgent, bond - slashed);
+        }
     }
 
     function _validateValidatorThresholds(uint256 approvals, uint256 disapprovals) internal pure {
@@ -340,13 +350,21 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (currentCount >= MAX_VALIDATORS_PER_JOB) revert ValidatorLimitReached();
     }
 
-    function _computeValidatorBond(uint256 payout) internal view returns (uint256 bond) {
+    function _computeBond(uint256 payout, uint256 bps, uint256 min, uint256 max) internal pure returns (uint256 bond) {
         unchecked {
-            bond = (payout * validatorBondBps) / 10_000;
+            bond = (payout * bps) / 10_000;
         }
-        if (bond < validatorBondMin) bond = validatorBondMin;
-        if (bond > validatorBondMax) bond = validatorBondMax;
+        if (bond < min) bond = min;
+        if (bond > max) bond = max;
         if (bond > payout) bond = payout;
+    }
+
+    function _computeValidatorBond(uint256 payout) internal view returns (uint256 bond) {
+        return _computeBond(payout, validatorBondBps, validatorBondMin, validatorBondMax);
+    }
+
+    function agentBondForPayout(uint256 payout) external pure returns (uint256 bond) {
+        return _computeBond(payout, agentBondBps, agentBondMin, agentBondMax);
     }
 
     function _maxAGITypePayoutPercentage() internal view returns (uint256) {
@@ -408,8 +426,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 snapshotPct = getHighestPayoutPercentage(msg.sender);
         if (snapshotPct == 0) revert IneligibleAgentPayout();
         job.agentPayoutPct = uint8(snapshotPct);
-        uint256 bond = agentBond;
-        if (bond > job.payout) bond = job.payout;
+        uint256 bond = _computeBond(job.payout, agentBondBps, agentBondMin, agentBondMax);
         _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
         unchecked {
             lockedAgentBonds += bond;
@@ -456,11 +473,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
                 bond -= 1;
             }
         }
-        if (bond > 0) {
-            _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
-            unchecked {
-                lockedValidatorBonds += bond;
-            }
+        _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
+        unchecked {
+            lockedValidatorBonds += bond;
         }
         emit ValidatorBonded(_jobId, msg.sender, bond, 1);
         _enforceValidatorCapacity(job.validators.length);
@@ -501,11 +516,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
                 bond -= 1;
             }
         }
-        if (bond > 0) {
-            _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
-            unchecked {
-                lockedValidatorBonds += bond;
-            }
+        _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
+        unchecked {
+            lockedValidatorBonds += bond;
         }
         emit ValidatorBonded(_jobId, msg.sender, bond, 2);
         _enforceValidatorCapacity(job.validators.length);
@@ -680,7 +693,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (bps > 10_000) revert InvalidParameters();
         if (min > max) revert InvalidParameters();
         if (!(bps == 0 && min == 0 && max == 0)) {
-            if (max == 0) revert InvalidParameters();
+            if (min == 0 || max == 0) revert InvalidParameters();
         }
         validatorBondBps = bps;
         validatorBondMin = min;

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1819,6 +1819,25 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "payout",
+          "type": "uint256"
+        }
+      ],
+      "name": "agentBondForPayout",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "bond",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "pause",
       "outputs": [],

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -8,8 +8,12 @@ async function fundValidators(token, manager, validators, owner, multiplier = 5)
   return bondMax;
 }
 
-async function resolveAgentBond(manager) {
-  return web3.utils.toBN(await manager.agentBond());
+const AGENT_BOND_BPS = web3.utils.toBN(100);
+const AGENT_BOND_MIN = web3.utils.toBN(web3.utils.toWei("1"));
+const AGENT_BOND_MAX = web3.utils.toBN(web3.utils.toWei("200"));
+
+async function resolveAgentBond(_manager) {
+  return AGENT_BOND_MAX;
 }
 
 async function fundAgents(token, manager, agents, owner, multiplier = 5) {
@@ -28,16 +32,27 @@ async function computeValidatorBond(manager, payout) {
     manager.validatorBondMin(),
     manager.validatorBondMax(),
   ]);
+  if (bps.isZero() && min.isZero() && max.isZero()) {
+    return web3.utils.toBN(0);
+  }
   let bond = payout.mul(bps).divn(10000);
   if (bond.lt(min)) bond = min;
   if (bond.gt(max)) bond = max;
   if (bond.gt(payout)) bond = payout;
+  if (bond.isZero() && payout.gt(web3.utils.toBN(0))) {
+    bond = web3.utils.toBN(1);
+  }
   return bond;
 }
 
 async function computeAgentBond(manager, payout) {
-  const bond = await resolveAgentBond(manager);
-  if (bond.gt(payout)) return payout;
+  if (AGENT_BOND_BPS.isZero() && AGENT_BOND_MIN.isZero() && AGENT_BOND_MAX.isZero()) {
+    return web3.utils.toBN(0);
+  }
+  let bond = payout.mul(AGENT_BOND_BPS).divn(10000);
+  if (bond.lt(AGENT_BOND_MIN)) bond = AGENT_BOND_MIN;
+  if (bond.gt(AGENT_BOND_MAX)) bond = AGENT_BOND_MAX;
+  if (bond.gt(payout)) bond = payout;
   return bond;
 }
 


### PR DESCRIPTION
### Motivation
- Provide a public helper so integrations can compute the agent bond required for a given payout instead of relying on the legacy `agentBond` value. 
- Make agent bonding proportional to job payout and implement idempotent settlement with slashing to create meaningful incentives. 
- Keep the contract under the EIP-170 runtime bytecode cap by streamlining small branches around ERC20 transfer checks.

### Description
- Added a reusable `_computeBond` helper and exposed `agentBondForPayout(uint256)` as a public view to return the computed agent bond for a payout, and wired validator bond computation to reuse `_computeBond` (changes in `contracts/AGIJobManager.sol`).
- Implemented payout-scaled agent bond collection in `applyForJob()` using the new bond math, snapshot `job.agentBondAmount`, track `lockedAgentBonds`, and settle bonds in `_settleAgentBond()` with `agentSlashBps` so employer receives the slashed portion on employer-win while the agent receives the remainder on settlement (changes in `contracts/AGIJobManager.sol`).
- Increased validator bond defaults (`validatorBondBps` 50→100 and `validatorBondMin` 1e18→2e18) and tightened `setValidatorBondParams` validation to avoid enabling a partially-zero bond config (changes in `contracts/AGIJobManager.sol`).
- Streamlined zero-amount ERC20 transfer handling by removing early-return branches in `_safeERC20Transfer` and `_safeERC20TransferFromExact` to reduce bytecode size and keep flow consistent for balance checks (changes in `contracts/AGIJobManager.sol`).
- Updated test helper logic to compute agent/validator bonds consistent with the new parameters and special-casing zero-enabled bond configs (`test/helpers/bonds.js`).
- Refreshed the exported UI ABI to include the new `agentBondForPayout` function (`docs/ui/abi/AGIJobManager.json`).

### Testing
- Ran `npm run ui:abi` to export the updated ABI and `npm test` (which runs `truffle compile --all`, the test suite, and contract-size checks), and the full test suite passed with `193 passing` tests. 
- ABI smoke checks passed and the exported ABI was refreshed to include `agentBondForPayout`. 
- Contract deployed runtime bytecode size recorded as `24572` bytes, which is under the EIP-170 cap (`24575`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e92248f0833386bf25940a34bc90)