### PR TITLE
docs: clarify ENSJobPages wiring steps

### DIFF
--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -80,8 +80,19 @@ The platform also authorizes the employer on creation and the assigned agent on 
 - NameWrapper owner of the root must be the platform contract (or approve it via `isApprovedForAll`).
 - Subnames are created via `NameWrapper.setSubnodeRecord(...)`.
 
+## ENSJobPages helper wiring (on-chain)
+
+When using the `ENSJobPages` helper contract, complete these wiring steps:
+1. Deploy `ENSJobPages` with the ENS registry, NameWrapper (if any), PublicResolver, root node, and root name.
+2. Ensure `alpha.jobs.agi.eth` is owned by the helper (or wrapped and approved for it).
+3. Call `ENSJobPages.setJobManager(AGIJobManager)` so hooks are accepted.
+4. Call `AGIJobManager.setEnsJobPages(ENSJobPages)` to enable hook callbacks.
+
+These steps keep ENS integration **opt-in** and ensure lifecycle hooks remain best-effort.
+
 ## Operator checklist
 - Ensure the platform controls `alpha.jobs.agi.eth` and the configured PublicResolver.
+- Ensure `ENSJobPages` is wired to `AGIJobManager` via `setJobManager` and `setEnsJobPages`.
 - Ensure employer/agent wallets are authorized to edit text records via the resolver.
 - Avoid secrets: use hashes or URIs only.
 - Revoke resolver authorizations after terminal settlement.


### PR DESCRIPTION
### Motivation
- Make the ENS integration explicitly opt-in and easy for operators to wire by documenting the on-chain setup steps required to connect the `ENSJobPages` helper to `AGIJobManager` so ENS lifecycle hooks behave as intended without affecting settlement flows.

### Description
- Added an "ENSJobPages helper wiring (on-chain)" section to `docs/ens-job-pages.md` with numbered setup steps (deploy helper, ensure root ownership/wrapping, call `ENSJobPages.setJobManager(...)`, then `AGIJobManager.setEnsJobPages(...)`) and a corresponding operator checklist reminder; this is a documentation-only change.

### Testing
- Automated test runs were attempted but could not be executed in this environment: `npm ci` failed due to an optional `fsevents` platform constraint, `npm test` failed because `truffle` is not available, and `node scripts/check-contract-sizes.js` failed due to missing `build/contracts` artifacts, so no unit tests were run here; the change is docs-only and does not modify contract behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69889375c65c83338ba79eeb2386b102)