### PR TITLE
Harden ENS job page authorizations (best-effort resolver calls)

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -130,8 +130,7 @@ contract ENSJobPages is Ownable {
         _requireConfigured();
         bytes32 node = _createSubname(jobId);
         emit JobENSPageCreated(jobId, node);
-        publicResolver.setAuthorisation(node, employer, true);
-        emit JobENSPermissionsUpdated(jobId, employer, true);
+        _setAuthorisationBestEffort(jobId, node, employer, true);
         _setTextBestEffort(node, "schema", "agijobmanager/v1");
         _setTextBestEffort(node, "agijobs.spec.public", specURI);
     }
@@ -174,8 +173,7 @@ contract ENSJobPages is Ownable {
         if (agent == address(0)) revert InvalidParameters();
         _requireConfigured();
         bytes32 node = jobEnsNode(jobId);
-        publicResolver.setAuthorisation(node, agent, true);
-        emit JobENSPermissionsUpdated(jobId, agent, true);
+        _setAuthorisationBestEffort(jobId, node, agent, true);
     }
 
     function onCompletionRequested(uint256 jobId, string memory completionURI) public onlyOwner {

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -68,7 +68,7 @@ When ENS job pages are configured, the platform attempts the following **best‑
 - On **requestJobCompletion**: `agijobs.completion.public = <jobCompletionURI>`.
 The platform also authorizes the employer on creation and the assigned agent on assignment, then revokes authorizations after terminal settlement.
 
-> These mirrors are **best‑effort** only; ENS failures never block settlement.
+> These mirrors and authorizations are **best‑effort** only; resolver/NameWrapper failures never block settlement.
 > All other keys (e.g., `agijobs.jobId`, `agijobs.contract`, `agijobs.state`) are intentionally left for employers/agents to set via the PublicResolver once authorized.
 
 ## Wrapped vs unwrapped root setup


### PR DESCRIPTION
### Motivation
- Ensure ENS resolver/NameWrapper failures never block job lifecycle by making resolver authorisation updates best-effort and non-reverting.

### Description
- Replace direct `publicResolver.setAuthorisation(...)` calls with the existing `_setAuthorisationBestEffort(...)` helper in `ENSJobPages` for job creation and agent assignment, and clarify the best-effort guarantee in `docs/ens-job-pages.md`.

### Testing
- Ran `npm run build`, `npm run lint`, and `npm test`; compilation succeeded, lint completed, and the test suite passed (`222 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ac24b2b88333b2df679f8b4313ac)