### PR TITLE
Quorum-gate slow-path finalize with owner-configurable voteQuorum

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1753,6 +1753,19 @@
     },
     {
       "inputs": [],
+      "name": "voteQuorum",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "pause",
       "outputs": [],
       "stateMutability": "nonpayable",
@@ -2154,6 +2167,19 @@
         }
       ],
       "name": "setRequiredValidatorDisapprovals",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "q",
+          "type": "uint256"
+        }
+      ],
+      "name": "setVoteQuorum",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"


### PR DESCRIPTION
### Motivation

- Prevent low-participation validator majorities from deterministically settling jobs on the slow path after the completion review window.  
- Maintain liveness and the existing centralized trust model while keeping changes minimal and bytecode within EIP-170 limits.

### Description

- Add `uint256 public voteQuorum = 3;` and an owner-only setter `setVoteQuorum(uint256 q)` with validation that `q > 0 && q <= MAX_VALIDATORS_PER_JOB`.  (no new events)  
- Change `finalizeJob()` slow-path logic so that after the review window: when `T == 0` the agent still wins deterministically; when `0 < T < voteQuorum` the job is escalated to dispute (`job.disputed = true`, set `disputedAt` if unset and emit `JobDisputed`); when `T >= voteQuorum` ties also escalate; otherwise existing majority settlement applies.  
- Preserve the early-approval path (validator-driven approval + `challengePeriodAfterApproval`) and keep `finalizeJob()` callable regardless of pause.  
- Minor consolidation of state guards and update of the exported UI ABI (`docs/ui/abi/AGIJobManager.json`) to include `voteQuorum` and `setVoteQuorum`.

Files changed: `contracts/AGIJobManager.sol`, `docs/ui/abi/AGIJobManager.json`.

### Testing

- Installed project deps and ran the full test suite with `npm test`, which runs compilation, Truffle tests, the ABI smoke script, and `node scripts/check-contract-sizes.js`; all automated tests passed.  
- Test run summary: `213 passing` (complete test suite).  
- Measured runtime deployed bytecode via the test script: `AGIJobManager deployedBytecode size: 24561 bytes`, measured by running `npm test` (which invokes `node scripts/check-contract-sizes.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986b1f6c294833381a745ff10d7e973)