### PR TITLE
Restore blacklist events; add voteQuorum slow-path gating; trim admin emits

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -102,11 +102,6 @@
       "type": "error"
     },
     {
-      "inputs": [],
-      "name": "ValidatorSetTooLarge",
-      "type": "error"
-    },
-    {
       "anonymous": false,
       "inputs": [
         {
@@ -1753,6 +1748,19 @@
     },
     {
       "inputs": [],
+      "name": "voteQuorum",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "pause",
       "outputs": [],
       "stateMutability": "nonpayable",
@@ -2154,6 +2162,19 @@
         }
       ],
       "name": "setRequiredValidatorDisapprovals",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "_quorum",
+          "type": "uint256"
+        }
+      ],
+      "name": "setVoteQuorum",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"


### PR DESCRIPTION
### Motivation
- Restore `AgentBlacklisted` / `ValidatorBlacklisted` event emissions so off-chain monitors remain in sync with owner blacklist actions.
- Prevent low-participation validator votes from deterministically capturing the slow-path finalization by adding a configurable vote quorum.
- Reduce non-essential bytecode (to satisfy the EIP-170 runtime cap) and keep the UI ABI in sync after changing the contract surface.

### Description
- Re-added emitting `AgentBlacklisted` and `ValidatorBlacklisted` in `blacklistAgent` / `blacklistValidator` so state updates are observable via events.
- Introduced `uint256 public voteQuorum = 3` and owner-only `setVoteQuorum(uint256)` that validates `> 0 && <= MAX_VALIDATORS_PER_JOB` and exported both in the UI ABI.
- Updated `finalizeJob()` slow-path to use `voteQuorum`: after the review period, zero votes settle for the agent with `repEligible = false`, totals below `voteQuorum` (or ties) escalate to dispute, and majority validator outcomes settle with `repEligible = true` where appropriate.
- Removed the unused `ValidatorSetTooLarge` error and trimmed non-critical emits from `setCompletionReviewPeriod` and `setDisputeReviewPeriod` to reduce runtime bytecode, then refreshed `docs/ui/abi/AGIJobManager.json` to match the artifact.

### Testing
- Ran `npm test` (full test suite), which completed successfully with `213 passing` tests.
- Ran `node scripts/check-bytecode-size.js`, which reported `AGIJobManager runtime bytecode size: 24526 bytes`, below the 24576-byte EIP-170 threshold.
- Ran `npm run ui:abi` to export the updated ABI to `docs/ui/abi/AGIJobManager.json`, and the ABI sync tests passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6986bf57807083338621cd03a1fb46b1)