### PR TITLE
Harden bond configuration checks and guard agent-bond disable path

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -359,6 +359,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
 
     function _computeAgentBond(uint256 payout) internal pure returns (uint256 bond) {
+        if (AGENT_BOND_BPS == 0 && AGENT_BOND_MIN == 0 && AGENT_BOND_MAX == 0) {
+            return 0;
+        }
         unchecked {
             bond = (payout * AGENT_BOND_BPS) / 10_000;
         }
@@ -698,7 +701,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (bps > 10_000) revert InvalidParameters();
         if (min > max) revert InvalidParameters();
         if (!(bps == 0 && min == 0 && max == 0)) {
-            if (max == 0) revert InvalidParameters();
+            if (max == 0 || min == 0) revert InvalidParameters();
         }
         validatorBondBps = bps;
         validatorBondMin = min;


### PR DESCRIPTION
### Motivation
- Protect against accidental zeroing of agent bonds and ensure validator-bond params cannot be partially enabled with a zero minimum, closing subtle attack/configuration vectors.
- Keep changes minimal and bytecode under the EIP-170 cap while preserving existing owner/moderator model and all external interfaces.

### Description
- Added a disable-guard in `_computeAgentBond` so the function returns `0` only when the agent-bond constants are all zero, preserving the proportional bond formula otherwise. 
- Tightened `setValidatorBondParams` validation to require non-zero `min` and `max` whenever bonding is enabled, preventing an enabled-but-zero-min configuration.
- Updated test helper `test/helpers/bonds.js` and one test (`test/incentiveHardening.test.js`) to align with the adjusted bond semantics and constants.

### Testing
- Ran pipeline commands: `npm ci` (failed on optional dependency `fsevents` due to platform), then `npm install --no-optional`, and `npm test` (which executes `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`).
- All automated tests passed: `196 passing` in the test suite.
- Contract deployed runtime bytecode size: `AGIJobManager deployedBytecode size: 24574 bytes`, which is below the EIP-170 cap (`< 24575`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69852e5a344c8333942a02c2945abdbe)