### PR TITLE
Harden AGIJobManager: dispute bond, active-job throttle, liveness and rep anti-farming

### DIFF
--- a/test/helpers/bonds.js
+++ b/test/helpers/bonds.js
@@ -37,7 +37,14 @@ async function computeValidatorBond(manager, payout) {
 }
 
 async function computeDisputeBond(manager, payout) {
-  return computeValidatorBond(manager, payout);
+  const bps = web3.utils.toBN("50");
+  const min = web3.utils.toBN(web3.utils.toWei("1"));
+  const max = web3.utils.toBN(web3.utils.toWei("200"));
+  let bond = payout.mul(bps).divn(10000);
+  if (bond.lt(min)) bond = min;
+  if (bond.gt(max)) bond = max;
+  if (bond.gt(payout)) bond = payout;
+  return bond;
 }
 
 async function fundDisputeBond(token, manager, disputant, payout, owner) {


### PR DESCRIPTION
### Motivation
- Remove low-cost stall and extortion vectors by ensuring permissionless progress after the review window and by pricing manual disputes. 
- Reduce cheap validator abstention / employer/agent capture-at-scale by aligning stakes with payouts and limiting concurrent active jobs per agent. 
- Make reputation harder to farm via tiny payouts while preserving a bounded time bonus that rewards faster completion. 
- Preserve the existing owner/moderator trust model, NFT behavior, and escrow accounting while keeping bytecode < EIP-170 limit. 

### Description
- Add a capped, payout-scaled dispute bond (constants `DISPUTE_BOND_BPS`, `DISPUTE_BOND_MIN`, `DISPUTE_BOND_MAX`) that is collected on `disputeJob`, tracked in `lockedDisputeBonds`, and settled/refunded/slashed in the existing dispute resolution paths. 
- Introduce a simple active-job throttle with `maxActiveJobsPerAgent = 3` and `activeJobsByAgent` to prevent a single agent from capturing many escrows, incrementing on assignment and decrementing exactly once on terminal transitions (`_decrementActiveJob` called on complete, refund, expire). 
- Strengthen liveness by keeping permissionless finalization when validators are silent (no-vote case remains finalizable for any caller after the review period), eliminating indefinite no-vote hold-up. 
- Tighten reputation math to reduce tiny-payout farming by using a slightly larger payout unit signal (`payoutUnits = job.payout / 1e15`) and keeping the time bonus bounded by the payout-derived base. 
- Small gas/size adjustments: remove a couple of redundant URI checks in tight paths and make some new parameters internal constants to control bytecode growth. 
- Tests and helper changes: add dispute-bond helper in `test/helpers/bonds.js` and expand `test/incentiveHardening.test.js` to cover tiny-payout reputation, active-job throttling, and expiry slot release. 

### Testing
- Ran the full automated suite with `npm test`; result: all tests passed (`208 passing`). 
- Checked bytecode before/after with `npm run size`; baseline `AGIJobManager` runtime bytecode was `24528` bytes and final runtime bytecode is `24545` bytes, which remains below the EIP-170 limit of `24575` bytes. 
- Commands executed: `npm run build`, `npm run size`, and `npm test`; all completed successfully in CI-like local runs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69860e2eaf7083338a50ac7b618067d4)