### PR TITLE
Update dispute windows, price disputes, and add scalable agent bonds

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -588,31 +588,6 @@
       "anonymous": false,
       "inputs": [
         {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "jobId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "lastApprover",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "at",
-          "type": "uint256"
-        }
-      ],
-      "name": "JobValidatorApproved",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
           "indexed": false,
           "internalType": "bytes32",
           "name": "validatorMerkleRoot",
@@ -850,108 +825,8 @@
       "type": "event"
     },
     {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "jobId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "validator",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "bond",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint8",
-          "name": "vote",
-          "type": "uint8"
-        }
-      ],
-      "name": "ValidatorBonded",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "bps",
-          "type": "uint256"
-        }
-      ],
-      "name": "ValidatorSlashBpsUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "jobId",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "bool",
-          "name": "agentWins",
-          "type": "bool"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "correctCount",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "escrowValidatorReward",
-          "type": "uint256"
-        },
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "totalSlashed",
-          "type": "uint256"
-        }
-      ],
-      "name": "ValidatorsSettled",
-      "type": "event"
-    },
-    {
       "inputs": [],
       "name": "MAX_VALIDATORS_PER_JOB",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "",
-          "type": "address"
-        }
-      ],
-      "name": "activeJobsByAgent",
       "outputs": [
         {
           "internalType": "uint256",
@@ -1055,6 +930,32 @@
     {
       "inputs": [],
       "name": "agentBond",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "agentBondBps",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "agentBondMax",
       "outputs": [
         {
           "internalType": "uint256",
@@ -2341,6 +2242,29 @@
         }
       ],
       "name": "setValidatorBondParams",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "bps",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "min",
+          "type": "uint256"
+        },
+        {
+          "internalType": "uint256",
+          "name": "max",
+          "type": "uint256"
+        }
+      ],
+      "name": "setAgentBondParams",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -200,7 +200,10 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const validatorTwoAfter = await token.balanceOf(validatorTwo);
     const validatorThreeAfter = await token.balanceOf(validatorThree);
     const rewardPool = payout.mul(await manager.validationRewardPercentage()).divn(100);
-    const perCorrectReward = rewardPool.add(bond).divn(2);
+    const validatorSlashBps = await manager.validatorSlashBps();
+    const slashedPerIncorrect = bond.mul(validatorSlashBps).divn(10000);
+    const poolForCorrect = rewardPool.add(slashedPerIncorrect);
+    const perCorrectReward = poolForCorrect.divn(2);
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
       perCorrectReward.toString(),
@@ -213,8 +216,8 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     );
     assert.equal(
       validatorTwoBefore.sub(validatorTwoAfter).toString(),
-      bond.toString(),
-      "incorrect validator should lose bonded amount"
+      slashedPerIncorrect.toString(),
+      "incorrect validator should lose slashed amount"
     );
   });
 

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -241,13 +241,16 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     };
 
     assert.ok(balancesAfter.agent.gt(balancesBefore.agent), "agent should receive payout on agent win");
+    const validatorSlashBps = await manager.validatorSlashBps();
+    const slashedPerIncorrect = bond.mul(validatorSlashBps).divn(10000);
+    const incorrectRefund = bond.sub(slashedPerIncorrect);
     assert.ok(
-      balancesAfter.validatorA.eq(balancesBefore.validatorA),
-      "disapproving validators should not regain slashed bonds on agent win"
+      balancesAfter.validatorA.sub(balancesBefore.validatorA).eq(incorrectRefund),
+      "disapproving validator should receive bond minus slashed amount on agent win"
     );
     assert.ok(
-      balancesAfter.validatorB.eq(balancesBefore.validatorB),
-      "disapproving validators should not regain slashed bonds on agent win"
+      balancesAfter.validatorB.sub(balancesBefore.validatorB).eq(incorrectRefund),
+      "disapproving validator should receive bond minus slashed amount on agent win"
     );
 
     const payoutTwo = toBN(toWei("22"));


### PR DESCRIPTION
### Motivation
- Ensure liveness by removing “no votes” settlement deadlocks and prevent late resurrection of jobs by gating disputes and validator votes to the completion review window. 
- Price delay tactics and disputes so they are not free and make bribery/hold-up expensive on high-value jobs. 
- Improve agent economics so agent bonds scale with job payout and duration to better align incentives and reduce cheap reputation farming.

### Description
- Liveness & timing: validator votes and `disputeJob()` are now only allowed inside the completion review window (`require(block.timestamp <= job.completionRequestedAt + completionReviewPeriod)`), and the no-vote finalization branch deterministically awards the agent when the review window elapsed (no employer-only caller gating changes needed).
- Dispute bonds: manual disputes now require a bond sized by the existing validator bond parameters (reusing `_computeValidatorBond(payout)`), which is collected to `lockedDisputeBonds` and settled to winner/agent/initiator idempotently.
- Scalable agent bonds: added owner-configurable `agentBondBps` and `agentBondMax` plus `setAgentBondParams()` (keeps `agentBond` as the minimum); updated `_computeAgentBond(payout,duration)` to return zero if disabled, compute `base = payout * agentBondBps / 10000`, apply the minimum, add a duration scaling term `(base * duration) / jobDurationLimit`, clamp to `agentBondMax` and `payout`, and snapshot/collect per-application as before.
- Validator economics tuning: softened default `validatorSlashBps` from 10000 to 8000 to reduce “one mistake nukes me” equilibria while keeping slashing effective; validator bond formulas unchanged otherwise.
- Minor size and event cleanup: removed some unused events/emit sites and the active-jobs-per-agent state (job cap feature trimmed to stay under the bytecode cap).
- Tests & helpers updated: `test/helpers/bonds.js` now reuses validator bond sizing for dispute bonds and computes agent bonds from the new on-chain params; tests touching liveness, disputes, agent bonds, validator slashing, reputation, and UI ABI exported JSON were updated to reflect the new behavior and math.

### Testing
- Commands run: `npm install --no-optional`, `npm run ui:abi`, `npm test`, `npm run size`.
- Test results: full test suite passed locally: `204 passing` (all modified and existing tests succeeded).
- Bytecode size: `npm run size` reports AGIJobManager runtime bytecode size 24,531 bytes, which is under the EIP-170 safety margin (limit 24,575 bytes).
- Notable automated test assertions added/updated: permissionless no-vote finalize (third party can finalize after review and agent receives payout), dispute window rejections (cannot dispute or vote after review window), dispute bond collection and locked accounting, agent bond scaling with payout and duration, and validator slashing math adjustments (tests updated to reflect reduced `validatorSlashBps`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6985e49cfcc88333b3a449ca44194862)