### PR TITLE
Add ENSJobPages helper, ENS interfaces and test mocks; update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,10 @@ AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other ma
 - **Docs index**: [`docs/README.md`](docs/README.md)
 - **Local test status**: [`docs/test-status.md`](docs/test-status.md)
 
+## ENS job pages (ALPHA)
+
+AGIJobManager can be paired with the **ENSJobPages** helper to publish **official ENS job pages** under `job-<jobId>.alpha.jobs.agi.eth`, owned by the platform with delegated resolver write access for employers + assigned agents. See [`docs/ens-job-pages.md`](docs/ens-job-pages.md) for naming, record keys, and operational notes.
+
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 
 **ERC‑8004** standardizes *trust signals* (identity, reputation, validation outcomes) for off-chain publication and indexing. **AGIJobManager** enforces *settlement* (escrow, payouts, dispute resolution, reputation updates) on-chain.

--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -1,0 +1,244 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "./IAGIJobManagerView.sol";
+
+interface IENSRegistry {
+    function owner(bytes32 node) external view returns (address);
+    function resolver(bytes32 node) external view returns (address);
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external;
+}
+
+interface IPublicResolver {
+    function setAuthorisation(bytes32 node, address target, bool isAuthorised) external;
+    function setText(bytes32 node, string calldata key, string calldata value) external;
+}
+
+interface INameWrapper {
+    function ownerOf(uint256 id) external view returns (address);
+    function isApprovedForAll(address owner, address operator) external view returns (bool);
+    function isWrapped(bytes32 node) external view returns (bool);
+    function setSubnodeRecord(
+        bytes32 node,
+        bytes32 label,
+        address owner,
+        address resolver,
+        uint64 ttl,
+        uint32 fuses,
+        uint64 expiry
+    ) external returns (bytes32);
+    function setFuses(bytes32 node, uint16 ownerControlledFuses) external returns (uint32);
+}
+
+contract ENSJobPages is Ownable {
+    using Strings for uint256;
+
+    error InvalidParameters();
+    error NotAuthorized();
+
+    uint8 private constant HOOK_CREATE = 1;
+    uint8 private constant HOOK_ASSIGNED = 2;
+    uint8 private constant HOOK_TERMINAL = 3;
+
+    IENSRegistry public ens;
+    INameWrapper public nameWrapper;
+    IPublicResolver public publicResolver;
+    bytes32 public jobsRootNode;
+    string public jobsRootName;
+
+    event ENSRegistryUpdated(address indexed ensRegistry);
+    event NameWrapperUpdated(address indexed nameWrapper);
+    event PublicResolverUpdated(address indexed publicResolver);
+    event JobsRootNodeUpdated(bytes32 indexed jobsRootNode, string jobsRootName);
+    event JobENSPageCreated(uint256 indexed jobId, bytes32 indexed node);
+    event JobENSPermissionsUpdated(uint256 indexed jobId, address indexed account, bool enabled);
+    event JobENSLocked(uint256 indexed jobId, bytes32 indexed node, bool fusesBurned);
+
+    constructor(
+        address ensRegistry,
+        address wrapper,
+        address resolver,
+        bytes32 rootNode,
+        string memory rootName
+    ) {
+        if (ensRegistry == address(0) || resolver == address(0)) revert InvalidParameters();
+        ens = IENSRegistry(ensRegistry);
+        nameWrapper = INameWrapper(wrapper);
+        publicResolver = IPublicResolver(resolver);
+        jobsRootNode = rootNode;
+        jobsRootName = rootName;
+    }
+
+    function setENSRegistry(address ensRegistry) external onlyOwner {
+        if (ensRegistry == address(0)) revert InvalidParameters();
+        ens = IENSRegistry(ensRegistry);
+        emit ENSRegistryUpdated(ensRegistry);
+    }
+
+    function setNameWrapper(address wrapper) external onlyOwner {
+        nameWrapper = INameWrapper(wrapper);
+        emit NameWrapperUpdated(wrapper);
+    }
+
+    function setPublicResolver(address resolver) external onlyOwner {
+        if (resolver == address(0)) revert InvalidParameters();
+        publicResolver = IPublicResolver(resolver);
+        emit PublicResolverUpdated(resolver);
+    }
+
+    function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner {
+        if (rootNode == bytes32(0)) revert InvalidParameters();
+        jobsRootNode = rootNode;
+        jobsRootName = rootName;
+        emit JobsRootNodeUpdated(rootNode, rootName);
+    }
+
+    function jobEnsLabel(uint256 jobId) public pure returns (string memory) {
+        return string(abi.encodePacked("job-", jobId.toString()));
+    }
+
+    function jobEnsName(uint256 jobId) public view returns (string memory) {
+        return string(abi.encodePacked(jobEnsLabel(jobId), ".", jobsRootName));
+    }
+
+    function jobEnsUri(uint256 jobId) public view returns (string memory) {
+        return string(abi.encodePacked("ens://", jobEnsName(jobId)));
+    }
+
+    function jobEnsNode(uint256 jobId) public view returns (bytes32) {
+        bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
+        return keccak256(abi.encodePacked(jobsRootNode, labelHash));
+    }
+
+    function createJobPage(uint256 jobId, address employer) public onlyOwner {
+        if (address(ens) == address(0) || address(publicResolver) == address(0)) revert InvalidParameters();
+        if (jobsRootNode == bytes32(0)) revert InvalidParameters();
+        bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
+        bytes32 node;
+        if (_isWrappedRoot()) {
+            _requireWrappedPermission();
+            node = nameWrapper.setSubnodeRecord(
+                jobsRootNode,
+                labelHash,
+                address(this),
+                address(publicResolver),
+                0,
+                0,
+                type(uint64).max
+            );
+        } else {
+            if (ens.owner(jobsRootNode) != address(this)) revert NotAuthorized();
+            ens.setSubnodeRecord(jobsRootNode, labelHash, address(this), address(publicResolver), 0);
+            node = keccak256(abi.encodePacked(jobsRootNode, labelHash));
+        }
+
+        publicResolver.setAuthorisation(node, employer, true);
+        emit JobENSPageCreated(jobId, node);
+        emit JobENSPermissionsUpdated(jobId, employer, true);
+
+        string memory specURI = IAGIJobManagerView(msg.sender).getJobSpecURI(jobId);
+        _trySetText(node, "schema", "agijobmanager/v1");
+        _trySetText(node, "agijobs.spec.public", specURI);
+    }
+
+    function onAgentAssigned(uint256 jobId, address agent) public onlyOwner {
+        bytes32 node = jobEnsNode(jobId);
+        publicResolver.setAuthorisation(node, agent, true);
+        emit JobENSPermissionsUpdated(jobId, agent, true);
+    }
+
+    function onCompletionRequested(uint256 jobId) public onlyOwner {
+        bytes32 node = jobEnsNode(jobId);
+        string memory completionURI = IAGIJobManagerView(msg.sender).getJobCompletionURI(jobId);
+        _trySetText(node, "agijobs.completion.public", completionURI);
+    }
+
+    function onJobEvent(uint256 jobId, uint8 hookType) external onlyOwner {
+        (
+            address employer,
+            address assignedAgent,
+            uint256 payout,
+            uint256 duration,
+            uint256 assignedAt,
+            bool completed,
+            bool disputed,
+            bool expired,
+            uint8 agentPayoutPct
+        ) = IAGIJobManagerView(msg.sender).getJobCore(jobId);
+        payout;
+        duration;
+        assignedAt;
+        completed;
+        disputed;
+        expired;
+        agentPayoutPct;
+
+        if (hookType == HOOK_CREATE) {
+            createJobPage(jobId, employer);
+        } else if (hookType == HOOK_ASSIGNED) {
+            onAgentAssigned(jobId, assignedAgent);
+        } else if (hookType == HOOK_TERMINAL) {
+            revokePermissions(jobId, employer, assignedAgent);
+        } else {
+            revert InvalidParameters();
+        }
+    }
+
+    function revokePermissions(uint256 jobId, address employer, address agent) public onlyOwner {
+        bytes32 node = jobEnsNode(jobId);
+        _trySetAuthorisation(node, employer, false, jobId);
+        _trySetAuthorisation(node, agent, false, jobId);
+    }
+
+    function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external onlyOwner {
+        bytes32 node = jobEnsNode(jobId);
+        revokePermissions(jobId, employer, agent);
+
+        bool fusesBurned;
+        if (burnFuses && _isWrapped(node)) {
+            try nameWrapper.setFuses(node, type(uint16).max) returns (uint32) {
+                fusesBurned = true;
+            } catch {}
+        }
+
+        emit JobENSLocked(jobId, node, fusesBurned);
+    }
+
+    function _trySetText(bytes32 node, string memory key, string memory value) internal {
+        if (bytes(value).length == 0) return;
+        try publicResolver.setText(node, key, value) {
+        } catch {}
+    }
+
+    function _trySetAuthorisation(bytes32 node, address account, bool enabled, uint256 jobId) internal {
+        if (account == address(0)) return;
+        try publicResolver.setAuthorisation(node, account, enabled) {
+            emit JobENSPermissionsUpdated(jobId, account, enabled);
+        } catch {}
+    }
+
+    function _isWrappedRoot() internal view returns (bool) {
+        address wrapper = address(nameWrapper);
+        return wrapper != address(0) && ens.owner(jobsRootNode) == wrapper;
+    }
+
+    function _isWrapped(bytes32 node) internal view returns (bool wrapped) {
+        if (address(nameWrapper) == address(0)) {
+            return false;
+        }
+        try nameWrapper.isWrapped(node) returns (bool value) {
+            wrapped = value;
+        } catch {
+            wrapped = false;
+        }
+    }
+
+    function _requireWrappedPermission() internal view {
+        address wrapperOwner = nameWrapper.ownerOf(uint256(jobsRootNode));
+        if (wrapperOwner != address(this) && !nameWrapper.isApprovedForAll(wrapperOwner, address(this))) {
+            revert NotAuthorized();
+        }
+    }
+}

--- a/contracts/ens/IAGIJobManagerView.sol
+++ b/contracts/ens/IAGIJobManagerView.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IAGIJobManagerView {
+    function getJobSpecURI(uint256 jobId) external view returns (string memory);
+    function getJobCompletionURI(uint256 jobId) external view returns (string memory);
+    function getJobCore(uint256 jobId)
+        external
+        view
+        returns (
+            address employer,
+            address assignedAgent,
+            uint256 payout,
+            uint256 duration,
+            uint256 assignedAt,
+            bool completed,
+            bool disputed,
+            bool expired,
+            uint8 agentPayoutPct
+        );
+}

--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IENSJobPages {
+    function onJobEvent(uint256 jobId, uint8 hookType) external;
+    function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external;
+    function jobEnsUri(uint256 jobId) external view returns (string memory);
+}

--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -1,0 +1,106 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/utils/Strings.sol";
+import "../ens/IAGIJobManagerView.sol";
+
+contract MockENSJobPages {
+    using Strings for uint256;
+
+    uint8 private constant HOOK_CREATE = 1;
+    uint8 private constant HOOK_ASSIGNED = 2;
+    uint8 private constant HOOK_TERMINAL = 3;
+
+    bool public shouldRevert;
+    uint256 public createCalls;
+    uint256 public agentCalls;
+    uint256 public completionCalls;
+    uint256 public revokeCalls;
+    uint256 public lockCalls;
+
+    uint256 public lastJobId;
+    address public lastEmployer;
+    address public lastAgent;
+    string public lastSpecURI;
+    string public lastCompletionURI;
+    bool public lastBurnFuses;
+
+    function setShouldRevert(bool value) external {
+        shouldRevert = value;
+    }
+
+    function createJobPage(uint256 jobId, address employer) public {
+        if (shouldRevert) revert("fail");
+        createCalls++;
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastSpecURI = IAGIJobManagerView(msg.sender).getJobSpecURI(jobId);
+    }
+
+    function onAgentAssigned(uint256 jobId, address agent) public {
+        if (shouldRevert) revert("fail");
+        agentCalls++;
+        lastJobId = jobId;
+        lastAgent = agent;
+    }
+
+    function onCompletionRequested(uint256 jobId) public {
+        if (shouldRevert) revert("fail");
+        completionCalls++;
+        lastJobId = jobId;
+        lastCompletionURI = IAGIJobManagerView(msg.sender).getJobCompletionURI(jobId);
+    }
+
+    function onJobEvent(uint256 jobId, uint8 hookType) external {
+        if (shouldRevert) revert("fail");
+        (
+            address employer,
+            address assignedAgent,
+            uint256 payout,
+            uint256 duration,
+            uint256 assignedAt,
+            bool completed,
+            bool disputed,
+            bool expired,
+            uint8 agentPayoutPct
+        ) = IAGIJobManagerView(msg.sender).getJobCore(jobId);
+        payout;
+        duration;
+        assignedAt;
+        completed;
+        disputed;
+        expired;
+        agentPayoutPct;
+
+        if (hookType == HOOK_CREATE) {
+            createJobPage(jobId, employer);
+        } else if (hookType == HOOK_ASSIGNED) {
+            onAgentAssigned(jobId, assignedAgent);
+        } else if (hookType == HOOK_TERMINAL) {
+            revokePermissions(jobId, employer, assignedAgent);
+        } else {
+            revert("bad hook");
+        }
+    }
+
+    function revokePermissions(uint256 jobId, address employer, address agent) public {
+        if (shouldRevert) revert("fail");
+        revokeCalls++;
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastAgent = agent;
+    }
+
+    function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external {
+        if (shouldRevert) revert("fail");
+        lockCalls++;
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastAgent = agent;
+        lastBurnFuses = burnFuses;
+    }
+
+    function jobEnsUri(uint256 jobId) external pure returns (string memory) {
+        return string(abi.encodePacked("ens://job-", jobId.toString(), ".alpha.jobs.agi.eth"));
+    }
+}

--- a/contracts/test/MockENSRegistry.sol
+++ b/contracts/test/MockENSRegistry.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockENSRegistry {
+    mapping(bytes32 => address) private owners;
+    mapping(bytes32 => address) private resolvers;
+
+    function setOwner(bytes32 node, address owner) external {
+        owners[node] = owner;
+    }
+
+    function owner(bytes32 node) external view returns (address) {
+        return owners[node];
+    }
+
+    function resolver(bytes32 node) external view returns (address) {
+        return resolvers[node];
+    }
+
+    function setSubnodeRecord(bytes32 node, bytes32 label, address ownerAddr, address resolverAddr, uint64) external {
+        bytes32 subnode = keccak256(abi.encodePacked(node, label));
+        owners[subnode] = ownerAddr;
+        resolvers[subnode] = resolverAddr;
+    }
+}

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -3,6 +3,9 @@ pragma solidity ^0.8.19;
 
 contract MockNameWrapper {
     mapping(uint256 => address) private owners;
+    mapping(address => mapping(address => bool)) private operatorApprovals;
+    mapping(bytes32 => bool) private wrappedNodes;
+    mapping(bytes32 => uint16) private nodeFuses;
 
     function setOwner(uint256 id, address owner) external {
         owners[id] = owner;
@@ -10,5 +13,36 @@ contract MockNameWrapper {
 
     function ownerOf(uint256 id) external view returns (address) {
         return owners[id];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        operatorApprovals[msg.sender][operator] = approved;
+    }
+
+    function isApprovedForAll(address owner, address operator) external view returns (bool) {
+        return operatorApprovals[owner][operator];
+    }
+
+    function isWrapped(bytes32 node) external view returns (bool) {
+        return wrappedNodes[node];
+    }
+
+    function setSubnodeRecord(
+        bytes32 parent,
+        bytes32 label,
+        address owner,
+        address,
+        uint64,
+        uint32,
+        uint64
+    ) external returns (bytes32 node) {
+        node = keccak256(abi.encodePacked(parent, label));
+        owners[uint256(node)] = owner;
+        wrappedNodes[node] = true;
+    }
+
+    function setFuses(bytes32 node, uint16 ownerControlledFuses) external returns (uint32) {
+        nodeFuses[node] = ownerControlledFuses;
+        return ownerControlledFuses;
     }
 }

--- a/contracts/test/MockPublicResolver.sol
+++ b/contracts/test/MockPublicResolver.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockPublicResolver {
+    mapping(bytes32 => mapping(address => bool)) private authorisations;
+    mapping(bytes32 => mapping(string => string)) private texts;
+
+    function setAuthorisation(bytes32 node, address target, bool isAuthorised) external {
+        authorisations[node][target] = isAuthorised;
+    }
+
+    function isAuthorised(bytes32 node, address target) external view returns (bool) {
+        return authorisations[node][target];
+    }
+
+    function setText(bytes32 node, string calldata key, string calldata value) external {
+        texts[node][key] = value;
+    }
+
+    function text(bytes32 node, string calldata key) external view returns (string memory) {
+        return texts[node][key];
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide a small, auditable on‑chain helper to create and manage official job ENS pages under the ALPHA root while avoiding bloat in `AGIJobManager` runtime bytecode (Model B: platform‑owned namespace, delegated edits).
- Keep ENS interactions best‑effort and off the critical settlement path so ENS failures never block escrow/dispute flows.
- Supply test fixtures and docs so operators can wire the helper to the platform safely and follow the intended naming/record conventions.

### Description
- Add an `ENSJobPages` helper contract that creates per-job subnames under a configurable root, sets the PublicResolver, authorises employer/agent write permissions, mirrors small text pointers, revokes permissions, and supports optional (best‑effort) fuse burning for wrapped names (`contracts/ens/ENSJobPages.sol`).
- Add small ENS-facing view interfaces used by the helper (`contracts/ens/IAGIJobManagerView.sol`, `contracts/ens/IENSJobPages.sol`) so the helper reads public URIs via the job manager view API.
- Add improved test mocks for ENS flows: `MockENSJobPages`, `MockENSRegistry`, `MockPublicResolver`; expand `MockNameWrapper` to emulate wrapped/unwrapped behavior and fuses for testing (`contracts/test/*`).
- Update documentation and README to describe ALPHA naming, Model B ownership/delegation, and the ENSJobPages helper usage (`docs/ens-job-pages.md`, `README.md`).

### Testing
- Ran the repository build and test suite via `npm run build` and `npm test`, which executed the Truffle tests and related checks and completed with `213 passing` tests.
- Bytecode size check ran as part of the test pipeline and reported `AGIJobManager` deployed runtime size = 24,526 bytes and `ENSJobPages` deployed runtime size = 6,738 bytes, keeping `AGIJobManager` under the EIP‑170 runtime cap.
- All automated tests passed after these changes (Truffle test + artifact size checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878764e28c8333ba59e979007ba96d)