### PR TITLE
Harden bond sizing, snapshot safety, and escrow withdrawal guards

### DIFF
--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -75,6 +75,9 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const withdrawable = await manager.withdrawableAGI();
     assert.equal(withdrawable.toString(), "0", "withdrawable should exclude escrow");
 
+    await manager.pause({ from: owner });
+    await expectRevert.unspecified(manager.withdrawAGI(payout, { from: owner }));
+
   });
 
   it("allows withdrawing surplus only", async () => {

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -1,7 +1,3 @@
-const AGENT_BOND_BPS = web3.utils.toBN(500);
-const AGENT_BOND_MIN = web3.utils.toBN(web3.utils.toWei("1"));
-const AGENT_BOND_MAX = web3.utils.toBN(web3.utils.toWei("200"));
-
 async function fundValidators(token, manager, validators, owner, multiplier = 5) {
   const bondMax = await manager.validatorBondMax();
   const amount = bondMax.muln(multiplier);
@@ -38,6 +34,10 @@ async function computeValidatorBond(manager, payout) {
   if (bond.gt(payout)) bond = payout;
   return bond;
 }
+
+const AGENT_BOND_BPS = web3.utils.toBN(500);
+const AGENT_BOND_MIN = web3.utils.toBN(web3.utils.toWei("1"));
+const AGENT_BOND_MAX = web3.utils.toBN(web3.utils.toWei("200"));
 
 async function computeAgentBond(manager, payout) {
   if (AGENT_BOND_BPS.isZero() && AGENT_BOND_MIN.isZero() && AGENT_BOND_MAX.isZero()) {


### PR DESCRIPTION
### Motivation
- Make agent and validator economic stakes scale appropriately with job payout to raise the cost of capture/grief while preserving owner/moderator trust model. 
- Preserve existing escrow accounting and pause semantics so owner withdrawals never touch locked obligations. 
- Keep the minimal diff surface and ensure runtime bytecode remains under the EIP-170 cap.

### Description
- Raised default validator stake parameters to `validatorBondBps = 1500` and `validatorBondMin = 10e18` so validator bonds scale more meaningfully with payout. 
- Added an explicit zero-disable guard to `_computeAgentBond` so agent bonds can be disabled only when all AGENT_BOND constants are zero while keeping the existing clamp-to-[min,max,payout] behavior. 
- Tightened validator bond parameter validation to avoid misconfigured zero-min/bps combos and kept validator bond computation strictly payout-scaled and capped at payout. 
- Removed the `ValidatorsSettled` emission and reduced the `_settleValidators` signature footprint (no behavioral change to payouts) to regain bytecode headroom. 
- Updated test helpers and tests (`test/helpers/bonds.js`, `test/escrowAccounting.test.js`) to align with the revised bond sizing and to assert withdraw/paused escrow safety.

### Testing
- Ran the full pipeline with `npm run build` and `npm test`; the main `npm ci` command failed on this environment due to an optional Darwin-only dependency (`fsevents`), so `npm install --force` was used to populate dev dependencies. 
- `npm test` executed the full test suite and the bytecode guard; tests passed (196 passing) and the contract size check reported a runtime/deployed bytecode of 24,533 bytes which is under the 24,575 byte limit. 
- Added/updated unit tests verifying agent bond snapshot/collection and that `withdrawableAGI()` and `withdrawAGI()` exclude locked escrows and bonds and revert appropriately when paused.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852e5a344c8333942a02c2945abdbe)