### PR TITLE
Clarify no-vote liveness settlement in finalizeJob

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -899,6 +899,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (block.timestamp <= job.completionRequestedAt + completionReviewPeriod) revert InvalidState();
 
         if (job.validatorApprovals == 0 && job.validatorDisapprovals == 0) {
+            // No-vote liveness: after the review window, settle deterministically in favor of the agent.
             _completeJob(_jobId, job.validators.length != 0);
             return;
         }


### PR DESCRIPTION
### Motivation
- Make the deterministic no-vote finalization rule explicit so that after the completion review window a silent validator set cannot indefinitely block settlement and anyone can finalize in favor of the agent.

### Description
- Add an in-line comment in `finalizeJob` documenting the no-vote liveness rule that, after the review window elapses and there are zero validator approvals/disapprovals, the job deterministically completes in favor of the agent.

### Testing
- Commands run: `NPM_CONFIG_OPTIONAL=false npm ci --force`, `npm test`, `npm run size`; the full test suite ran and all tests passed (`208 passing`).
- Measured runtime bytecode size: `AGIJobManager runtime bytecode size: 24545 bytes` (under the 24,575 byte limit).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986240ec798833380a763f6e761315b)