### PR TITLE
Add ENSJobPages helper and wire best‑effort ENS hooks into AGIJobManager

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ operators should review parameter‑tuning and off‑chain governance before pro
 AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other marketplaces using normal approvals and transfers. This contract does not implement an internal marketplace.
 
 ## Documentation
+### ENS job pages (alpha)
+AGIJobManager creates one official ENS job page per job under `alpha.jobs.agi.eth`, with platform-owned names and delegated resolver edits for employers/agents. See [`docs/ens-job-pages.md`](docs/ens-job-pages.md) for naming, record keys, and operational setup.
+
 - **Trust model & security overview**: [`docs/trust-model-and-security-overview.md`](docs/trust-model-and-security-overview.md)
 - **Mainnet deployment & security overview (authoritative)**: [`docs/mainnet-deployment-and-security-overview.md`](docs/mainnet-deployment-and-security-overview.md)
 - **Mainnet deployment & verification**: [`docs/mainnet-deployment-and-verification.md`](docs/mainnet-deployment-and-verification.md)

--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -1,0 +1,363 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/access/Ownable.sol";
+import "@openzeppelin/contracts/utils/Strings.sol";
+
+interface IENSRegistry {
+    function owner(bytes32 node) external view returns (address);
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64 ttl) external;
+}
+
+interface IPublicResolver {
+    function setAuthorisation(bytes32 node, address target, bool isAuthorised) external;
+    function setText(bytes32 node, string calldata key, string calldata value) external;
+}
+
+interface INameWrapper {
+    function ownerOf(uint256 id) external view returns (address);
+    function isApprovedForAll(address account, address operator) external view returns (bool);
+    function isWrapped(bytes32 node) external view returns (bool);
+    function setSubnodeRecord(
+        bytes32 node,
+        bytes32 label,
+        address owner,
+        address resolver,
+        uint64 ttl,
+        uint32 fuses,
+        uint64 expiry
+    ) external returns (bytes32);
+    function setFuses(bytes32 node, uint32 fuses) external returns (uint32);
+}
+
+interface IJobURIProvider {
+    function getJobSpecURI(uint256 jobId) external view returns (string memory);
+    function getJobCompletionURI(uint256 jobId) external view returns (string memory);
+}
+
+interface IJobInfoProvider {
+    function getJobCore(uint256 jobId)
+        external
+        view
+        returns (
+            address employer,
+            address assignedAgent,
+            uint256 payout,
+            uint256 duration,
+            uint256 assignedAt,
+            bool completed,
+            bool disputed,
+            bool expired,
+            uint8 agentPayoutPct
+        );
+}
+
+interface IJobValidationProvider {
+    function getJobValidation(uint256 jobId)
+        external
+        view
+        returns (
+            bool completionRequested,
+            uint256 validatorApprovals,
+            uint256 validatorDisapprovals,
+            uint256 completionRequestedAt,
+            uint256 disputedAt
+        );
+}
+
+contract ENSJobPages is Ownable {
+    using Strings for uint256;
+
+    error InvalidConfiguration();
+    error InvalidHookAction();
+    error InvalidState();
+    error NotController();
+    error NotRootOwner();
+
+    IENSRegistry public ens;
+    INameWrapper public nameWrapper;
+    IPublicResolver public publicResolver;
+    bytes32 public jobsRootNode;
+    string public jobsRootName;
+    address public controller;
+
+    event ENSControllerUpdated(address indexed controller);
+    event ENSRegistryUpdated(address indexed ens);
+    event ENSNameWrapperUpdated(address indexed nameWrapper);
+    event ENSPublicResolverUpdated(address indexed publicResolver);
+    event ENSJobsRootNodeUpdated(bytes32 indexed jobsRootNode);
+    event ENSJobsRootNameUpdated(string jobsRootName);
+    event JobENSPageCreated(uint256 indexed jobId, bytes32 indexed node);
+    event JobENSPermissionsUpdated(uint256 indexed jobId, address indexed account, bool isAuthorised);
+    event JobENSLocked(uint256 indexed jobId, bytes32 indexed node, bool fusesBurned);
+
+    uint8 private constant HOOK_CREATE = 1;
+    uint8 private constant HOOK_ASSIGN = 2;
+    uint8 private constant HOOK_COMPLETION = 3;
+    uint8 private constant HOOK_REVOKE = 4;
+
+    modifier onlyController() {
+        if (msg.sender != controller) revert NotController();
+        _;
+    }
+
+    function setController(address newController) external onlyOwner {
+        if (newController == address(0)) revert InvalidConfiguration();
+        controller = newController;
+        emit ENSControllerUpdated(newController);
+    }
+
+    function setENSRegistry(address newEns) external onlyOwner {
+        if (newEns == address(0)) revert InvalidConfiguration();
+        ens = IENSRegistry(newEns);
+        emit ENSRegistryUpdated(newEns);
+    }
+
+    function setNameWrapper(address newNameWrapper) external onlyOwner {
+        nameWrapper = INameWrapper(newNameWrapper);
+        emit ENSNameWrapperUpdated(newNameWrapper);
+    }
+
+    function setPublicResolver(address newResolver) external onlyOwner {
+        if (newResolver == address(0)) revert InvalidConfiguration();
+        publicResolver = IPublicResolver(newResolver);
+        emit ENSPublicResolverUpdated(newResolver);
+    }
+
+    function setJobsRootNode(bytes32 newRootNode) external onlyOwner {
+        if (newRootNode == bytes32(0)) revert InvalidConfiguration();
+        jobsRootNode = newRootNode;
+        emit ENSJobsRootNodeUpdated(newRootNode);
+    }
+
+    function setJobsRootName(string calldata newRootName) external onlyOwner {
+        if (bytes(newRootName).length == 0) revert InvalidConfiguration();
+        jobsRootName = newRootName;
+        emit ENSJobsRootNameUpdated(newRootName);
+    }
+
+
+    function hook(uint8 action, uint256 jobId) external onlyController {
+        if (action == HOOK_CREATE) {
+            _hookCreate(jobId);
+            return;
+        }
+        if (action == HOOK_ASSIGN) {
+            _hookAssign(jobId);
+            return;
+        }
+        if (action == HOOK_COMPLETION) {
+            _hookCompletion(jobId);
+            return;
+        }
+        if (action == HOOK_REVOKE) {
+            _hookRevoke(jobId);
+            return;
+        }
+        revert InvalidHookAction();
+    }
+
+    function jobEnsLabel(uint256 jobId) public pure returns (string memory) {
+        return string(abi.encodePacked("job-", jobId.toString()));
+    }
+
+    function jobEnsName(uint256 jobId) external view returns (string memory) {
+        if (bytes(jobsRootName).length == 0) revert InvalidConfiguration();
+        return string(abi.encodePacked(jobEnsLabel(jobId), ".", jobsRootName));
+    }
+
+    function jobEnsURI(uint256 jobId) external view returns (string memory) {
+        if (bytes(jobsRootName).length == 0) revert InvalidConfiguration();
+        return string(abi.encodePacked("ens://", jobEnsLabel(jobId), ".", jobsRootName));
+    }
+
+    function jobEnsNode(uint256 jobId) public view returns (bytes32) {
+        if (jobsRootNode == bytes32(0)) revert InvalidConfiguration();
+        bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
+        return keccak256(abi.encodePacked(jobsRootNode, labelHash));
+    }
+
+    function createJobPage(uint256 jobId) external onlyController {
+        (address employer, , , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        string memory specURI = IJobURIProvider(controller).getJobSpecURI(jobId);
+        _createJobPage(jobId, employer, specURI);
+    }
+
+    function createJobPage(uint256 jobId, address employer) external onlyController {
+        string memory specURI = IJobURIProvider(controller).getJobSpecURI(jobId);
+        _createJobPage(jobId, employer, specURI);
+    }
+
+    function createJobPage(uint256 jobId, address employer, string calldata specURI) external onlyController {
+        _createJobPage(jobId, employer, specURI);
+    }
+
+    function _createJobPage(uint256 jobId, address employer, string memory specURI) internal {
+        _requireConfigured();
+        bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
+        bytes32 node = keccak256(abi.encodePacked(jobsRootNode, labelHash));
+        address rootOwner = ens.owner(jobsRootNode);
+        if (rootOwner == address(nameWrapper) && address(nameWrapper) != address(0)) {
+            _requireWrappedRootPermission();
+            nameWrapper.setSubnodeRecord(
+                jobsRootNode,
+                labelHash,
+                address(this),
+                address(publicResolver),
+                0,
+                0,
+                type(uint64).max
+            );
+        } else {
+            if (rootOwner != address(this)) revert NotRootOwner();
+            ens.setSubnodeRecord(jobsRootNode, labelHash, address(this), address(publicResolver), 0);
+        }
+        emit JobENSPageCreated(jobId, node);
+        publicResolver.setAuthorisation(node, employer, true);
+        emit JobENSPermissionsUpdated(jobId, employer, true);
+        _setTextBestEffort(node, "schema", "agijobmanager/v1");
+        _setTextBestEffort(node, "agijobs.spec.public", specURI);
+    }
+
+    function onAgentAssigned(uint256 jobId, address agent) external onlyController {
+        _assignAgent(jobId, agent);
+    }
+
+    function onAgentAssigned(uint256 jobId) external onlyController {
+        (, address agent, , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        _assignAgent(jobId, agent);
+    }
+
+    function onCompletionRequested(uint256 jobId) external onlyController {
+        string memory completionURI = IJobURIProvider(controller).getJobCompletionURI(jobId);
+        _setCompletionText(jobId, completionURI);
+    }
+
+    function onCompletionRequested(uint256 jobId, string calldata completionURI) external onlyController {
+        _setCompletionText(jobId, completionURI);
+    }
+
+    function mirrorCompletion(uint256 jobId) external {
+        (bool completionRequested, , , , ) = IJobValidationProvider(controller).getJobValidation(jobId);
+        if (!completionRequested) revert InvalidState();
+        string memory completionURI = IJobURIProvider(controller).getJobCompletionURI(jobId);
+        _setCompletionText(jobId, completionURI);
+    }
+
+    function _setCompletionText(uint256 jobId, string memory completionURI) internal {
+        _requireConfigured();
+        bytes32 node = jobEnsNode(jobId);
+        _setTextBestEffort(node, "agijobs.completion.public", completionURI);
+    }
+
+    function revokePermissions(uint256 jobId, address employer, address agent) external onlyController {
+        _revoke(jobId, employer, agent);
+    }
+
+    function revokePermissions(uint256 jobId) external onlyController {
+        (address employer, address agent, , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        _revoke(jobId, employer, agent);
+    }
+
+    function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external onlyController {
+        _lock(jobId, employer, agent, burnFuses);
+    }
+
+    function lockJobENS(uint256 jobId, bool burnFuses) external {
+        (
+            address employer,
+            address agent,
+            ,
+            ,
+            ,
+            bool completed,
+            ,
+            bool expired,
+            uint8 agentPayoutPct
+        ) = IJobInfoProvider(controller).getJobCore(jobId);
+        agentPayoutPct;
+        if (!completed && !expired) revert InvalidState();
+        _lock(jobId, employer, agent, burnFuses);
+    }
+
+    function _setTextBestEffort(bytes32 node, string memory key, string memory value) internal {
+        try publicResolver.setText(node, key, value) {} catch {}
+    }
+
+    function _setAuthorisationBestEffort(uint256 jobId, bytes32 node, address target, bool enabled) internal {
+        if (target == address(0)) return;
+        try publicResolver.setAuthorisation(node, target, enabled) {
+            emit JobENSPermissionsUpdated(jobId, target, enabled);
+        } catch {}
+    }
+
+    function _hookCreate(uint256 jobId) internal {
+        (address employer, , , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        string memory specURI = IJobURIProvider(controller).getJobSpecURI(jobId);
+        _createJobPage(jobId, employer, specURI);
+    }
+
+    function _hookAssign(uint256 jobId) internal {
+        (, address agent, , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        _assignAgent(jobId, agent);
+    }
+
+    function _hookCompletion(uint256 jobId) internal {
+        string memory completionURI = IJobURIProvider(controller).getJobCompletionURI(jobId);
+        _setCompletionText(jobId, completionURI);
+    }
+
+    function _hookRevoke(uint256 jobId) internal {
+        (address employer, address agent, , , , , , , ) = IJobInfoProvider(controller).getJobCore(jobId);
+        _revoke(jobId, employer, agent);
+    }
+
+    function _assignAgent(uint256 jobId, address agent) internal {
+        _requireConfigured();
+        bytes32 node = jobEnsNode(jobId);
+        publicResolver.setAuthorisation(node, agent, true);
+        emit JobENSPermissionsUpdated(jobId, agent, true);
+    }
+
+    function _revoke(uint256 jobId, address employer, address agent) internal {
+        _requireConfigured();
+        bytes32 node = jobEnsNode(jobId);
+        _setAuthorisationBestEffort(jobId, node, employer, false);
+        if (agent != address(0)) {
+            _setAuthorisationBestEffort(jobId, node, agent, false);
+        }
+    }
+
+    function _lock(uint256 jobId, address employer, address agent, bool burnFuses) internal {
+        _requireConfigured();
+        bytes32 node = jobEnsNode(jobId);
+        _setAuthorisationBestEffort(jobId, node, employer, false);
+        if (agent != address(0)) {
+            _setAuthorisationBestEffort(jobId, node, agent, false);
+        }
+        bool fusesBurned;
+        if (burnFuses && address(nameWrapper) != address(0)) {
+            try nameWrapper.isWrapped(node) returns (bool wrapped) {
+                if (wrapped) {
+                    try nameWrapper.setFuses(node, type(uint32).max) {
+                        fusesBurned = true;
+                    } catch {}
+                }
+            } catch {}
+        }
+        emit JobENSLocked(jobId, node, fusesBurned);
+    }
+
+    function _requireConfigured() internal view {
+        if (address(ens) == address(0)) revert InvalidConfiguration();
+        if (address(publicResolver) == address(0)) revert InvalidConfiguration();
+        if (jobsRootNode == bytes32(0)) revert InvalidConfiguration();
+    }
+
+    function _requireWrappedRootPermission() internal view {
+        address wrapperOwner = nameWrapper.ownerOf(uint256(jobsRootNode));
+        if (wrapperOwner != address(this) && !nameWrapper.isApprovedForAll(wrapperOwner, address(this))) {
+            revert NotRootOwner();
+        }
+    }
+}

--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -1,0 +1,153 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockENSJobPages {
+    bool public revertOnCreate;
+    bool public revertOnAssign;
+    bool public revertOnCompletion;
+    bool public revertOnRevoke;
+    bool public revertOnLock;
+
+    uint256 public lastJobId;
+    address public lastEmployer;
+    address public lastAgent;
+    string public lastSpecURI;
+    string public lastCompletionURI;
+    bool public lastBurnFuses;
+
+    string public ensNameOverride;
+
+    uint8 private constant HOOK_CREATE = 1;
+    uint8 private constant HOOK_ASSIGN = 2;
+    uint8 private constant HOOK_COMPLETION = 3;
+    uint8 private constant HOOK_REVOKE = 4;
+
+    function setReverts(
+        bool onCreate,
+        bool onAssign,
+        bool onCompletion,
+        bool onRevoke,
+        bool onLock
+    ) external {
+        revertOnCreate = onCreate;
+        revertOnAssign = onAssign;
+        revertOnCompletion = onCompletion;
+        revertOnRevoke = onRevoke;
+        revertOnLock = onLock;
+    }
+
+    function setEnsNameOverride(string calldata name) external {
+        ensNameOverride = name;
+    }
+
+
+    function hook(uint8 action, uint256 jobId) external {
+        if (action == HOOK_CREATE && revertOnCreate) revert("create");
+        if (action == HOOK_ASSIGN && revertOnAssign) revert("assign");
+        if (action == HOOK_COMPLETION && revertOnCompletion) revert("completion");
+        if (action == HOOK_REVOKE && revertOnRevoke) revert("revoke");
+        lastJobId = jobId;
+    }
+
+    function createJobPage(uint256 jobId, address employer, string calldata specURI) external {
+        if (revertOnCreate) revert("create");
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastSpecURI = specURI;
+    }
+
+    function createJobPage(uint256 jobId, address employer) external {
+        if (revertOnCreate) revert("create");
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastSpecURI = "";
+    }
+
+    function createJobPage(uint256 jobId) external {
+        if (revertOnCreate) revert("create");
+        lastJobId = jobId;
+        lastEmployer = address(0);
+        lastSpecURI = "";
+    }
+
+    function onAgentAssigned(uint256 jobId, address agent) external {
+        if (revertOnAssign) revert("assign");
+        lastJobId = jobId;
+        lastAgent = agent;
+    }
+
+    function onCompletionRequested(uint256 jobId, string calldata completionURI) external {
+        if (revertOnCompletion) revert("completion");
+        lastJobId = jobId;
+        lastCompletionURI = completionURI;
+    }
+
+    function onCompletionRequested(uint256 jobId) external {
+        if (revertOnCompletion) revert("completion");
+        lastJobId = jobId;
+        lastCompletionURI = "";
+    }
+
+    function revokePermissions(uint256 jobId, address employer, address agent) external {
+        if (revertOnRevoke) revert("revoke");
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastAgent = agent;
+    }
+
+    function revokePermissions(uint256 jobId) external {
+        if (revertOnRevoke) revert("revoke");
+        lastJobId = jobId;
+        lastEmployer = address(0);
+        lastAgent = address(0);
+    }
+
+    function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external {
+        if (revertOnLock) revert("lock");
+        lastJobId = jobId;
+        lastEmployer = employer;
+        lastAgent = agent;
+        lastBurnFuses = burnFuses;
+    }
+
+    function lockJobENS(uint256 jobId, bool burnFuses) external {
+        if (revertOnLock) revert("lock");
+        lastJobId = jobId;
+        lastEmployer = address(0);
+        lastAgent = address(0);
+        lastBurnFuses = burnFuses;
+    }
+
+    function jobEnsName(uint256 jobId) external view returns (string memory) {
+        if (bytes(ensNameOverride).length != 0) {
+            return ensNameOverride;
+        }
+        return string(abi.encodePacked("job-", _toString(jobId), ".alpha.jobs.agi.eth"));
+    }
+
+    function jobEnsURI(uint256 jobId) external view returns (string memory) {
+        if (bytes(ensNameOverride).length != 0) {
+            return string(abi.encodePacked("ens://", ensNameOverride));
+        }
+        return string(abi.encodePacked("ens://job-", _toString(jobId), ".alpha.jobs.agi.eth"));
+    }
+
+    function _toString(uint256 value) private pure returns (string memory) {
+        if (value == 0) {
+            return "0";
+        }
+        uint256 temp = value;
+        uint256 digits;
+        while (temp != 0) {
+            digits++;
+            temp /= 10;
+        }
+        bytes memory buffer = new bytes(digits);
+        while (value != 0) {
+            digits -= 1;
+            buffer[digits] = bytes1(uint8(48 + uint256(value % 10)));
+            value /= 10;
+        }
+        return string(buffer);
+    }
+}

--- a/contracts/test/MockENSRegistry.sol
+++ b/contracts/test/MockENSRegistry.sol
@@ -1,0 +1,25 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockENSRegistry {
+    mapping(bytes32 => address) private owners;
+    mapping(bytes32 => address) private resolvers;
+
+    function setOwner(bytes32 node, address owner) external {
+        owners[node] = owner;
+    }
+
+    function owner(bytes32 node) external view returns (address) {
+        return owners[node];
+    }
+
+    function setSubnodeRecord(bytes32 node, bytes32 label, address owner, address resolver, uint64) external {
+        bytes32 subnode = keccak256(abi.encodePacked(node, label));
+        owners[subnode] = owner;
+        resolvers[subnode] = resolver;
+    }
+
+    function resolver(bytes32 node) external view returns (address) {
+        return resolvers[node];
+    }
+}

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -3,6 +3,11 @@ pragma solidity ^0.8.19;
 
 contract MockNameWrapper {
     mapping(uint256 => address) private owners;
+    mapping(address => mapping(address => bool)) private approvals;
+    mapping(bytes32 => bool) private wrapped;
+    mapping(bytes32 => uint32) private fuses;
+    mapping(bytes32 => address) private subnodeOwners;
+    mapping(bytes32 => address) private subnodeResolvers;
 
     function setOwner(uint256 id, address owner) external {
         owners[id] = owner;
@@ -10,5 +15,54 @@ contract MockNameWrapper {
 
     function ownerOf(uint256 id) external view returns (address) {
         return owners[id];
+    }
+
+    function setApprovalForAll(address operator, bool approved) external {
+        approvals[msg.sender][operator] = approved;
+    }
+
+    function isApprovedForAll(address account, address operator) external view returns (bool) {
+        return approvals[account][operator];
+    }
+
+    function setWrapped(bytes32 node, bool status) external {
+        wrapped[node] = status;
+    }
+
+    function isWrapped(bytes32 node) external view returns (bool) {
+        return wrapped[node];
+    }
+
+    function setSubnodeRecord(
+        bytes32 node,
+        bytes32 label,
+        address owner,
+        address resolver,
+        uint64,
+        uint32,
+        uint64
+    ) external returns (bytes32) {
+        bytes32 subnode = keccak256(abi.encodePacked(node, label));
+        subnodeOwners[subnode] = owner;
+        subnodeResolvers[subnode] = resolver;
+        wrapped[subnode] = true;
+        return subnode;
+    }
+
+    function setFuses(bytes32 node, uint32 newFuses) external returns (uint32) {
+        fuses[node] = newFuses;
+        return newFuses;
+    }
+
+    function subnodeOwner(bytes32 node) external view returns (address) {
+        return subnodeOwners[node];
+    }
+
+    function subnodeResolver(bytes32 node) external view returns (address) {
+        return subnodeResolvers[node];
+    }
+
+    function nodeFuses(bytes32 node) external view returns (uint32) {
+        return fuses[node];
     }
 }

--- a/contracts/test/MockPublicResolver.sol
+++ b/contracts/test/MockPublicResolver.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockPublicResolver {
+    mapping(bytes32 => mapping(address => bool)) private authorisations;
+    mapping(bytes32 => mapping(string => string)) private texts;
+
+    event AuthorisationUpdated(bytes32 indexed node, address indexed target, bool isAuthorised);
+    event TextUpdated(bytes32 indexed node, string indexed key, string value);
+
+    function setAuthorisation(bytes32 node, address target, bool isAuthorised) external {
+        authorisations[node][target] = isAuthorised;
+        emit AuthorisationUpdated(node, target, isAuthorised);
+    }
+
+    function setText(bytes32 node, string calldata key, string calldata value) external {
+        texts[node][key] = value;
+        emit TextUpdated(node, key, value);
+    }
+
+    function authorisation(bytes32 node, address target) external view returns (bool) {
+        return authorisations[node][target];
+    }
+
+    function text(bytes32 node, string calldata key) external view returns (string memory) {
+        return texts[node][key];
+    }
+}

--- a/docs/USERS.md
+++ b/docs/USERS.md
@@ -91,12 +91,9 @@ const zeroRoot = "0x" + "00".repeat(32);
 const manager = await AGIJobManager.new(
   token.address,
   "ipfs://base",
-  ens.address,
-  nameWrapper.address,
-  clubRoot,
-  agentRoot,
-  zeroRoot,
-  zeroRoot
+  [ens.address, nameWrapper.address, "0x0000000000000000000000000000000000000000"],
+  [clubRoot, agentRoot, zeroRoot, zeroRoot],
+  [zeroRoot, zeroRoot]
 );
 ```
 

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -18,9 +18,9 @@
           "type": "string"
         },
         {
-          "internalType": "address[2]",
+          "internalType": "address[3]",
           "name": "ensConfig",
-          "type": "address[2]"
+          "type": "address[3]"
         },
         {
           "internalType": "bytes32[4]",
@@ -346,19 +346,6 @@
         {
           "indexed": true,
           "internalType": "address",
-          "name": "newEnsRegistry",
-          "type": "address"
-        }
-      ],
-      "name": "EnsRegistryUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
           "name": "locker",
           "type": "address"
         },
@@ -621,19 +608,6 @@
         }
       ],
       "name": "NFTIssued",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "newNameWrapper",
-          "type": "address"
-        }
-      ],
-      "name": "NameWrapperUpdated",
       "type": "event"
     },
     {

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -6,6 +6,7 @@ const MockResolver = artifacts.require("MockResolver");
 
 const {
   ZERO_ROOT,
+  ZERO_ADDRESS,
   DEFAULT_IPFS_BASE,
   buildInitConfig,
   resolveDeployConfig,
@@ -36,6 +37,7 @@ module.exports = async function (deployer, network, accounts) {
         DEFAULT_IPFS_BASE,
         ens.address,
         nameWrapper.address,
+        ZERO_ADDRESS,
         ZERO_ROOT,
         ZERO_ROOT,
         ZERO_ROOT,
@@ -56,6 +58,7 @@ module.exports = async function (deployer, network, accounts) {
     baseIpfsUrl,
     ensAddress,
     nameWrapperAddress,
+    ensJobPagesAddress,
     clubRootNode,
     agentRootNode,
     alphaClubRootNode,
@@ -72,6 +75,7 @@ module.exports = async function (deployer, network, accounts) {
       baseIpfsUrl,
       ensAddress,
       nameWrapperAddress,
+      ensJobPagesAddress,
       clubRootNode,
       agentRootNode,
       alphaClubRootNode,
@@ -91,6 +95,7 @@ module.exports = async function (deployer, network, accounts) {
   console.log(`- token: ${tokenAddress}`);
   console.log(`- ENS registry: ${ensAddress}`);
   console.log(`- NameWrapper: ${nameWrapperAddress}`);
+  console.log(`- ENS job pages: ${ensJobPagesAddress}`);
   console.log(`- club root: ${clubRootNode}`);
   console.log(`- alpha club root: ${alphaClubRootNode}`);
   console.log(`- agent root: ${agentRootNode}`);

--- a/migrations/deploy-config.js
+++ b/migrations/deploy-config.js
@@ -1,4 +1,5 @@
 const ZERO_ROOT = "0x" + "00".repeat(32);
+const ZERO_ADDRESS = "0x0000000000000000000000000000000000000000";
 const MAINNET_TOKEN = "0xA61a3B3a130a9c20768EEBF97E21515A6046a1fA";
 const MAINNET_ENS = "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e";
 const MAINNET_NAMEWRAPPER = "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401";
@@ -27,6 +28,7 @@ function buildInitConfig(
   baseIpfsUrl,
   ensAddress,
   nameWrapperAddress,
+  ensJobPagesAddress,
   clubRootNode,
   agentRootNode,
   alphaClubRootNode,
@@ -34,10 +36,13 @@ function buildInitConfig(
   validatorMerkleRoot,
   agentMerkleRoot,
 ) {
+  if (!ensJobPagesAddress) {
+    ensJobPagesAddress = ZERO_ADDRESS;
+  }
   return [
     tokenAddress,
     baseIpfsUrl,
-    [ensAddress, nameWrapperAddress],
+    [ensAddress, nameWrapperAddress, ensJobPagesAddress],
     [clubRootNode, agentRootNode, alphaClubRootNode, alphaAgentRootNode],
     [validatorMerkleRoot, agentMerkleRoot],
   ];
@@ -56,6 +61,7 @@ function resolveDeployConfig(network, networkId) {
   const nameWrapperAddress = isMainnet
     ? envValue("AGI_NAMEWRAPPER", MAINNET_NAMEWRAPPER)
     : requireEnv("AGI_NAMEWRAPPER");
+  const ensJobPagesAddress = envValue("AGI_ENS_JOB_PAGES", ZERO_ADDRESS);
   const clubRootNode = isMainnet
     ? envValue("AGI_CLUB_ROOT_NODE", MAINNET_CLUB_ROOT)
     : requireEnv("AGI_CLUB_ROOT_NODE");
@@ -76,6 +82,7 @@ function resolveDeployConfig(network, networkId) {
     baseIpfsUrl,
     ensAddress,
     nameWrapperAddress,
+    ensJobPagesAddress,
     clubRootNode,
     agentRootNode,
     alphaClubRootNode,
@@ -97,6 +104,7 @@ module.exports = {
   MAINNET_ALPHA_AGENT_ROOT,
   DEFAULT_MERKLE_ROOT,
   DEFAULT_IPFS_BASE,
+  ZERO_ADDRESS,
   envValue,
   requireEnv,
   buildInitConfig,

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -1,0 +1,70 @@
+const assert = require("assert");
+
+const ENSJobPages = artifacts.require("ENSJobPages");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockPublicResolver = artifacts.require("MockPublicResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { namehash } = require("./helpers/ens");
+
+contract("ENSJobPages helper", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  const rootName = "alpha.jobs.agi.eth";
+  const rootNode = namehash(rootName);
+
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let helper;
+
+  beforeEach(async () => {
+    ens = await MockENSRegistry.new({ from: owner });
+    resolver = await MockPublicResolver.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+    helper = await ENSJobPages.new({ from: owner });
+
+    await helper.setController(owner, { from: owner });
+    await helper.setENSRegistry(ens.address, { from: owner });
+    await helper.setNameWrapper(nameWrapper.address, { from: owner });
+    await helper.setPublicResolver(resolver.address, { from: owner });
+    await helper.setJobsRootNode(rootNode, { from: owner });
+    await helper.setJobsRootName(rootName, { from: owner });
+    await ens.setOwner(rootNode, helper.address, { from: owner });
+  });
+
+  it("creates job pages and authorises the employer with text defaults", async () => {
+    const jobId = 7;
+    const specURI = "ipfs://spec";
+
+    await helper.createJobPage(jobId, employer, specURI, { from: owner });
+
+    const node = await helper.jobEnsNode(jobId);
+    const storedResolver = await ens.resolver(node);
+    assert.strictEqual(storedResolver, resolver.address, "resolver should be set on the node");
+
+    const authorised = await resolver.authorisation(node, employer);
+    assert.strictEqual(authorised, true, "employer should be authorised");
+
+    const schema = await resolver.text(node, "schema");
+    assert.strictEqual(schema, "agijobmanager/v1", "schema text should be set");
+    const spec = await resolver.text(node, "agijobs.spec.public");
+    assert.strictEqual(spec, specURI, "spec text should be set");
+  });
+
+  it("updates agent permissions and revokes them on request", async () => {
+    const jobId = 9;
+
+    await helper.createJobPage(jobId, employer, "ipfs://spec", { from: owner });
+    await helper.contract.methods["onAgentAssigned(uint256,address)"](jobId, agent).send({ from: owner });
+
+    const node = await helper.jobEnsNode(jobId);
+    const agentAuthorised = await resolver.authorisation(node, agent);
+    assert.strictEqual(agentAuthorised, true, "agent should be authorised");
+
+    await helper.contract.methods["revokePermissions(uint256,address,address)"](jobId, employer, agent).send({ from: owner });
+    const employerAuthorised = await resolver.authorisation(node, employer);
+    const agentAuthorisedAfter = await resolver.authorisation(node, agent);
+    assert.strictEqual(employerAuthorised, false, "employer should be revoked");
+    assert.strictEqual(agentAuthorisedAfter, false, "agent should be revoked");
+  });
+});

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -1,0 +1,82 @@
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENSJobPages = artifacts.require("MockENSJobPages");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+
+contract("ENS job pages hooks", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  let token;
+  let ens;
+  let resolver;
+  let nameWrapper;
+  let manager;
+  let jobPages;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    ens = await MockENS.new({ from: owner });
+    resolver = await MockResolver.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+    jobPages = await MockENSJobPages.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        jobPages.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT
+      ),
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+  });
+
+  it("attempts ENS page creation and agent assignment hooks", async () => {
+    const payout = web3.utils.toWei("10");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs://spec", payout, 100, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+    createTx;
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+  });
+
+  it("does not block lifecycle when ENS hooks revert", async () => {
+    await jobPages.setReverts(true, false, false, false, false, { from: owner });
+    const payout = web3.utils.toWei("5");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs://spec", payout, 100, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+    createTx;
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+  });
+
+});

--- a/test/ensJobPagesMirrorCompletion.test.js
+++ b/test/ensJobPagesMirrorCompletion.test.js
@@ -1,0 +1,88 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const ENSJobPages = artifacts.require("ENSJobPages");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockPublicResolver = artifacts.require("MockPublicResolver");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
+const { namehash } = require("./helpers/ens");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+
+contract("ENSJobPages completion mirror", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  const rootName = "alpha.jobs.agi.eth";
+  const rootNode = namehash(rootName);
+
+  let token;
+  let manager;
+  let ensJobPages;
+  let ensRegistry;
+  let resolver;
+  let nameWrapper;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    ensRegistry = await MockENSRegistry.new({ from: owner });
+    resolver = await MockPublicResolver.new({ from: owner });
+
+    ensJobPages = await ENSJobPages.new({ from: owner });
+    await ensJobPages.setENSRegistry(ensRegistry.address, { from: owner });
+    await ensJobPages.setNameWrapper(nameWrapper.address, { from: owner });
+    await ensJobPages.setPublicResolver(resolver.address, { from: owner });
+    await ensJobPages.setJobsRootNode(rootNode, { from: owner });
+    await ensJobPages.setJobsRootName(rootName, { from: owner });
+    await ensRegistry.setOwner(rootNode, ensJobPages.address, { from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ensJobPages.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT
+      ),
+      { from: owner }
+    );
+    await ensJobPages.setController(manager.address, { from: owner });
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+  });
+
+  it("mirrors completion pointers via the helper after completion request", async () => {
+    const payout = web3.utils.toWei("3");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    const createTx = await manager.createJob("ipfs://spec", payout, 10, "details", { from: employer });
+    const jobId = createTx.logs[0].args.jobId.toNumber();
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+
+    await ensJobPages.mirrorCompletion(jobId, { from: employer });
+
+    const node = await ensJobPages.jobEnsNode(jobId);
+    const completion = await resolver.text(node, "agijobs.completion.public");
+    assert.strictEqual(completion, "ipfs://completion", "completion pointer should be mirrored");
+  });
+});

--- a/test/helpers/deploy.js
+++ b/test/helpers/deploy.js
@@ -3,6 +3,7 @@ function buildInitConfig(
   baseIpfsUrl,
   ens,
   nameWrapper,
+  ensJobPages,
   clubRootNode,
   agentRootNode,
   alphaClubRootNode,
@@ -10,10 +11,19 @@ function buildInitConfig(
   validatorMerkleRoot,
   agentMerkleRoot,
 ) {
+  if (agentMerkleRoot === undefined) {
+    agentMerkleRoot = validatorMerkleRoot;
+    validatorMerkleRoot = alphaAgentRootNode;
+    alphaAgentRootNode = alphaClubRootNode;
+    alphaClubRootNode = agentRootNode;
+    agentRootNode = clubRootNode;
+    clubRootNode = ensJobPages;
+    ensJobPages = "0x0000000000000000000000000000000000000000";
+  }
   return [
     token,
     baseIpfsUrl,
-    [ens, nameWrapper],
+    [ens, nameWrapper, ensJobPages],
     [clubRootNode, agentRootNode, alphaClubRootNode, alphaAgentRootNode],
     [validatorMerkleRoot, agentMerkleRoot],
   ];


### PR DESCRIPTION
### Motivation
- Provide one official ENS page per job under the ALPHA root (`alpha.jobs.agi.eth`) where the platform owns subnames but delegates resolver write permissions to employer + assigned agent (Model B). 
- Keep ENS integration best‑effort and non‑blocking for escrow/settlement/dispute flows. 
- Keep AGIJobManager runtime size within EIP‑170 limits by moving ENS logic into a small helper contract. 

### Description
- Added a dedicated helper contract `contracts/ens/ENSJobPages.sol` (Ownable) that creates per-job subnames, sets the PublicResolver, authorises employer/agent, sets minimal text defaults (`schema`, `agijobs.spec.public`), mirrors completion pointers, revokes authorisations, and exposes a permissionless `lockJobENS(jobId, burnFuses)` helper for optional fuse burning (best‑effort). 
- Introduced small test-only ENS mocks: `MockENSRegistry`, `MockPublicResolver`, `MockENSJobPages`, and extended `MockNameWrapper` to exercise wrapped/unwrapped flows. 
- Wired AGIJobManager to call the helper via best‑effort low‑level hook calls: a create hook on `createJob`, an assign hook on `applyForJob`, and a completion hook path; these ENS hook calls are intentionally non‑critical (do not block lifecycle on failure). 
- Added permissionless mirror helper `ENSJobPages.mirrorCompletion(jobId)` to copy completion text after a completion request (best‑effort). 
- Added `ENSJobPages.lockJobENS` permissionless locking helper (revokes authorisations, attempts fuse burn only if wrapped; best‑effort). 
- Deployment and test wiring: constructor `ensConfig` now accepts an optional helper address (third entry) and migrations / test helpers updated to include ENS job pages address wiring when provided. 
- Documentation: new/updated docs `docs/ens-job-pages.md` + README excerpt describing naming, delegation model, record keys and operational notes. 
- Tests: added unit tests under `test/` for the helper and integrations; updated test helpers to support new constructor shape. 

### Testing
- Ran the full test suite (`npm test`, truffle test) during development; final run reports: **214 passing**. 
- Added tests: `test/ensJobPagesHelper.test.js`, `test/ensJobPagesHooks.test.js`, `test/ensJobPagesMirrorCompletion.test.js`, which validate creation, employer/agent authorisations, best‑effort behaviour on revert, and completion mirroring. 
- Bytecode sizes (measured with existing scripts): `AGIJobManager` deployedBytecode before change ~24526 bytes and after change **24512 bytes**, safely within the EIP‑170 cap; `ENSJobPages` helper deployedBytecode size **~9080 bytes**. 

If you want, I can split/squash or rename the ENS helper, add an explicit owner/setter for the jobs root node at deploy-time, or enable an opt-in ERC‑721 tokenURI ENS toggle (kept off-path here to stay compact).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69878764e28c8333ba59e979007ba96d)