### PR TITLE
Docs: clarify ENS wiring guards; expand docs on bonds, finalization, and identity/escrow invariants

### DIFF
--- a/docs/AGIJobManager_Operator_Guide.md
+++ b/docs/AGIJobManager_Operator_Guide.md
@@ -4,16 +4,30 @@ This runbook is for owners/operators deploying and maintaining the `AGIJobManage
 
 ## Deployment parameters (constructor)
 
-The constructor requires:
+The constructor signature is:
 
-1. `address _agiTokenAddress` — ERC‑20 token used for escrow and payouts.
-2. `string _baseIpfsUrl` — base URL used to prefix non‑full token URIs.
-3. `address _ensAddress` — ENS registry address.
-4. `address _nameWrapperAddress` — ENS NameWrapper address.
-5. `bytes32 _clubRootNode` — ENS root node for validator subdomains.
-6. `bytes32 _agentRootNode` — ENS root node for agent subdomains.
-7. `bytes32 _validatorMerkleRoot` — Merkle root for validator allowlist (leaf = `keccak256(abi.encodePacked(address))`).
-8. `bytes32 _agentMerkleRoot` — Merkle root for agent allowlist (leaf = `keccak256(abi.encodePacked(address))`).
+```
+constructor(
+  address agiTokenAddress,
+  string baseIpfs,
+  address[2] ensConfig,
+  bytes32[4] rootNodes,
+  bytes32[2] merkleRoots
+)
+```
+
+Parameter mapping:
+
+1. `agiTokenAddress` — ERC‑20 token used for escrow and payouts.
+2. `baseIpfs` — base URL used to prefix non‑full token URIs.
+3. `ensConfig[0]` — ENS registry address.
+4. `ensConfig[1]` — ENS NameWrapper address.
+5. `rootNodes[0]` — `clubRootNode` (validator ENS root).
+6. `rootNodes[1]` — `agentRootNode` (agent ENS root).
+7. `rootNodes[2]` — `alphaClubRootNode` (secondary validator root).
+8. `rootNodes[3]` — `alphaAgentRootNode` (secondary agent root).
+9. `merkleRoots[0]` — `validatorMerkleRoot` (leaf = `keccak256(abi.encodePacked(address))`).
+10. `merkleRoots[1]` — `agentMerkleRoot` (leaf = `keccak256(abi.encodePacked(address))`).
 
 The ERC‑721 token is initialized as `AGIJobs` / `Job`.
 
@@ -22,8 +36,13 @@ The ERC‑721 token is initialized as `AGIJobs` / `Job`.
 All parameters are upgradable by the owner. Defaults are set in the contract to conservative values; operators should verify each one before deployment:
 
 - `requiredValidatorApprovals` / `requiredValidatorDisapprovals`: thresholds that control validation vs dispute. Must not exceed `MAX_VALIDATORS_PER_JOB` and the sum must not exceed `MAX_VALIDATORS_PER_JOB`.
+- `voteQuorum`: minimum total validator votes required to avoid an automatic dispute when finalizing after the review period.
 - `validationRewardPercentage`: percent of payout reserved for validators (only paid if at least one validator participates). Keep `max(AGIType.payoutPercentage) + validationRewardPercentage <= 100`.
-- `additionalAgentPayoutPercentage`: stored configuration value; not currently used in payout calculations. Changes emit `AdditionalAgentPayoutPercentageUpdated`.
+- `additionalAgentPayoutPercentage`: stored configuration value; not used in payout calculations. Changes emit `AdditionalAgentPayoutPercentageUpdated`.
+- `validatorBondBps`, `validatorBondMin`, `validatorBondMax`: bond size per validator vote; set to zero to disable bonds.
+- `validatorSlashBps`: slash rate for incorrect validator votes.
+- `agentBondBps`, `agentBond`, `agentBondMax`: agent bond size per job; set to zero to disable agent bonds.
+- `challengePeriodAfterApproval`: delay after validator approval threshold before settlement.
 - `maxJobPayout` / `jobDurationLimit`: upper bounds for new jobs.
 - `completionReviewPeriod` / `disputeReviewPeriod`: timeouts for `finalizeJob` and `resolveStaleDispute`.
 - `premiumReputationThreshold`: threshold for `canAccessPremiumFeature`.
@@ -33,18 +52,23 @@ All parameters are upgradable by the owner. Defaults are set in the contract to 
 ### Pausing
 - `pause`/`unpause` are owner‑only.
 - When paused:
-  - Most job actions are blocked (`createJob`, `applyForJob`, validation, etc.).
+  - Most job actions are blocked (`createJob`, `applyForJob`, validation, disputes).
   - `requestJobCompletion` remains available for assigned agents so completion metadata can be submitted even during a brief pause.
   - `resolveStaleDispute` and `withdrawAGI` require the contract to be paused.
 
 ### Managing allowlists
-- **Merkle roots** are stored on-chain and can be updated by the owner via `updateMerkleRoots`. Treat updates as governance events with audit logs.
+- **Merkle roots** are stored on‑chain and can be updated by the owner via `updateMerkleRoots`. Treat updates as governance events with audit logs.
 - **Explicit allowlists** can be modified at runtime via:
   - `addAdditionalAgent` / `removeAdditionalAgent`
   - `addAdditionalValidator` / `removeAdditionalValidator`
 - **Blacklists** can be enforced via:
   - `blacklistAgent`
   - `blacklistValidator`
+
+### Managing ENS wiring and identity lock
+- ENS wiring functions (`updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`) are only available while `lockIdentityConfig` is false **and** before any jobs exist (`nextJobId == 0`) with zero escrow (`lockedEscrow == 0`).
+- `lockIdentityConfiguration()` permanently disables those wiring updates by setting `lockIdentityConfig = true` and emits `IdentityConfigurationLocked`.
+- `updateMerkleRoots` remains available after the lock and is the primary mechanism for allowlist rotation.
 
 ### Managing moderators
 - `addModerator` / `removeModerator` are owner‑only.
@@ -56,21 +80,22 @@ All parameters are upgradable by the owner. Defaults are set in the contract to 
 - Agent payout percentage is snapshotted at assignment based on the highest AGI type the agent holds.
 
 ### Withdrawing ERC‑20
-- `withdrawAGI(amount)` can only withdraw surplus balances; it fails if `balance < lockedEscrow + lockedAgentBonds + lockedValidatorBonds` or `amount > withdrawableAGI()`.
+- `withdrawAGI(amount)` can only withdraw surplus balances; it fails if `balance < lockedEscrow + lockedAgentBonds + lockedValidatorBonds + lockedDisputeBonds` or `amount > withdrawableAGI()`.
 - Withdrawals are only allowed while paused.
 
 ### Rotating the escrow token
 - `updateAGITokenAddress` changes the ERC‑20 used for escrow, payouts, and reward pool contributions.
+- The token can only be changed while identity configuration is unlocked **and** before any jobs exist (`nextJobId == 0`) with zero escrow (`lockedEscrow == 0`).
 - Changing the token can break integrations and invalidate approvals. Ensure all users re‑approve the new token and carefully manage `lockedEscrow` vs balances before switching.
-- **Production invariant**: treat the escrow token as immutable once jobs are funded. If your program has a canonical token (e.g., AGIALPHA), document the address in deployment records and avoid on-chain rotation outside test environments.
+- **Production invariant**: treat the escrow token as immutable once jobs are funded.
 
 ## Monitoring checklist
 
-- Track `JobCreated`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `JobCompleted`, `DisputeResolvedWithCode`, and `JobFinalized` for lifecycle visibility.
-- Track `AGIWithdrawn` and `lockedEscrow` to ensure the contract remains solvent.
+- Track `JobCreated`, `JobCompletionRequested`, `JobValidated`, `JobDisapproved`, `JobDisputed`, `JobCompleted`, `DisputeResolvedWithCode`, and `JobExpired` for lifecycle visibility.
+- Track `AGIWithdrawn` and `lockedEscrow`/`lockedAgentBonds`/`lockedValidatorBonds`/`lockedDisputeBonds` to ensure the contract remains solvent.
 - Monitor `ReputationUpdated` to maintain off‑chain reputation views.
 
 ## Upgrade & recovery notes
 
 - There is no upgradability pattern; any new version requires a new deployment.
-- If a dispute becomes stale (no moderator action within `disputeReviewPeriod`), the owner can call `resolveStaleDispute` **only while paused**.
+- If a dispute becomes stale (no moderator action within `disputeReviewPeriod`), the owner can call `resolveStaleDispute` (no pause required).

--- a/docs/AGIJobManager_Security.md
+++ b/docs/AGIJobManager_Security.md
@@ -5,7 +5,7 @@ This document summarizes security posture, fixed issues, and remaining risks bas
 ## Reentrancy posture
 
 The contract inherits `ReentrancyGuard` and applies `nonReentrant` to state‑changing functions that handle funds or sensitive transitions, including:
-- Job escrow and settlement (`createJob`, `finalizeJob`, `cancelJob`, `expireJob`).
+- Job escrow and settlement (`createJob`, `cancelJob`, `expireJob`, `finalizeJob`).
 - Validation and dispute resolution (`validateJob`, `disapproveJob`, `disputeJob`, `resolveDispute`, `resolveDisputeWithCode`, `resolveStaleDispute`).
 - Funds management (`withdrawAGI`, `contributeToRewardPool`).
 
@@ -17,23 +17,26 @@ The contract explicitly addresses common issues observed in earlier variants:
 
 - **Phantom job IDs / takeover**: `_job` reverts when the job’s employer is the zero address. This prevents interacting with deleted or nonexistent job records.
 - **Double voting by validators**: `approvals` and `disapprovals` mappings enforce single‑vote behavior, and the contract reverts if a validator tries to vote twice or vote on both sides.
-- **Division by zero on validator payouts**: validator payouts are only computed if `validators.length > 0`; otherwise, validator payout is zero.
+- **Division by zero on validator payouts**: validator payouts are only computed if `validators.length > 0`; otherwise, the validator budget is returned to the employer.
 - **Employer‑win double completion**: `_refundEmployer` marks the job as completed and releases escrow, preventing additional settlement paths.
 - **Unchecked ERC‑20 transfers**: `_callOptionalReturn` and `_safeERC20TransferFromExact` enforce successful transfers and exact amount receipt; fee‑on‑transfer or non‑standard tokens will revert.
 - **Validator bonds & slashing**: bonded voting is accounted via `lockedValidatorBonds` and released on settlement; incorrect votes are slashed, while correct votes receive rewards.
+- **Challenge window**: after approvals reach threshold, `challengePeriodAfterApproval` prevents instant settlement to mitigate last‑block bribery.
 
 ## Remaining risks and assumptions
 
-- **Owner centralization**: the owner can pause/unpause, modify parameters, update the escrow token, add AGI types, and withdraw surplus funds. A compromised owner can disrupt or redirect flows.
+- **Owner centralization**: the owner can pause/unpause, modify parameters, update the escrow token (pre‑lock), add AGI types, and withdraw surplus funds. A compromised owner can disrupt or redirect flows.
 - **Moderator trust**: moderators can unilaterally decide disputes. There is no on‑chain appeal mechanism.
 - **External dependencies**: ENS, NameWrapper, and Resolver contracts are trusted for ownership validation.
-- **Merkle root management**: Merkle roots are set at deployment but can be updated by the owner via `updateMerkleRoots`. Incorrect roots can be corrected without redeploying; use explicit allowlists for urgent recovery while governance approves an update.
+- **Merkle root management**: Merkle roots can be updated by the owner via `updateMerkleRoots`. Incorrect roots can be corrected without redeploying; use explicit allowlists for urgent recovery while governance approves an update.
 - **ERC‑20 behavior assumptions**: the token must return `true` on transfers or provide no return data, and it must transfer exact amounts (no transfer fees). Fee‑on‑transfer tokens are incompatible.
-- **Escrow solvency**: `withdrawableAGI` reverts if the contract balance is below `lockedEscrow + lockedAgentBonds + lockedValidatorBonds`. Operators must avoid draining escrowed funds or locked bonds by mistake.
+- **Escrow solvency**: `withdrawableAGI` reverts if the contract balance is below `lockedEscrow + lockedAgentBonds + lockedValidatorBonds + lockedDisputeBonds`. Operators must avoid draining escrowed funds or locked bonds by mistake.
+- **Dispute bonds**: the dispute bond is paid to the winning side, not refunded to the initiator unless they win. Ensure participants understand this risk.
+- **Vote quorum edge cases**: after the completion review period, jobs with low vote counts or ties are auto‑disputed, which relies on moderator availability or owner intervention after `disputeReviewPeriod`.
 
 ## Recommended best practices
 
 - Use multi‑sig ownership and rotate moderators periodically.
-- Monitor `lockedEscrow + lockedAgentBonds + lockedValidatorBonds` and ensure the contract’s ERC‑20 balance never drops below it.
+- Monitor `lockedEscrow + lockedAgentBonds + lockedValidatorBonds + lockedDisputeBonds` and ensure the contract’s ERC‑20 balance never drops below it.
 - Ensure validator thresholds, AGI type percentages, and validation reward percentage maintain `agentPayoutPct + validationRewardPercentage <= 100`.
 - Prefer explicit allowlisting when ENS/Merkle configuration is uncertain.


### PR DESCRIPTION
### Motivation
- Remove ambiguous operator guidance around ENS/token/root rotation so operators know wiring changes require identity unlock plus zero jobs/escrow (`nextJobId == 0` and `lockedEscrow == 0`).
- Align the documentation with contract behavior for validator rewards, bonded voting, dispute bonds, and finalization windows so integrators can reason about escrow solvency and settlement outcomes.
- Surface identity/ENS/Merkle verification nuances and the one‑way identity lock to reduce operator errors during rotations and audits.

### Description
- Updated `docs/AGIJobManager_Operator_Guide.md` to require identity config unlocked **and** zero jobs/zero escrow for `updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, and `updateRootNodes`, and clarified token-rotation guidance. 
- Revised `docs/AGIJobManager.md` to document agent/validator/dispute bond accounting, validator slashing/reward semantics (only correct‑side validators split the reward pool), `challengePeriodAfterApproval`/finalization flow, no‑vote liveness, and tightened `withdrawableAGI`/escrow invariants to include `lockedDisputeBonds`.
- Regenerated and edited `docs/AGIJobManager_Interface.md` to reflect ABI‑accurate events, added bond/quorum/challenge fields, updated function preconditions (ENS wiring guards, bond collection on votes, `finalizeJob` logic), and aligned event/error signatures with the implementation.
- Updated `docs/AGIJobManager_Security.md` to call out dispute bond handling, vote quorum edge cases, challenge window mitigation, and updated insolvency monitoring to include dispute bonds.

### Testing
- No automated tests were run because these are documentation-only changes and do not modify contract source or runtime behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69873ed5fbd08333bed67bd4a22e7142)