### PR TITLE
Harden ENS job page authorisation writes

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -130,8 +130,7 @@ contract ENSJobPages is Ownable {
         _requireConfigured();
         bytes32 node = _createSubname(jobId);
         emit JobENSPageCreated(jobId, node);
-        publicResolver.setAuthorisation(node, employer, true);
-        emit JobENSPermissionsUpdated(jobId, employer, true);
+        _setAuthorisationBestEffort(jobId, node, employer, true);
         _setTextBestEffort(node, "schema", "agijobmanager/v1");
         _setTextBestEffort(node, "agijobs.spec.public", specURI);
     }
@@ -174,8 +173,7 @@ contract ENSJobPages is Ownable {
         if (agent == address(0)) revert InvalidParameters();
         _requireConfigured();
         bytes32 node = jobEnsNode(jobId);
-        publicResolver.setAuthorisation(node, agent, true);
-        emit JobENSPermissionsUpdated(jobId, agent, true);
+        _setAuthorisationBestEffort(jobId, node, agent, true);
     }
 
     function onCompletionRequested(uint256 jobId, string memory completionURI) public onlyOwner {

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -17,6 +17,10 @@ job-42.alpha.jobs.agi.eth
 
 `jobId` is the on‑chain AGIJobManager job ID.
 
+**Root configuration (ALPHA):**
+- `jobsRootName = "alpha.jobs.agi.eth"`
+- `jobsRootNode = namehash("alpha.jobs.agi.eth")`
+
 ## Ownership + delegation model (Model B)
 
 ### Ownership


### PR DESCRIPTION
### Motivation
- Ensure ENS resolver failures do not surface as hard failures during job lifecycle hooks by making authorisation writes best-effort. 
- Improve operator documentation with explicit ALPHA root configuration details for job pages so maintainers can wire `alpha.jobs.agi.eth` correctly.

### Description
- Replace direct `publicResolver.setAuthorisation(...)` calls with `_setAuthorisationBestEffort(...)` in `ENSJobPages._createJobPage` so employer authorisation is best-effort. 
- Replace direct `publicResolver.setAuthorisation(...)` calls with `_setAuthorisationBestEffort(...)` in `ENSJobPages._onAgentAssigned` so agent authorisation is best-effort. 
- Add explicit ALPHA root configuration notes to `docs/ens-job-pages.md` documenting `jobsRootName = "alpha.jobs.agi.eth"` and `jobsRootNode = namehash("alpha.jobs.agi.eth")`.

### Testing
- Ran `npm run lint`; the lint step completed successfully. 
- Ran full test suite with `npm test`; Truffle + node tests completed with all tests passing (222 passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ac24b2b88333b2df679f8b4313ac)