### PR TITLE
Harden incentives: dispute bonds, active-job throttle, validator/rep refactors

### DIFF
--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -37,7 +37,14 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeDisputeBond(manager, payout) {
-  return computeValidatorBond(manager, payout);
+  const bps = web3.utils.toBN("50");
+  const min = web3.utils.toBN(web3.utils.toWei("1"));
+  const max = web3.utils.toBN(web3.utils.toWei("200"));
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
+  if (bond.gt(payout)) bond = payout;
+  return bond;
 }
 
 async function fundDisputeBond(token, manager, disputant, payout, owner) {


### PR DESCRIPTION
### Motivation
- Prevent low-cost liveness and extortion attacks by ensuring completion cannot be hostage to validator silence and by pricing manual disputes with a bond sized to payout.
- Reduce validator abstention and cheap bribery by routing agent-bond upside to correct validators when employer outcomes prevail and by keeping validator bond sizing proportional to payout.
- Throttle single-agent capture-of-many jobs with a small active-job cap and make agent bonds scale with payout+duration to raise the economic cost of mass-griefing. 
- Hardening reputation so tiny payouts cannot be cheaply farmed while preserving a bounded time bonus that rewards faster completion only when meaningful.

### Description
- Add dispute-bond pricing and accounting using internal constants `DISPUTE_BOND_BPS`, `DISPUTE_BOND_MIN`, and `DISPUTE_BOND_MAX` and track `lockedDisputeBonds`, collect bond in `disputeJob()` and settle via `_settleDisputeBond()` so winners receive the bond.  Refactored bond math via `_computeBond()` to centralize sizing logic. 
- Introduce a minimal active-job throttle via `MAX_ACTIVE_JOBS_PER_AGENT` and `activeJobsByAgent` and enforce it in `applyForJob()`, increment on apply and decrement exactly once on terminal transitions (`_completeJob`, `_refundEmployer`, `expireJob`).
- Preserve and reuse existing validator settlement plumbing: `_settleAgentBond()` can return an agent-bond pool for routing into `_settleValidators()` (so correct validators can share an extra pool when employer wins and disapprovals exist), while keeping locked-bond accounting idempotent.
- Tighten liveness: maintain permissionless finalization after the completion review period when there are zero validator votes so silence cannot stall completion forever; keep dispute windows intact so employers can still dispute during the review window.
- Reputation scaling tweaks: increased granularity of payout units to reduce tiny-payout truncation (`payout / 1e15`), keep time bonus bounded by the payout-derived base, and keep earlier diminishing-growth enforcement (`enforceReputationGrowth`).
- Tests and helpers updated: `test/helpers/bonds.js` dispute bond helper adapted, new tests in `test/incentiveHardening.test.js` validating active-job caps and reputation anti-farming behavior, and small test adjustments to reflect the new bond logic.

### Testing
- Baseline runtime bytecode size before changes: `AGIJobManager runtime bytecode size: 24528 bytes` (recorded prior to edits).  Final runtime bytecode size after changes: `24539 bytes` which is under the EIP-170 limit (< 24,575 bytes).
- Commands executed: `npm run size` (bytecode check) and `npm test` (full test suite).
- Results: `npm run size` reported `AGIJobManager runtime bytecode size: 24539 bytes` (pass), and `npm test` completed with `207 passing` (all automated tests passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860e2eaf7083338a50ac7b618067d4)