### PR TITLE
ENS job‑page tokenURI toggle, lock hook, and ENSJobPages helper integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,7 @@ AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other ma
 
 ## ENS job pages (ALPHA)
 Official job pages live under `job-<jobId>.alpha.jobs.agi.eth` and are platform‑owned with delegated resolver edits. See [`docs/ens-job-pages.md`](docs/ens-job-pages.md) for the full record conventions and setup notes.
+Optional: the completion NFT tokenURI can be switched to `ens://job-<jobId>.alpha.jobs.agi.eth` via an owner toggle; the default remains the completion metadata URI. See [`docs/ens-job-pages.md`](docs/ens-job-pages.md).
 
 ## MONTREAL.AI × ERC‑8004: From signaling → enforcement
 

--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -101,6 +101,10 @@ contract ENSJobPages is Ownable {
         return string(abi.encodePacked(jobEnsLabel(jobId), ".", jobsRootName));
     }
 
+    function jobEnsURI(uint256 jobId) public view returns (string memory) {
+        return string(abi.encodePacked("ens://", jobEnsName(jobId)));
+    }
+
 
     function jobEnsNode(uint256 jobId) public view returns (bytes32) {
         bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
@@ -146,8 +150,19 @@ contract ENSJobPages is Ownable {
             return;
         }
         if (hook == 5) {
-            (address employer, address agent, , , , , , , ) = jobManagerView.getJobCore(jobId);
+            (address employer, address agent, , , , bool completed, , bool expired, ) = jobManagerView.getJobCore(jobId);
+            if (!completed && !expired) {
+                return;
+            }
             _lockJobENS(jobId, employer, agent, false);
+            return;
+        }
+        if (hook == 6) {
+            (address employer, address agent, , , , bool completed, , bool expired, ) = jobManagerView.getJobCore(jobId);
+            if (!completed && !expired) {
+                return;
+            }
+            _lockJobENS(jobId, employer, agent, true);
             return;
         }
     }

--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -9,4 +9,5 @@ interface IENSJobPages {
     function revokePermissions(uint256 jobId, address employer, address agent) external;
     function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external;
     function jobEnsName(uint256 jobId) external view returns (string memory);
+    function jobEnsURI(uint256 jobId) external view returns (string memory);
 }

--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -11,6 +11,7 @@ contract MockENSJobPages {
     uint8 public constant HOOK_COMPLETION = 3;
     uint8 public constant HOOK_REVOKE = 4;
     uint8 public constant HOOK_LOCK = 5;
+    uint8 public constant HOOK_LOCK_BURN = 6;
 
     mapping(uint8 => bool) public revertHook;
 
@@ -75,6 +76,14 @@ contract MockENSJobPages {
             lastBurnFuses = false;
             return;
         }
+        if (hook == HOOK_LOCK_BURN) {
+            lockCalls += 1;
+            lastJobId = jobId;
+            lastEmployer = address(0);
+            lastAgent = address(0);
+            lastBurnFuses = true;
+            return;
+        }
     }
 
     function onAgentAssigned(uint256 jobId, address agent) external {
@@ -110,6 +119,10 @@ contract MockENSJobPages {
 
     function jobEnsName(uint256 jobId) external pure returns (string memory) {
         return string(abi.encodePacked("job-", jobId.toString(), ".alpha.jobs.agi.eth"));
+    }
+
+    function jobEnsURI(uint256 jobId) external pure returns (string memory) {
+        return string(abi.encodePacked("ens://job-", jobId.toString(), ".alpha.jobs.agi.eth"));
     }
 
 }

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -67,6 +67,11 @@ When ENS job pages are configured, the platform attempts the following **best‑
 
 > These mirrors are **best‑effort** only; ENS failures never block settlement.
 
+## Optional ENS token URI for completion NFTs
+
+Operators can enable an optional toggle so the completion NFT tokenURI uses the ENS job page:
+`ens://job-<jobId>.alpha.jobs.agi.eth`. When disabled, NFTs keep the existing completion metadata URI behavior.
+
 ## Wrapped vs unwrapped root setup
 
 ### Unwrapped root (`alpha.jobs.agi.eth`)

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2110,6 +2110,19 @@
     {
       "inputs": [
         {
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "name": "setUseEnsJobTokenURI",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "bytes32",
           "name": "_clubRootNode",
           "type": "bytes32"

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -100,4 +100,59 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await manager.finalizeJob(0, { from: employer });
   });
 
+  it("locks job ENS records after terminal settlement", async () => {
+    const { token, manager } = await deployManager();
+    const nft = await MockERC721.new({ from: owner });
+    const ensJobPages = await MockENSJobPages.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+    await manager.setEnsJobPages(ensJobPages.address, { from: owner });
+
+    const payout = web3.utils.toWei("3");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+
+    await manager.requestJobCompletion(0, "ipfs://completion.json", { from: agent });
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    await manager.finalizeJob(0, { from: employer });
+
+    await manager.lockJobENS(0, true, { from: agent });
+    assert.equal((await ensJobPages.lockCalls()).toString(), "1");
+    assert.equal(await ensJobPages.lastBurnFuses(), true);
+  });
+
+  it("uses ENS token URIs when enabled", async () => {
+    const { token, manager } = await deployManager();
+    const nft = await MockERC721.new({ from: owner });
+    const ensJobPages = await MockENSJobPages.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+    await manager.setEnsJobPages(ensJobPages.address, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
+
+    const payout = web3.utils.toWei("4");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+
+    await manager.requestJobCompletion(0, "ipfs://completion.json", { from: agent });
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    await manager.finalizeJob(0, { from: employer });
+
+    assert.equal(await manager.tokenURI(0), "ens://job-0.alpha.jobs.agi.eth");
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Provide one official ENS page per job under `alpha.jobs.agi.eth` and allow the platform to delegate resolver edits to employer/agent while keeping platform ownership, without changing settlement semantics. 
- Expose best‑effort ENS mirrors (spec + completion pointers), a post‑terminal lock path, and an optional NFT tokenURI scheme that points to the ENS page.
- Keep ENS interactions best‑effort and non‑blocking for escrow/dispute flows and preserve existing ownership/pausing/trust semantics.

### Description
- Added an `IENSJobPages` interface and extended the `ENSJobPages` helper with `jobEnsURI`, a `handleHook` path for a burn‑fuse lock hook, and safe best‑effort resolver/text/authorisation calls; the helper still emits compact events for created/permission/locked actions.
- Wired a small, minimal integration in `AGIJobManager`: `ensJobPages` address config, an owner toggle `setUseEnsJobTokenURI(bool)`, best‑effort hook calls during `createJob`, `applyForJob`, `requestJobCompletion`, terminal flows, and a `lockJobENS` passthrough (non‑blocking, idempotent behavior via hook codes).
- Added ENS URI tokenURI behavior: when `useEnsJobTokenURI` is enabled the completion NFT tokenURI resolves to `ens://job-<jobId>.alpha.jobs.agi.eth` by querying the helper (staticcall, best‑effort), otherwise previous tokenURI logic is preserved.
- Tests, mocks and docs updated: `MockENSJobPages` now supports `jobEnsURI` and lock burn hook; `test/ensJobPagesHooks.test.js` covers lifecycle hook calls, hook reverts not breaking flows, lock behavior, and the ENS tokenURI toggle; documentation updated (`docs/ens-job-pages.md`, `README.md`) and UI ABI exported (`docs/ui/abi/AGIJobManager.json`).
- Bytecode discipline: measured AGIJobManager runtime deployedBytecode before/after and kept it within the EIP‑170 runtime cap by moving ENS logic into the helper and keeping minimal hooks in the manager.

### Testing
- Ran `npm test` (full suite + bytecode checks): all tests passed locally after the change (final run: **219 passing**), and the bytecode size check succeeded.
- Ran `npm run ui:abi` to export the updated ABI used by the UI and committed `docs/ui/abi/AGIJobManager.json`.
- Note: `npm ci` in this environment initially reported an unrelated `fsevents` platform warning (darwin‑only) but does not affect the test runs here.

Key runtime bytecode sizes observed:
- AGIJobManager deployedBytecode before changes: `24529` bytes.
- AGIJobManager deployedBytecode after changes: `24567` bytes (below the 24,576 EIP‑170 guideline in the repository checks).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6987f7077f6c8333b140be0ce5b95afe)