### PR TITLE
No-vote finalize determinism: allow anyone to finalize after review window

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -899,7 +899,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (block.timestamp <= job.completionRequestedAt + completionReviewPeriod) revert InvalidState();
 
         if (job.validatorApprovals == 0 && job.validatorDisapprovals == 0) {
-            _completeJob(_jobId, job.validators.length != 0);
+            _completeJob(_jobId, false);
             return;
         }
         if (job.validatorApprovals > job.validatorDisapprovals) {


### PR DESCRIPTION
### Motivation
- Remove the “no votes” finalize deadlock by making the no-vote finalize path permissionless and caller-independent so silence after the review window deterministically completes the job in favor of the agent.

### Description
- Change `finalizeJob()` no-vote branch to deterministically call `_completeJob(_jobId, false)` so a no-vote job finalizes identically for any caller after the review window has elapsed.
- Preserve the review-window restriction on `disputeJob()` and validator voting (validators/disputes remain limited to `completionRequestedAt + completionReviewPeriod`), keeping late resurrection and hold-up mitigations intact.
- No behavioral changes to dispute-bond, agent-bond, validator-bond, reputation, or withdrawable accounting logic were made; the existing tests that cover the no-vote, dispute-timing, and bonded accounting scenarios remain applicable.

### Testing
- Ran `npm ci` (platform optional deps caused `fsevents` warning), then `npm install --omit=optional`, `npm test`, and `npm run size` and verified all automated checks passed.
- Test outcome: `npm test` reported `208 passing` and all suite assertions succeeded.
- Bytecode size: baseline runtime bytecode was `24,545` bytes and final measured runtime bytecode is `24,538` bytes (both under the 24,575 byte limit).
- Commands used: `npm ci`, `npm install --omit=optional`, `npm test`, `npm run size`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986240ec798833380a763f6e761315b)