### PR TITLE
Harden slow-path quorum settlement and validator incentives

### DIFF
--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -247,18 +247,18 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     assert.equal(
       employerAfter.sub(employerBefore).toString(),
-      payout.sub(rewardPool).toString(),
-      "employer refund should exclude validator rewards; agent bond routes to disapprovers"
+      payout.sub(rewardPool).add(agentBond).toString(),
+      "employer refund should exclude validator rewards and include agent bond"
     );
     assert.equal(
       validatorAfter.sub(validatorBefore).toString(),
-      rewardPool.add(agentBond).divn(2).toString(),
-      "correct disapprover should earn half the reward pool plus agent bond"
+      rewardPool.divn(2).toString(),
+      "correct disapprover should earn half the reward pool"
     );
     assert.equal(
       validatorTwoAfter.sub(validatorTwoBefore).toString(),
-      rewardPool.add(agentBond).divn(2).toString(),
-      "second disapprover should earn half the reward pool plus agent bond"
+      rewardPool.divn(2).toString(),
+      "second disapprover should earn half the reward pool"
     );
   });
 


### PR DESCRIPTION
### Motivation
- Prevent low-participation “dictator vote” outcomes on the slow-path after the completion review period and ensure deterministic termination to either settlement or the dispute/moderator route.
- Preserve the existing centralized trust model (owner + moderators) and opt-in validator semantics while keeping contract runtime size under the EIP-170 safety margin.
- Remove perverse incentives where single disapprovals or zero validator participation could route escrowed funds into platform/validator captures.

### Description
- Add a small shared helper `_markDisputed` and gate the slow-path in `finalizeJob` so that after `completionReviewPeriod` the slow-path settles agent wins only for `T == 0`, but escalates to dispute when `T < quorum` or when `A == D`, and otherwise settles by majority; quorum is derived from the configured validator thresholds.
- Make validator reward budgeting unconditional in `_completeJob` by computing `validatorBudget = (job.payout * validationRewardPercentage) / 100` always, rebate that budget to the employer when `validatorCount == 0`, and otherwise pass it to `_settleValidators` unchanged.
- Change `_refundEmployer` so the agent bond is pooled to validators only when `job.validatorDisapprovals >= requiredValidatorDisapprovals` (strong negative-signal threshold), preventing single-disapproval bounties.
- Update and extend tests to cover quorum escalation, tie escalation, validator-budget rebate-to-employer when zero validators participate, and agent-bond pooling gating; make minimal test adjustments to reflect payout/accounting changes.

### Testing
- Ran the full automated suite with `npm test` (which triggers `truffle compile --all && truffle test ...`) and all tests passed: `215 passing`.
- Compiled with `npx truffle compile` which completed successfully.
- Measured runtime bytecode using `node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=a.deployedBytecode||a.evm?.deployedBytecode?.object; console.log('AGIJobManager runtime bytes:', (b.length-2)/2)"` which reported `AGIJobManager runtime bytes: 24551`, which is under the 24,575 byte EIP-170 safety margin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698648d069508333a66ac4e1dc6381d8)