### PR TITLE
Enhance ENS job pages: fuse-safe lock, resilient hooks, tests & docs

### DIFF
--- a/contracts/test/MockENSJobPages.sol
+++ b/contracts/test/MockENSJobPages.sol
@@ -15,6 +15,8 @@ contract MockENSJobPages {
 
     mapping(uint8 => bool) public revertHook;
     bool public useEnsJobTokenURI;
+    bool public useJobEnsUriOverride;
+    string public jobEnsUriOverride;
 
     uint256 public createCalls;
     uint256 public assignCalls;
@@ -123,7 +125,20 @@ contract MockENSJobPages {
     }
 
     function jobEnsURI(uint256 jobId) external view returns (string memory) {
+        if (useJobEnsUriOverride) {
+            return jobEnsUriOverride;
+        }
         return string(abi.encodePacked("ens://job-", jobId.toString(), ".alpha.jobs.agi.eth"));
+    }
+
+    function setJobEnsUriOverride(string calldata uri) external {
+        useJobEnsUriOverride = true;
+        jobEnsUriOverride = uri;
+    }
+
+    function clearJobEnsUriOverride() external {
+        useJobEnsUriOverride = false;
+        jobEnsUriOverride = "";
     }
 
     function setUseEnsJobTokenURI(bool enabled) external {

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -13,14 +13,14 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
   const [owner, employer, agent] = accounts;
   const ZERO32 = "0x" + "00".repeat(32);
 
-  async function deployManager() {
+  async function deployManager(baseIpfsUrl = "") {
     const token = await MockERC20.new({ from: owner });
     const ens = await MockENS.new({ from: owner });
     const nameWrapper = await MockNameWrapper.new({ from: owner });
     const manager = await AGIJobManager.new(
       ...buildInitConfig(
         token.address,
-        "",
+        baseIpfsUrl,
         ens.address,
         nameWrapper.address,
         ZERO32,
@@ -83,6 +83,7 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await manager.setEnsJobPages(ensJobPages.address, { from: owner });
     await ensJobPages.setRevertHook(1, true, { from: owner });
     await ensJobPages.setRevertHook(2, true, { from: owner });
+    await ensJobPages.setRevertHook(3, true, { from: owner });
     await ensJobPages.setRevertHook(4, true, { from: owner });
     assert.equal(await ensJobPages.revertHook(1), true, "create hook should revert");
 
@@ -97,15 +98,43 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await manager.applyForJob(0, "agent", [], { from: agent });
 
     await manager.requestJobCompletion(0, "ipfs://completion.json", { from: agent });
-    assert.equal((await ensJobPages.completionCalls()).toString(), "1");
+    assert.equal((await ensJobPages.completionCalls()).toString(), "0", "reverted hook should not count");
 
     const reviewPeriod = await manager.completionReviewPeriod();
     await time.increase(reviewPeriod.addn(1));
     await manager.finalizeJob(0, { from: employer });
   });
 
-  it("uses ENS tokenURI when configured", async () => {
+  it("does not block cancel/expire when ENS hooks revert", async () => {
     const { token, manager } = await deployManager();
+    const nft = await MockERC721.new({ from: owner });
+    const ensJobPages = await MockENSJobPages.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+    await manager.setEnsJobPages(ensJobPages.address, { from: owner });
+    await ensJobPages.setRevertHook(4, true, { from: owner });
+
+    const payout = web3.utils.toWei("3");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+    await manager.cancelJob(0, { from: employer });
+
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    await manager.createJob("ipfs://spec2.json", payout, 1, "details", { from: employer });
+
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(1, "agent", [], { from: agent });
+
+    await time.increase(2);
+    await manager.expireJob(1, { from: employer });
+  });
+
+  it("uses ENS tokenURI when configured and preserves ens:// scheme", async () => {
+    const { token, manager } = await deployManager("ipfs://base");
     const nft = await MockERC721.new({ from: owner });
     const ensJobPages = await MockENSJobPages.new({ from: owner });
 
@@ -122,7 +151,7 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await token.mint(agent, web3.utils.toWei("2"), { from: owner });
     await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
     await manager.applyForJob(0, "agent", [], { from: agent });
-    await manager.requestJobCompletion(0, "ipfs://completion.json", { from: agent });
+    await manager.requestJobCompletion(0, "QmCompletion", { from: agent });
 
     const reviewPeriod = await manager.completionReviewPeriod();
     await time.increase(reviewPeriod.addn(1));
@@ -132,6 +161,79 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     const tokenId = issued.args.tokenId.toString();
     const tokenUri = await manager.tokenURI(tokenId);
     assert.equal(tokenUri, "ens://job-0.alpha.jobs.agi.eth");
+  });
+
+  it("falls back to completion URI when ENS tokenURI is empty", async () => {
+    const { token, manager } = await deployManager("ipfs://base");
+    const nft = await MockERC721.new({ from: owner });
+    const ensJobPages = await MockENSJobPages.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+    await manager.setEnsJobPages(ensJobPages.address, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
+    await ensJobPages.setJobEnsUriOverride("", { from: owner });
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, "QmCompletion", { from: agent });
+
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    const receipt = await manager.finalizeJob(0, { from: employer });
+    const issued = receipt.logs.find((log) => log.event === "NFTIssued");
+    const tokenId = issued.args.tokenId.toString();
+    const tokenUri = await manager.tokenURI(tokenId);
+    assert.equal(tokenUri, "ipfs://base/QmCompletion");
+  });
+
+  it("does not call lock hook before terminal state", async () => {
+    const { token, manager } = await deployManager();
+    const nft = await MockERC721.new({ from: owner });
+    const ensJobPages = await MockENSJobPages.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+    await manager.setEnsJobPages(ensJobPages.address, { from: owner });
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+    await manager.lockJobENS(0, true, { from: employer });
+    assert.equal((await ensJobPages.lockCalls()).toString(), "0");
+  });
+
+  it("uses completion URI when ENS tokenURI is disabled", async () => {
+    const { token, manager } = await deployManager("ipfs://base");
+    const nft = await MockERC721.new({ from: owner });
+
+    await seedAgentType(manager, nft, agent);
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, "QmCompletion", { from: agent });
+
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    const receipt = await manager.finalizeJob(0, { from: employer });
+    const issued = receipt.logs.find((log) => log.event === "NFTIssued");
+    const tokenId = issued.args.tokenId.toString();
+    const tokenUri = await manager.tokenURI(tokenId);
+    assert.equal(tokenUri, "ipfs://base/QmCompletion");
   });
 
 });


### PR DESCRIPTION
### Motivation
- Implement and harden the ENS "one page per job" Model B flow for the ALPHA namespace so platform-owned job names can be delegated to employers/agents while keeping ENS interactions best-effort and non-blocking.
- Ensure optional post‑terminal locking (fuse burning) is safe, minimal, and best‑effort so on‑chain settlement and refunds never depend on ENS success.
- Add tests and docs so maintainers can wire and operate the feature safely and CI remains green.

### Description
- Add minimal NameWrapper fuse constants and change `ENSJobPages._lockJobENS` to attempt burning only the minimal `LOCK_FUSES` (`CANNOT_SET_RESOLVER | CANNOT_SET_TTL`) in a best‑effort `try/catch` (no revert on failure). (`contracts/ens/ENSJobPages.sol`).
- Harden `ENSJobPages` helper with best‑effort resolver writes/authorisation and small linter-friendly `try/catch` blocks; retain idempotent revoke semantics and wrapped/unwrapped root support. (`contracts/ens/ENSJobPages.sol`).
- Extend test mock with a configurable ENS URI override and flags to exercise tokenURI fallbacks. (`contracts/test/MockENSJobPages.sol`).
- Expand `test/ensJobPagesHooks.test.js` to cover hook resilience (reverting hooks), cancellation/expiry flows when ENS hooks revert, pre‑terminal lock gating, ENS tokenURI toggle behavior, and fallback to completion URI when ENS returns empty. (`test/ensJobPagesHooks.test.js`).
- Update docs `docs/ens-job-pages.md` to clarify naming, resolver requirements, record keys, and post‑terminal lock guidance including which fuses are attempted and why (best‑effort). (`docs/ens-job-pages.md`).
- Preserve core invariants and behaviors: ENS integration remains opt‑in, best‑effort, non-blocking, and no changes were made to `truffle-config.js` or compiler settings; regulatory headers and access/pause semantics are unchanged.

### Testing
- Ran `npm run build` (Truffle compile) and compilation succeeded with artifacts produced. (success)
- Ran `npm run lint` (solhint) and the linter completed; warnings are informational and did not block CI. (success with warnings)
- Ran full test suite via `npm test` and all tests passed: `222 passing` and the bytecode size checks completed (EIP‑170 guard included). (success)

Known limitation: NameWrapper fuse burning is intentionally conservative and best‑effort—only `CANNOT_SET_RESOLVER` and `CANNOT_SET_TTL` are attempted to avoid accidental lockouts; fuse burning failures are ignored and do not affect job settlement.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988a35800588333b12cc58b1d613329)