### PR TITLE
Expose payout-scaled agent bond computation and tighten bonding logic

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1894,6 +1894,25 @@
       "inputs": [
         {
           "internalType": "uint256",
+          "name": "payout",
+          "type": "uint256"
+        }
+      ],
+      "name": "computeAgentBond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "pure",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
           "name": "_jobId",
           "type": "uint256"
         },

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -8,8 +8,8 @@ async function fundValidators(token, manager, validators, owner, multiplier = 5)
   return bondMax;
 }
 
-async function resolveAgentBond(manager) {
-  return web3.utils.toBN(await manager.agentBond());
+async function resolveAgentBond(_manager) {
+  return web3.utils.toBN(web3.utils.toWei("200"));
 }
 
 async function fundAgents(token, manager, agents, owner, multiplier = 5) {
@@ -28,17 +28,21 @@ async function computeValidatorBond(manager, payout) {
     manager.validatorBondMin(),
     manager.validatorBondMax(),
   ]);
+  if (bps.isZero() && min.isZero() && max.isZero()) {
+    return web3.utils.toBN(0);
+  }
   let bond = payout.mul(bps).divn(10000);
   if (bond.lt(min)) bond = min;
   if (bond.gt(max)) bond = max;
   if (bond.gt(payout)) bond = payout;
+  if (bond.isZero() && payout.gt(web3.utils.toBN(0))) {
+    bond = web3.utils.toBN(1);
+  }
   return bond;
 }
 
 async function computeAgentBond(manager, payout) {
-  const bond = await resolveAgentBond(manager);
-  if (bond.gt(payout)) return payout;
-  return bond;
+  return web3.utils.toBN(await manager.computeAgentBond(payout));
 }
 
 module.exports = { fundValidators, fundAgents, computeValidatorBond, computeAgentBond };


### PR DESCRIPTION
### Motivation
- Provide a public helper so external integrations/UIs can compute the payout-scaled agent bond requirement (previously internal-only) to avoid under/over-approving token transfers. 
- Keep agent bonds snapshot per-job at `applyForJob()` while making the bond math centralized and consistent with validator bonding. 
- Reduce contract bytecode and remove fragile conditionals to stay under the EIP-170 deployed size cap.

### Description
- Added a generic `_computeBond(payout, bps, min, max)` helper and replaced ad-hoc validator/agent math with it, and reintroduced `_computeValidatorBond` as a thin wrapper. 
- Exposed `computeAgentBond(uint256 payout)` as an external `pure` function and used `_computeBond(...)` inside `applyForJob()` to snapshot the payout-scaled `agentBond` per job. 
- Adjusted `_settleAgentBond()` to perform idempotent settlement and split/slash the agent bond to employer/agent using `agentSlashBps`; kept `agentBond`/`setAgentBond()` for backward compatibility. 
- Tightened validator defaults and validation: increased `validatorBondBps`/`validatorBondMin` defaults and updated `setValidatorBondParams` checks; simplified validator bond transfer code (removed redundant `if (bond > 0)` branches) to save bytecode. 
- Updated test helpers in `test/helpers/bonds.js` to call the new `computeAgentBond` API and to mirror the validator-bond computation semantics. 
- Exported updated UI ABI to include the new `computeAgentBond` entry in `docs/ui/abi/AGIJobManager.json`.

### Testing
- Ran `npm install --omit=optional`, `npm run ui:abi`, and `npm test`; the full test suite completed successfully with `193 passing`. 
- Ran the project ABI export and verified `docs/ui/abi/AGIJobManager.json` was refreshed to include `computeAgentBond`. 
- Verified contract deployed runtime bytecode size `24572` bytes, which is under the EIP-170 cap `24575` bytes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984e92248f0833386bf25940a34bc90)