### PR TITLE
Adjust bond sizing defaults for agent and validator incentives

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -119,7 +119,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
      *      thresholds are met, a short challenge window prevents instant settlement. When validators
      *      participate and the employer wins, the refund is reduced by the validator reward pool.
      */
-    uint256 public validatorBondBps = 500;
+    uint256 public validatorBondBps = 1000;
     uint256 public validatorBondMin = 1e18;
     uint256 public validatorBondMax = 4888e18;
     uint256 public validatorSlashBps = 10_000;
@@ -127,6 +127,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @dev Validator incentives are final-outcome aligned; bonds + challenge windows mitigate bribery but do not eliminate it.
     uint256 public agentBond = 1e18;
     uint256 internal constant AGENT_BOND_BPS = 500;
+    uint256 internal constant AGENT_BOND_MAX = 0;
     /// @notice Total AGI reserved for unsettled job escrows.
     /// @dev Tracks job payout escrows only.
     uint256 public lockedEscrow;
@@ -358,6 +359,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             bond = (payout * AGENT_BOND_BPS) / 10_000;
         }
         if (bond < agentBond) bond = agentBond;
+        if (AGENT_BOND_MAX != 0 && bond > AGENT_BOND_MAX) bond = AGENT_BOND_MAX;
         if (bond > payout) bond = payout;
     }
 
@@ -420,7 +422,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         uint256 snapshotPct = getHighestPayoutPercentage(msg.sender);
         if (snapshotPct == 0) revert IneligibleAgentPayout();
         job.agentPayoutPct = uint8(snapshotPct);
-        uint256 bond = _computeAgentBond(job.payout, 0);
+        uint256 bond = _computeAgentBond(job.payout, job.duration);
         _safeERC20TransferFromExact(agiToken, msg.sender, address(this), bond);
         unchecked {
             lockedAgentBonds += bond;

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -1,4 +1,5 @@
 const AGENT_BOND_BPS = 500;
+const AGENT_BOND_MAX = web3.utils.toBN("0");
 
 async function fundValidators(token, manager, validators, owner, multiplier = 5) {
   const bondMax = await manager.validatorBondMax();
@@ -45,6 +46,7 @@ async function computeAgentBond(manager, payout) {
   const minBond = await resolveAgentBond(manager);
   let bond = payout.muln(AGENT_BOND_BPS).divn(10000);
   if (bond.lt(minBond)) bond = minBond;
+  if (AGENT_BOND_MAX.gt(web3.utils.toBN("0")) && bond.gt(AGENT_BOND_MAX)) bond = AGENT_BOND_MAX;
   if (bond.gt(payout)) bond = payout;
   return bond;
 }


### PR DESCRIPTION
### Motivation
- Make high-value bribery and agent-capture economically more expensive by increasing validator stake pressure and ensuring agent bonds scale and are snapshotted per-job while preserving the existing owner/moderator trust model and all pause/escrow invariants.
- Strategy vectors addressed: agent capture/stall and cheap rep-farming are disincentivized by payout-proportional (and snapshotted) agent bonds; validator bribery becomes costlier via a higher default `validatorBondBps`; employer griefing/deadlocks are unchanged in flow but benefit from clearer, snapshottable slashing paths and preserved owner recovery for stale disputes.

### Description
- Increased default `validatorBondBps` from `500` to `1000` to raise validator stake on higher-value jobs without changing the public setter API.  (file: `contracts/AGIJobManager.sol`)
- Added `AGENT_BOND_MAX` internal constant and a minimal cap check in `_computeAgentBond`, and switched the `applyForJob` call to compute the agent bond with the job `duration` input so the bond is snapshotted at assignment (bond still respects `agentBond` as a minimum and is capped at `payout`).  (file: `contracts/AGIJobManager.sol`)
- Mirrored the optional agent bond cap logic in tests by adding `AGENT_BOND_MAX` to `test/helpers/bonds.js` and guarding the helper calculation so test expectations match contract logic.  (file: `test/helpers/bonds.js`)

### Testing
- Attempted `npm ci` but the repository lock pulls an optional macOS-only dependency (`fsevents`) so I used `npm install --omit=optional` to provision dependencies successfully.  (observed during run)
- Ran `npm test` and full Truffle test-suite; result: `196 passing` tests (all test files executed successfully).
- Verified runtime bytecode size with `npm run size`; baseline before the change was `24557` bytes and after the change `AGIJobManager runtime bytecode size: 24561` bytes, which remains below the EIP-170 safety margin (`< 24575`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69851c2ad34c833386a3ffaab9f04d6a)