### PR TITLE
docs: expand game-theory, validator guidance, and known-issues; update README pointer

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@
 **Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
 
 ## Incentives & game theory
-AGIJobManager is optimized for a **business‑run escrow** with a **permissioned validator club** and **moderator backstop**—not a trustless court. “Optimal” means **liveness**, **priced deviations**, **predictable validator turnout**, and **cheap operations** given that trust model. See [`docs/game-theory.md`](docs/game-theory.md) for the full incentive map, deviation strategies, and operator playbooks. Validators and operators should read the parameter tuning and off‑chain policy sections before production use.
+AGIJobManager is optimized for a **business‑run escrow** with a **permissioned validator club** and **moderator backstop**—not a trustless court. “Optimal” here means **liveness**, **priced deviations**, **predictable validator turnout**, and **cheap operations** within that trust model. The full incentive map, deviation strategies, and operator playbooks live in [`docs/game-theory.md`](docs/game-theory.md). Validators should review the vote‑window and evidence expectations; operators should review the parameter‑tuning and off‑chain governance sections before production use.
 
 ## NFT trading
 

--- a/docs/KNOWN_ISSUES.md
+++ b/docs/KNOWN_ISSUES.md
@@ -23,6 +23,26 @@ and fails on Linux in this environment.
   `package-lock.json`), then rerun `npm ci` when appropriate in a macOS
   environment.
 
+## `npm ci --omit=optional` still fails on Linux
+
+**Reproduction**
+```bash
+npm ci --omit=optional
+```
+
+**Failure**
+```
+npm error notsup Unsupported platform for fsevents@2.3.2: wanted {"os":"darwin"} (current: {"os":"linux"})
+```
+
+**Root cause**
+The `fsevents` dependency is still treated as required in this environment,
+even with `--omit=optional`.
+
+**Smallest fix**
+- Resolve `fsevents` handling in the lockfile or run installs on macOS; then
+  rerun `npm ci`.
+
 ## `npx truffle compile` / `npx truffle test` fail with missing `dotenv`
 
 **Reproduction**
@@ -62,3 +82,21 @@ sh: 1: truffle: not found
 
 **Smallest fix**
 - Resolve the `npm ci` Linux failure above, then rerun `npm test`.
+
+## `npm run lint` fails because `solhint` is missing
+
+**Reproduction**
+```bash
+npm run lint
+```
+
+**Failure**
+```
+sh: 1: solhint: not found
+```
+
+**Root cause**
+`npm ci` failed, so `solhint` (a dev dependency) was not installed.
+
+**Smallest fix**
+- Resolve the `npm ci` Linux failure above, then rerun `npm run lint`.

--- a/docs/validator-guide.md
+++ b/docs/validator-guide.md
@@ -1,6 +1,6 @@
 # Validator guide (10‑minute workflow)
 
-This short guide helps permissioned validators review and vote on a job. It is intentionally practical and maps directly to on‑chain fields like `jobSpecURI` and `jobCompletionURI`. For incentive context, see [`game-theory.md`](game-theory.md).
+This short guide helps permissioned validators review and vote on a job in **~10 minutes**. It is intentionally practical and maps directly to on‑chain fields like `jobSpecURI` and `jobCompletionURI`. For incentive context and strategic risks, see [`game-theory.md`](game-theory.md).
 
 ## 1) Confirm you are eligible
 Validators must be allowlisted **or** hold a valid ENS identity in the platform’s validator namespace (the “ENS club”). If you are unsure, ask the operator for your allowlist status or ENS namespace.
@@ -26,6 +26,7 @@ A simple checklist template:
 
 ## 5) Vote within the review window
 - Voting requires a **validator bond**; it is **returned if you vote with the final outcome** and **partially slashed** if you are on the losing side (see `validatorSlashBps` in the contract docs).
+- Voting is only counted **before `completionReviewPeriod` ends**. Once a job is **disputed**, validator votes no longer advance settlement.
 - If no validators vote before the review window ends, the job can still settle via the **no‑vote liveness** rule (agent wins without reputation).
 
 ## 6) After you vote
@@ -37,6 +38,15 @@ A simple checklist template:
 - A completion JSON that maps to the spec’s deliverables.
 - A manifest (hashes/CIDs) or reproducible steps to verify artifacts.
 - A short note on any deviations and why they are acceptable.
+
+## 8) When to abstain (and why)
+- **Abstain** if you cannot access the evidence, if links are broken, or if the spec is ambiguous. Abstention avoids incorrect slashing but has an opportunity cost because validator rewards are paid only when you vote with the final outcome.
+- **Escalate** to moderators or operators when ambiguity is systemic (e.g., missing acceptance criteria); disputes freeze validator voting and rely on moderator resolution.
+
+## 9) Bonds and slashing: how your vote pays out
+- **Correct vote** (final outcome matches your vote): bond returned + share of validator reward pool.
+- **Incorrect vote**: bond is partially slashed (`validatorSlashBps`) and you forgo validator rewards.
+- **No vote**: no bond risk, but also no validator reward. Repeated abstention can reduce operator trust.
 
 ## Quick tips
 - Never vote without reading both the spec and completion.


### PR DESCRIPTION
### Motivation
- Clarify the game‑theoretic / incentive design and operator playbooks so validators, employers, agents, and moderators can reason about strategic behavior using the actual contract semantics. 
- Make explicit which incentives are enforced on‑chain (function names, parameters, thresholds, bonds, slashing) versus what is an off‑chain or operator responsibility under the owner‑operated escrow trust model. 
- Reduce operational surprise by documenting common failure modes and local CI / test limitations observed when validating changes.

### Description
- Expanded `docs/game-theory.md` with a full A→H structure: explicit definition of “optimal” for this repo, role actions tied to functions (`createJob`, `applyForJob`, `requestJobCompletion`, `validateJob`, `disapproveJob`, `disputeJob`, `finalizeJob`, `resolveDisputeWithCode`, `resolveStaleDispute`), lifecycle incentives, deviation strategies, parameter tuning playbook (including `requiredValidatorApprovals`, `requiredValidatorDisapprovals`, `voteQuorum`, `completionReviewPeriod`, `disputeReviewPeriod`, `challengePeriodAfterApproval`, bonds and `validatorSlashBps`), operator policies, limitations, and future improvements (docs‑only). 
- Improved `docs/validator-guide.md` with a concise ~10‑minute workflow, explicit vote‑window constraints (`completionReviewPeriod`), guidance on when to abstain vs escalate, and a plain description of bonds/slashing payout behavior (correct/incorrect/no‑vote). 
- Updated `README.md` to point concisely to `docs/game-theory.md` and to state the trust model and what “optimal” means in this context. 
- Updated `docs/KNOWN_ISSUES.md` to record reproducible local install/test failures observed in this environment (macOS‑only `fsevents` in lockfile causing `npm ci` failure, missing `truffle`/`solhint` after failed install) and the minimal mitigations; added a small numeric example of payout + validator pool in `docs/game-theory.md`. 
- Files changed: `docs/game-theory.md`, `docs/validator-guide.md`, `docs/KNOWN_ISSUES.md`, `README.md`.

### Testing
- Ran `npm ci` which failed due to an optional macOS dependency: `fsevents@2.3.2` unsupported on Linux (error: "Unsupported platform for fsevents@2.3.2: wanted {\"os\":\"darwin\"}").
- Ran `npm ci --omit=optional` which also failed in this environment with the same `fsevents` error observed here, so dev dependencies were not installed.
- Ran `npm test` which could not run because `truffle` was not installed (failure: `sh: 1: truffle: not found`) as a direct consequence of `npm ci` failing.
- Ran `npm run lint` which could not run because `solhint` was not installed (failure: `sh: 1: solhint: not found`) for the same root cause; recorded all of the above in `docs/KNOWN_ISSUES.md`.
- No on‑chain or contract code was modified and no contract tests were executed successfully in this environment due to the dependency/install failures; the PR is docs‑only and includes a commit with these doc updates.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698778f7e9fc83338a11cd75eea6d876)