### PR TITLE
Harden incentives with dispute bonds and active job caps

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -838,6 +838,25 @@
       "type": "function"
     },
     {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "",
+          "type": "address"
+        }
+      ],
+      "name": "activeJobsByAgent",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [],
       "name": "additionalAgentPayoutPercentage",
       "outputs": [

--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -37,7 +37,17 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeDisputeBond(manager, payout) {
-  return computeValidatorBond(manager, payout);
+  const bps = web3.utils.toBN("50");
+  const min = web3.utils.toBN(web3.utils.toWei("1"));
+  const max = web3.utils.toBN(web3.utils.toWei("200"));
+  if (bps.isZero() && min.isZero() && max.isZero()) {
+    return web3.utils.toBN("0");
+  }
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
+  if (bond.gt(payout)) bond = payout;
+  return bond;
 }
 
 async function fundDisputeBond(token, manager, disputant, payout, owner) {


### PR DESCRIPTION
### Motivation

- Prevent no‑vote hold‑up by ensuring permissionless finalization after the review window so inactivity cannot stall payouts indefinitely.
- Price frivolous or extortionate disputes so initiating a dispute is costly and refunded/slashed to align incentives with honest behaviour under centralized moderation.
- Reduce validator abstention and cheap bribery by redirecting agent-loss upside toward correct validators and keeping validator bond economics proportional to payout.
- Limit large‑scale job capture and reputation farming by adding a small per‑agent active‑job throttle and tightening reputation/time bonus arithmetic.

### Description

- Add bounded dispute bond pricing constants and per‑job dispute bond accounting, collect the bond in `disputeJob()` and settle it to the dispute winner in `_settleDisputeBond()` so frivolous disputes are priced and tracked (`lockedDisputeBonds`).
- Enforce a small active‑job throttle by adding `MAX_ACTIVE_JOBS_PER_AGENT` and `activeJobsByAgent`, require the cap in `applyForJob()` and decrement the counter on terminal flows via `_clearActiveAgent()` (called from `_completeJob()`, `_refundEmployer()` and `expireJob()`).
- Improve liveness: preserve permissionless finalization when validators are silent (any caller can finalize after the review window), removing the employer-only no‑vote hold‑up vector.
- Tighten reputation math by increasing payout granularity and capping the time bonus to the payout‑based base so time bonuses are bounded and cannot be cheaply farmed; keep the diminishing function intact.
- Update test helpers and tests: add dispute bond math to `test/helpers/bonds.js`, add an active‑job cap test to `test/incentiveHardening.test.js`, and regenerate the exported UI ABI to reflect the new public view (`activeJobsByAgent`).

### Testing

- Commands run: `npx truffle compile --all`, `npm test`, `npm run ui:abi`, and `node scripts/check-bytecode-size.js`.
- Tests: full test suite executed (`npm test`) and all tests passed locally (206 passing).
- Bytecode sizes: baseline runtime size recorded before changes was `24528` bytes and final runtime size is `24534` bytes, which remains under the EIP‑170 limit (`24575` bytes).
- Specific tests added/updated: `test/helpers/bonds.js` (dispute bond math) and `test/incentiveHardening.test.js` (active job cap + terminal release); the ABI export `docs/ui/abi/AGIJobManager.json` was refreshed to match the compiled contract.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860e2eaf7083338a50ac7b618067d4)