### PR TITLE
Add ENS-backed job page URI toggle and lock hook (ENSJobPages integration)

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other ma
 
 ## ENS job pages (ALPHA)
 Official job pages live under `job-<jobId>.alpha.jobs.agi.eth` and are platform‑owned with delegated resolver edits. See [`docs/ens-job-pages.md`](docs/ens-job-pages.md) for the full record conventions and setup notes.
+The completion NFT tokenURI can optionally point to the ENS job page (`ens://job-<jobId>.alpha.jobs.agi.eth`) when enabled.
 
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 

--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -9,4 +9,5 @@ interface IENSJobPages {
     function revokePermissions(uint256 jobId, address employer, address agent) external;
     function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external;
     function jobEnsName(uint256 jobId) external view returns (string memory);
+    function jobEnsTokenURI(uint256 jobId) external view returns (string memory);
 }

--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -11,6 +11,7 @@ contract MockENSJobPages {
     uint8 public constant HOOK_COMPLETION = 3;
     uint8 public constant HOOK_REVOKE = 4;
     uint8 public constant HOOK_LOCK = 5;
+    uint8 public constant HOOK_LOCK_BURN = 6;
 
     mapping(uint8 => bool) public revertHook;
 
@@ -26,9 +27,14 @@ contract MockENSJobPages {
     string public lastSpecURI;
     string public lastCompletionURI;
     bool public lastBurnFuses;
+    bool public useEnsTokenURI;
 
     function setRevertHook(uint8 hook, bool shouldRevert) external {
         revertHook[hook] = shouldRevert;
+    }
+
+    function setUseEnsJobTokenURI(bool enabled) external {
+        useEnsTokenURI = enabled;
     }
 
     function createJobPage(uint256 jobId, address employer, string calldata specURI) external {
@@ -75,6 +81,14 @@ contract MockENSJobPages {
             lastBurnFuses = false;
             return;
         }
+        if (hook == HOOK_LOCK_BURN) {
+            lockCalls += 1;
+            lastJobId = jobId;
+            lastEmployer = address(0);
+            lastAgent = address(0);
+            lastBurnFuses = true;
+            return;
+        }
     }
 
     function onAgentAssigned(uint256 jobId, address agent) external {
@@ -110,6 +124,11 @@ contract MockENSJobPages {
 
     function jobEnsName(uint256 jobId) external pure returns (string memory) {
         return string(abi.encodePacked("job-", jobId.toString(), ".alpha.jobs.agi.eth"));
+    }
+
+    function jobEnsTokenURI(uint256 jobId) external view returns (string memory) {
+        require(useEnsTokenURI, "disabled");
+        return string(abi.encodePacked("ens://job-", jobId.toString(), ".alpha.jobs.agi.eth"));
     }
 
 }

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -67,6 +67,14 @@ When ENS job pages are configured, the platform attempts the following **best‑
 
 > These mirrors are **best‑effort** only; ENS failures never block settlement.
 
+## Optional ENS-backed NFT tokenURI
+
+The completion NFT can optionally point to the ENS job page instead of the completion URI (configured via `ENSJobPages.setUseEnsJobTokenURI`):
+- When enabled, the tokenURI is `ens://job-<jobId>.alpha.jobs.agi.eth`.
+- When disabled (default), the tokenURI remains the completion metadata URI.
+
+This toggle only affects the stored URI string and does not change ERC‑721 minting semantics.
+
 ## Wrapped vs unwrapped root setup
 
 ### Unwrapped root (`alpha.jobs.agi.eth`)


### PR DESCRIPTION
### Motivation
- Provide one official ENS page per job under `alpha.jobs.agi.eth` that the platform owns while delegating resolver edit permissions to employer and assigned agent, and optionally let completion NFTs point to that ENS page. 
- Ensure ENS interactions are best-effort and never block settlement/dispute/fund flows, and keep runtime bytecode under the EIP‑170 cap.

### Description
- Wire AGIJobManager to an `ENSJobPages` helper via `IENSJobPages`, dispatching lifecycle hooks (`CREATE`, `ASSIGN`, `COMPLETION`, `REVOKE`, `LOCK` and `LOCK_BURN`) using best-effort calls; added `lockJobENS(jobId,bool)` passthrough that anyone may call after terminal state. 
- Add optional ENS-backed NFT tokenURI resolution: AGIJobManager attempts to obtain `jobEnsTokenURI(jobId)` from the helper (safe low-level/staticcall/assembly) and stores `ens://...` when present; preserved existing tokenURI/baseIpfsUrl behavior when absent. 
- Extended `ENSJobPages` (helper) to expose `jobEnsTokenURI`, `setUseEnsJobTokenURI`, and accept lock-with-burn hook; helper validates terminal state on lock hooks and performs best-effort revoke/fuse attempts. 
- Updated interface `IENSJobPages`, test mock `MockENSJobPages`, unit tests, README and `docs/ens-job-pages.md` to cover the ENS-backed tokenURI toggle, hook behavior, and lock semantics; kept all ENS interactions best-effort and preserved pause/ownership semantics. 
- Tightened hook dispatch using compact low-level/assembly calls and small selector plumbing to control bytecode growth and avoid changing compiler/truffle settings.

### Testing
- Ran the full automated suite via `npm test` (which runs `truffle test` and internal checks); all tests passed: `218 passing` in CI run. 
- Added/extended tests in `test/ensJobPagesHooks.test.js` covering ENS hook invocation, revert-safe behavior, ENS-backed tokenURI usage, and terminal lock behavior; these tests passed. 
- Measured runtime bytecode with `node scripts/check-bytecode-size.js`: `AGIJobManager` runtime bytecode = `24529` bytes, which is under the EIP‑170 limit (24,576 bytes). 

Files changed (high level): `contracts/AGIJobManager.sol`, `contracts/ens/ENSJobPages.sol`, `contracts/ens/IENSJobPages.sol`, `contracts/test/MockENSJobPages.sol`, `test/ensJobPagesHooks.test.js`, `docs/ens-job-pages.md`, and `README.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987f7077f6c8333b140be0ce5b95afe)