### PR TITLE
Harden bond parameter validation and disabled-agent-bond guard

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -359,6 +359,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function _computeAgentBond(uint256 payout) internal pure returns (uint256 bond) {
+        if (AGENT_BOND_BPS == 0 && AGENT_BOND_MIN == 0 && AGENT_BOND_MAX == 0) {
+            return 0;
+        }
         unchecked {
             bond = (payout * AGENT_BOND_BPS) / 10_000;
         }
@@ -698,7 +701,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (bps > 10_000) revert InvalidParameters();
         if (min > max) revert InvalidParameters();
         if (!(bps == 0 && min == 0 && max == 0)) {
-            if (max == 0) revert InvalidParameters();
+            if (max == 0 || min == 0) revert InvalidParameters();
         }
         validatorBondBps = bps;
         validatorBondMin = min;


### PR DESCRIPTION
### Motivation
- Make the agent/validator bond paths explicit and safe by ensuring the agent-disabled state is honored and validator bonding cannot be enabled with a zero minimum bond.

### Description
- Add an explicit disabled-path guard to `_computeAgentBond` so it returns `0` when `AGENT_BOND_BPS`, `AGENT_BOND_MIN`, and `AGENT_BOND_MAX` are all zero.
- Tighten `setValidatorBondParams` to require a non-zero `min` whenever validator bonding is enabled (i.e. when not all params are zero).
- Preserve existing `agentBond` state and its setter and avoid any changes to external/public function signatures or trust model.

### Testing
- Installed dependencies with `npm install --no-optional` and ran the full test pipeline with `npm test`, which executed the Truffle tests and node checks and completed with `196 passing`.
- Checked runtime bytecode size with `node scripts/check-bytecode-size.js`, which reported `AGIJobManager runtime bytecode size: 24574 bytes`, under the EIP-170 cap of `24575` bytes.
- Note: `npm ci` on this Linux runner fails due to `fsevents` being an optional macOS-only dependency, but using `--no-optional` allowed the test run to succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852e5a344c8333942a02c2945abdbe)