### PR TITLE
Simplify no-vote finalization path

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -899,7 +899,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (block.timestamp <= job.completionRequestedAt + completionReviewPeriod) revert InvalidState();
 
         if (job.validatorApprovals == 0 && job.validatorDisapprovals == 0) {
-            _completeJob(_jobId, job.validators.length != 0);
+            _completeJob(_jobId, false);
             return;
         }
         if (job.validatorApprovals > job.validatorDisapprovals) {


### PR DESCRIPTION
### Motivation
- Eliminate the finalization deadlock when validators abstain by making the no-vote outcome deterministic and caller‑independent after the completion review window.

### Description
- Modified `finalizeJob` in `contracts/AGIJobManager.sol` so the branch where `validatorApprovals == 0 && validatorDisapprovals == 0` now calls `_completeJob(_jobId, false)`, deterministically settling in favor of the agent without relying on validator presence or special callers.

### Testing
- Commands run: `npm ci --force` and `npm test` (tests invoke the bytecode size checks); test run produced `208 passing` and `AGIJobManager deployedBytecode size: 24538 bytes` which is below the 24,575 byte cap.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986240ec798833380a763f6e761315b)