### PR TITLE
Harden incentive, liveness, and reputation mechanics

### DIFF
--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -241,12 +241,12 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(rewardPool).add(agentBond).toString(),
+      payout.sub(rewardPool).toString(),
       "employer refund should exclude validator rewards"
     );
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
-      rewardPool.toString(),
+      rewardPool.add(agentBond).toString(),
       "correct disapprover should earn reward pool"
     );
   });

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -37,9 +37,11 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeDisputeBond(manager, payout) {
-  let bond = payout.muln(200).divn(10000);
-  const floor = web3.utils.toBN(await manager.agentBond());
-  if (bond.lt(floor)) bond = floor;
+  let bond = payout.muln(50).divn(10000);
+  const minBond = web3.utils.toBN(web3.utils.toWei("1"));
+  const maxBond = web3.utils.toBN(web3.utils.toWei("200"));
+  if (bond.lt(minBond)) bond = minBond;
+  if (bond.gt(maxBond)) bond = maxBond;
   if (bond.gt(payout)) bond = payout;
   return bond;
 }
@@ -52,7 +54,7 @@ async function fundDisputeBond(token, manager, disputant, payout, owner) {
 }
 
 const AGENT_BOND_BPS = web3.utils.toBN(500);
-const AGENT_BOND_MAX = web3.utils.toBN(web3.utils.toWei("200"));
+const AGENT_BOND_MAX = web3.utils.toBN("0");
 
 async function computeAgentBond(manager, payout, duration) {
   const agentBond = web3.utils.toBN(await manager.agentBond());

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -152,9 +152,15 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
 
     await advanceTime(120);
 
-    await expectCustomError(manager.finalizeJob.call(jobId, { from: agent }), "InvalidState");
-    await expectCustomError(manager.finalizeJob.call(jobId, { from: other }), "InvalidState");
-    await manager.finalizeJob(jobId, { from: employer });
+    const agentBefore = await token.balanceOf(agent);
+    await manager.finalizeJob(jobId, { from: other });
+    const agentAfter = await token.balanceOf(agent);
+    const agentBond = await computeAgentBond(manager, payout, toBN(1000));
+    assert.equal(
+      agentAfter.sub(agentBefore).toString(),
+      payout.muln(90).divn(100).add(agentBond).toString(),
+      "agent should be paid after silent review period"
+    );
   });
 
   it("rejects finalize before the review window elapses", async () => {
@@ -208,13 +214,13 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(validatorReward).add(agentBond).toString(),
+      payout.sub(validatorReward).toString(),
       "employer should be refunded minus validator reward"
     );
     const validatorAfter = await token.balanceOf(validator);
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
-      validatorReward.toString(),
+      validatorReward.add(agentBond).toString(),
       "disapproving validator should be rewarded on employer win"
     );
 

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -271,20 +271,20 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     const agentBondTwo = await computeAgentBond(manager, payoutTwo, toBN(3600));
     const validatorReward = validatorRewardTotal.divn(2);
     assert.equal(
-      employerAfter.toString(),
-      employerBefore.add(payoutTwo.sub(validatorRewardTotal)).add(agentBondTwo).toString(),
+      employerAfter.sub(employerBefore).toString(),
+      payoutTwo.sub(validatorRewardTotal).toString(),
       "employer should be refunded minus validator rewards on employer win"
     );
     const validatorAAfter = await token.balanceOf(validatorA);
     const validatorBAfter = await token.balanceOf(validatorB);
     assert.equal(
       validatorAAfter.sub(validatorABefore).toString(),
-      validatorReward.toString(),
+      validatorReward.add(agentBondTwo.divn(2)).toString(),
       "disapproving validator A should earn rewards on employer win"
     );
     assert.equal(
       validatorBAfter.sub(validatorBBefore).toString(),
-      validatorReward.toString(),
+      validatorReward.add(agentBondTwo.divn(2)).toString(),
       "disapproving validator B should earn rewards on employer win"
     );
     assert.equal((await manager.nextTokenId()).toNumber(), 1, "no NFT should mint on employer win");


### PR DESCRIPTION
### Motivation
- Remove low-cost hold-ups and cheap dispute/extortion while preserving the owner/moderator trust model and existing allowlist/pause semantics. 
- Increase validators' upside and make abstention/bribery less attractive by routing economic upside to correct validators and pricing dispute initiation. 
- Limit attack surface for a single agent locking many escrows and make reputation harder to farm cheaply.

### Description
- Liveness: allow permissionless finalization when `validatorApprovals == 0 && validatorDisapprovals == 0` after the review window so silent validators can no longer cause indefinite hold-ups (`finalizeJob` change). 
- Dispute bond: add sized dispute bond logic (`DISPUTE_BOND_*`, `_computeDisputeBond`) collected only on manual `disputeJob`, tracked in `lockedDisputeBonds`, refunded/slashed to winners/losers in settlement (`_settleDisputeBond`). 
- Validator incentives / abstention: on employer-win with disapprovals present, route the agent bond into the validator reward pool instead of paying it directly to employer; validators split the pool (small signature changes to `_settleValidators` and `_refundEmployer`). 
- Agent capture throttling: add `MAX_ACTIVE_JOBS_PER_AGENT = 3` and per-agent `activeJobsByAgent` counting at `applyForJob` and decrementing on terminal transitions to limit capture-many attacks. 
- Agent bond handling: snapshot/take agent bond with `_takeAgentBond` and ensure idempotent zeroing + locked counters maintained. 
- Reputation anti-farming: change reputation signal to use a payout-based `payoutSignal` and bound the time bonus by the payout-based base so tiny payouts or delaying completion cannot cheaply farm reputation (`_computeReputationPoints`). 
- Minor helpers and tests updated: add `_computeDisputeBond`, adjust withdraw accounting via `lockedDisputeBonds`, adjust validator bond settlement math to avoid stack pressure, and keep all owner/moderator restrictions intact.

### Testing
- Ran full test suite with `npm test` (which runs compilation, all Truffle tests and size checks). Result: `206 passing`. 
- Bytecode size: baseline `AGIJobManager` deployed bytecode = `24,389` bytes; final `AGIJobManager` deployed bytecode = `24,519` bytes, which remains below the EIP-170 limit (`24,575`). 
- Tests modified/added to cover the changes: `test/helpers/bonds.js`, `test/incentiveHardening.test.js`, `test/livenessTimeouts.test.js`, `test/escrowAccounting.test.js`, `test/scenarioEconomicStateMachine.test.js` (see test logs for successful assertions).
- Commands run: `npm test` (this includes `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985689c11888333aa04604703021ca3)