### PR TITLE
docs: clarify ENS record responsibilities

### DIFF
--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -68,6 +68,7 @@ When ENS job pages are configured, the platform attempts the following **best‑
 The platform also authorizes the employer on creation and the assigned agent on assignment, then revokes authorizations after terminal settlement.
 
 > These mirrors are **best‑effort** only; ENS failures never block settlement.
+> All other keys (e.g., `agijobs.jobId`, `agijobs.contract`, `agijobs.state`) are intentionally left for employers/agents to set via the PublicResolver once authorized.
 
 ## Wrapped vs unwrapped root setup
 


### PR DESCRIPTION
### Motivation
- Clarify operator expectations about which ENS text records the contract auto-mirrors vs which records employers/agents must set via the resolver so operators understand responsibilities and privacy implications.

### Description
- Added a short clarification to `docs/ens-job-pages.md` stating that only a small set of keys are auto-mirrored by on-chain hooks and that other keys (e.g., `agijobs.jobId`, `agijobs.contract`, `agijobs.state`) are intended to be set by authorized employers/agents via the PublicResolver.

### Testing
- Ran the repository test suite with `npm test` (Truffle tests + size checks); all tests passed (`218 passing`) and `AGIJobManager` deployed runtime bytecode remained within the EIP-170 limit at `24574` bytes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698899d77d2c8333b52aced6ef981cd9)