### PR TITLE
Add ENS job page tokenURI toggle and resilient lock hook handling

### DIFF
--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -10,5 +10,4 @@ interface IENSJobPages {
     function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external;
     function jobEnsName(uint256 jobId) external view returns (string memory);
     function jobEnsURI(uint256 jobId) external view returns (string memory);
-    function setUseEnsJobTokenURI(bool enabled) external;
 }

--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -14,7 +14,6 @@ contract MockENSJobPages {
     uint8 public constant HOOK_LOCK_BURN = 6;
 
     mapping(uint8 => bool) public revertHook;
-    bool public useEnsJobTokenURI;
 
     uint256 public createCalls;
     uint256 public assignCalls;
@@ -123,13 +122,6 @@ contract MockENSJobPages {
     }
 
     function jobEnsURI(uint256 jobId) external view returns (string memory) {
-        if (!useEnsJobTokenURI) {
-            return "";
-        }
         return string(abi.encodePacked("ens://job-", jobId.toString(), ".alpha.jobs.agi.eth"));
-    }
-
-    function setUseEnsJobTokenURI(bool enabled) external {
-        useEnsJobTokenURI = enabled;
     }
 }

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -87,7 +87,7 @@ The platform also authorizes the employer on creation and the assigned agent on 
 - Revoke resolver authorizations after terminal settlement.
 
 ## ENS job NFT tokenURI (optional)
-When `ENSJobPages.useEnsJobTokenURI` is enabled and an ENS helper is configured, completion NFTs point to:
+When `AGIJobManager.useEnsJobTokenURI` is enabled and an ENS helper is configured, completion NFTs point to:
 ```
 ens://job-<jobId>.alpha.jobs.agi.eth
 ```

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -1683,6 +1683,19 @@
     },
     {
       "inputs": [],
+      "name": "useEnsJobTokenURI",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "validationRewardPercentage",
       "outputs": [
         {
@@ -2103,6 +2116,19 @@
         }
       ],
       "name": "setEnsJobPages",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "enabled",
+          "type": "bool"
+        }
+      ],
+      "name": "setUseEnsJobTokenURI",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -111,7 +111,7 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
 
     await seedAgentType(manager, nft, agent);
     await manager.setEnsJobPages(ensJobPages.address, { from: owner });
-    await ensJobPages.setUseEnsJobTokenURI(true, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
 
     const payout = web3.utils.toWei("10");
     await token.mint(employer, payout, { from: owner });


### PR DESCRIPTION
### Motivation
- Provide an optional, operator-controlled toggle so completion NFT tokenURIs can point to the official ENS job page (`ens://job-<jobId>.alpha.jobs.agi.eth`) without changing existing mint semantics by default. 
- Ensure job ENS locking and resolver-authorisation revocation are best-effort and do not block core settlement flows when ENS helpers or lookups fail. 
- Keep changes small and auditable while preserving existing ownership / pause / settlement invariants and EIP‑170 bytecode safety.

### Description
- Added a boolean config `useEnsJobTokenURI` and owner setter `setUseEnsJobTokenURI(bool)` to `AGIJobManager` to enable ENS-backed tokenURIs; default remains false. 
- Updated `_mintCompletionNFT` to, when the toggle is enabled and an ENS helper is configured, query the ENS helper for an ENS URI and prefer it for the minted NFT; otherwise preserve the previous completion-URI behavior and base-IPFS application. 
- Implemented resilient lock semantics: `lockJobENS(jobId, burnFuses)` now invokes the ENS helper lock hook via the existing hook path (`_callEnsJobPagesHook`) so locking is best-effort and does not revert core flows. 
- Hardened `ENSJobPages.handleHook` to tolerate missing job-core return data for lock hooks (it attempts to fetch employer/agent via `getJobCore` in a try/catch and proceeds), and standardized `jobEnsURI` to return canonical `ens://...` URIs so the manager can consume that string directly. 
- Small interface and test harness updates: removed redundant per-helper toggle, updated `IENSJobPages`, `MockENSJobPages`, `docs/ens-job-pages.md`, the exported ABI (`docs/ui/abi/AGIJobManager.json`), and adjusted `test/ensJobPagesHooks.test.js` to use the new manager toggle. 
- Preserved best-effort semantics everywhere: ENS calls are wrapped or invoked so they cannot block refunds/finalization/expiry flows.

### Testing
- Ran the full automated suite with `npm test` (which executes `truffle compile`, the JS/Truffle tests, the ABI smoke test, and `node scripts/check-contract-sizes.js`); result: all tests passed (218 passing). 
- Measured runtime bytecode sizes with `node scripts/check-contract-sizes.js`: `AGIJobManager` deployedBytecode was `24381` bytes (baseline) and increased to `24571` bytes after these changes, which remains under the EIP‑170 runtime limit (24,576 bytes). 
- Updated/verified tests specifically covering ENS hooks: `test/ensJobPagesHelper.test.js` and `test/ensJobPagesHooks.test.js` exercised creation, assignment, completion mirroring, revoke, lock, and the tokenURI toggle and passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698879257e2c833390a0286b9f5da4f5)