### PR TITLE
Clarify ENS wiring update guards

### DIFF
--- a/docs/AGIJobManager_Operator_Guide.md
+++ b/docs/AGIJobManager_Operator_Guide.md
@@ -66,7 +66,7 @@ All parameters are upgradable by the owner. Defaults are set in the contract to 
   - `blacklistValidator`
 
 ### Managing ENS wiring and identity lock
-- ENS wiring functions (`updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`) are only available while `lockIdentityConfig` is false **and** only before any jobs exist (`nextJobId == 0`) with zero escrow (`lockedEscrow == 0`).
+- ENS wiring functions (`updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`) are only available while `lockIdentityConfig` is false **and** only before any jobs exist (`nextJobId == 0`) with zero escrow (`lockedEscrow == 0`). If either guard fails, the call reverts with `InvalidState` even if identity configuration is still unlocked.
 - `lockIdentityConfiguration()` permanently disables those wiring updates by setting `lockIdentityConfig = true` and emits `IdentityConfigurationLocked`.
 - `updateMerkleRoots` remains available after the lock and is the primary mechanism for allowlist rotation.
 


### PR DESCRIPTION
### Motivation
- Clarify that ENS wiring update functions are not only gated by `lockIdentityConfig` but also require `nextJobId == 0` and `lockedEscrow == 0`, since the contract reverts otherwise and operators could be misled.

### Description
- Update `docs/AGIJobManager_Operator_Guide.md` to explicitly state that calls to `updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, and `updateRootNodes` will revert with `InvalidState` if either the identity lock is unlocked but `nextJobId != 0` or `lockedEscrow != 0`.

### Testing
- No automated tests were run because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698750689e908333aceca697d533b290)