### PR TITLE
Clarify dispute bond settlement behavior

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -356,6 +356,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             lockedDisputeBonds -= bond;
         }
         if (initiator == address(0)) return;
+        // Dispute bonds follow the outcome: initiators are refunded on wins, otherwise the counterparty receives the bond.
         _t(agentWon ? job.assignedAgent : job.employer, bond);
     }
 


### PR DESCRIPTION
### Motivation
- Make the intent and outcome of dispute-bond settlement explicit in `AGIJobManager.sol` so it is clear that dispute bonds follow the resolution (initiators refunded on wins; counterparty receives the bond otherwise). 

### Description
- Added an inline comment and clarified the `_settleDisputeBond(Job storage job, bool agentWon)` flow in `contracts/AGIJobManager.sol` to document that dispute bonds are handed to the outcome winner (agent on `agentWon`, employer on employer win) and that locked dispute accounting is cleared prior to the transfer. 

### Testing
- Ran the full automated test suite and size check with `npm test` and `npm run size`, which completed successfully (`204 passing`) and the runtime bytecode size remained `24540` bytes (baseline `24540` bytes, final `24540` bytes), both within the EIP-170 limit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69857f7425c8833395599af3fb2f7a28)