### PR TITLE
Harden slow-path settlement incentives and validator payout handling

### DIFF
--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -222,7 +222,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
   });
 
   it("refunds employer minus validator rewards when validators participate", async () => {
-    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(2, { from: owner });
     await manager.setCompletionReviewPeriod(1, { from: owner });
 
@@ -244,13 +244,13 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(rewardPool).toString(),
-      "employer refund should exclude validator rewards; agent bond routes to disapprovers"
+      payout.sub(rewardPool).add(agentBond).toString(),
+      "employer refund should exclude validator rewards and include agent bond under low disapprovals"
     );
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
-      rewardPool.add(agentBond).toString(),
-      "correct disapprover should earn reward pool plus agent bond"
+      rewardPool.toString(),
+      "correct disapprover should earn reward pool without agent bond"
     );
   });
 

--- a/test/livenessTimeouts.test.js
+++ b/test/livenessTimeouts.test.js
@@ -80,7 +80,7 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     await manager.addAdditionalValidator(validator, { from: owner });
     await manager.addModerator(moderator, { from: owner });
 
-    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setRequiredValidatorDisapprovals(2, { from: owner });
     await manager.setCompletionReviewPeriod(100, { from: owner });
     await manager.setDisputeReviewPeriod(100, { from: owner });
@@ -229,13 +229,13 @@ contract("AGIJobManager liveness timeouts", (accounts) => {
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(validatorReward).toString(),
-      "employer should be refunded minus validator reward and agent bond"
+      payout.sub(validatorReward).add(agentBond).toString(),
+      "employer should be refunded minus validator reward plus agent bond"
     );
     const validatorAfter = await token.balanceOf(validator);
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
-      validatorReward.add(agentBond).toString(),
+      validatorReward.toString(),
       "disapproving validator should be rewarded on employer win"
     );
 


### PR DESCRIPTION
### Motivation
- Prevent single- or few-voter “dictator vote” outcomes on the slow-path and ensure deterministic job termination while preserving owner/moderator trust model and opt-in validators.
- Remove perverse incentives that route the agent bond to validators on weak negative signals and ensure the validator budget does not become implicit platform revenue when validators abstain.

### Description
- Add quorum derivation for slow-path finalization by computing `quorum = minNonZero(requiredValidatorApprovals, requiredValidatorDisapprovals)` and using it in `finalizeJob`; behavior is: if `T==0` settle agent win, if `T < quorum` settle agent win (size-playbook last-resort rule applied), if `T >= quorum` and `A==D` escalate to dispute, otherwise settle by majority; ties mark `job.disputed` and emit `JobDisputed`.
- Neutralize validator-budget capture by computing `validatorBudget = (job.payout * validationRewardPercentage) / 100` unconditionally in `_completeJob` and refunding that budget to the employer when `validatorCount == 0`; otherwise pass it to `_settleValidators` (no change to NFT, reputation math, or escrow semantics).
- Gate agent-bond pooling into validator rewards only when strong negative signal exists by changing `_refundEmployer` to set `poolToValidators = (requiredValidatorDisapprovals != 0 && job.validatorDisapprovals >= requiredValidatorDisapprovals)`.
- Minimal public API/config changes: removed an earlier optional `voteQuorum` storage to keep bytecode small and instead derive quorum from existing validator thresholds; no new events added.
- Tests updated/added to cover quorum, rebate, and bond-pooling behaviors and a few existing expectations adjusted to reflect the new rebate/pooling semantics; only `contracts/AGIJobManager.sol` and tests were modified.

### Testing
- Ran the full suite: `npm test` (which runs `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`), resulting in all tests passing (213 passing).
- Measured runtime bytecode with `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=a.deployedBytecode||a.evm?.deployedBytecode?.object; console.log('AGIJobManager runtime bytes:', (b.length-2)/2)"` which reported `AGIJobManager runtime bytes: 24568`, below the 24,575 limit.
- Note: an initial `npm ci` invocation failed on an optional `fsevents` platform dependency, but the repository test run was completed after installing dependencies (`npm install --omit=optional`) and all automated tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69863a67811c8333ba3f4d4fdb9f4e59)