### PR TITLE
Harden AGIJobManager incentives and liveness

### DIFF
--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -37,9 +37,11 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeDisputeBond(manager, payout) {
-  let bond = payout.muln(200).divn(10000);
-  const floor = web3.utils.toBN(await manager.agentBond());
-  if (bond.lt(floor)) bond = floor;
+  const min = web3.utils.toBN(web3.utils.toWei("1"));
+  const max = web3.utils.toBN(web3.utils.toWei("200"));
+  let bond = payout.muln(50).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (!max.isZero() && bond.gt(max)) bond = max;
   if (bond.gt(payout)) bond = payout;
   return bond;
 }
@@ -52,7 +54,7 @@ async function fundDisputeBond(token, manager, disputant, payout, owner) {
 }
 
 const AGENT_BOND_BPS = web3.utils.toBN(500);
-const AGENT_BOND_MAX = web3.utils.toBN(web3.utils.toWei("200"));
+const AGENT_BOND_MAX = web3.utils.toBN("0");
 
 async function computeAgentBond(manager, payout, duration) {
   const agentBond = web3.utils.toBN(await manager.agentBond());


### PR DESCRIPTION
### Motivation
- Remove low-cost stall/capture and make equilibrium strategies align with intended outcomes by (1) eliminating no-vote hold-up, (2) pricing frivolous disputes, (3) increasing validator upside for correct votes, and (4) throttling large-scale job capture and cheap reputation farming.  
- Mechanism-design audit: agents’ capture-and-stall is addressed by permissionless finalization after the review window and an active-job cap; capture-many is throttled by per-agent active job limits; low-effort submission/validator abstention is discouraged by routing agent-loss bond value into the correct-validator reward pool; dispute-spam/extortion is priced by a payout‑scaled dispute bond; employer hold‑up is countered by permissionless finalize; validators’ free‑ride/bribe attractiveness is reduced by enlarging correct-side upside (centralized moderation remains unchanged).  

### Description
- Permissionless no-vote finalization: `finalizeJob` now treats zero validator votes as an eventual agent win after the review window and therefore allows any caller to finalize, removing the employer-only requirement that caused indefinite hold‑ups.  
- Dispute bond: added `DISPUTE_BOND_BPS`, `DISPUTE_BOND_MIN`, `DISPUTE_BOND_MAX` and collection/refund/slash flow for manual `disputeJob` calls, tracked by `lockedDisputeBonds` so `withdrawableAGI` remains sound.  
- Validator incentives and agent-bond routing: on employer-win paths where disapprovals exist, the agent bond is allocated as an extra reward pool for correct validators (handled via an `extraPoolForCorrect` parameter to validator settlement), increasing validator EV to participate and raising the cost of bribery/extortion.  
- Active-job throttle and bond accounting: added `activeJobsByAgent` and an internal `MAX_ACTIVE_JOBS_PER_AGENT` cap enforced in `applyForJob` and decremented on terminal transitions; introduced `_pullAgentBond` helper and ensured all locked counters (`lockedAgentBonds`, `lockedValidatorBonds`, `lockedDisputeBonds`, `lockedEscrow`) remain consistent and idempotent.  
- Reputation anti‑farming: changed reputation base to a payout-driven `payoutSignal = job.payout / 1e16` and bounded the time bonus by `base = log2(1 + payoutSignal)` so tiny payouts cannot meaningfully farm reputation while preserving faster-is-better.  
- Tests and helpers: updated `test/helpers/bonds.js` `computeDisputeBond` behavior and added/updated tests in `test/incentiveHardening.test.js` and `test/livenessTimeouts.test.js` to cover permissionless finalization, dispute-bond accounting, active-job throttling, validator reward routing, and reputation bounding.  

### Testing
- Built and ran targeted tests and size checks: `npx truffle compile --all --network test`, `npx truffle test --network test test/incentiveHardening.test.js`, `npx truffle test --network test test/livenessTimeouts.test.js`, `npx truffle test --network test test/disputeHardening.test.js`, and `npx truffle test --network test test/bytecodeSize.test.js`.  
- All modified/targeted test suites passed (13, 8, and 10 tests respectively in the incentive/liveness/dispute suites) and the bytecode size check passed.  
- Bytecode size: baseline ~24,389 bytes and final deployed size `24,574` bytes, which remains under the EIP‑170 limit (`24,575` bytes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985689c11888333aa04604703021ca3)