### PR TITLE
Harden ENS job page hooks and document ALPHA root setup

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -154,13 +154,40 @@ contract ENSJobPages is Ownable {
             return;
         }
         if (hook == 4) {
-            (address employer, address agent, , , , , , , ) = jobManagerView.getJobCore(jobId);
-            _revokePermissions(jobId, employer, agent);
+            try jobManagerView.getJobCore(jobId) returns (
+                address employer,
+                address agent,
+                uint256,
+                uint256,
+                uint256,
+                bool,
+                bool,
+                bool,
+                uint8
+            ) {
+                _revokePermissions(jobId, employer, agent);
+            } catch {
+                _revokePermissions(jobId, address(0), address(0));
+            }
             return;
         }
         if (hook == 5 || hook == 6) {
-            (address employer, address agent, , , , , , , ) = jobManagerView.getJobCore(jobId);
-            _lockJobENS(jobId, employer, agent, hook == 6);
+            bool burnFuses = hook == 6;
+            try jobManagerView.getJobCore(jobId) returns (
+                address employer,
+                address agent,
+                uint256,
+                uint256,
+                uint256,
+                bool,
+                bool,
+                bool,
+                uint8
+            ) {
+                _lockJobENS(jobId, employer, agent, burnFuses);
+            } catch {
+                _lockJobENS(jobId, address(0), address(0), burnFuses);
+            }
             return;
         }
     }

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -17,6 +17,10 @@ job-42.alpha.jobs.agi.eth
 
 `jobId` is the on‑chain AGIJobManager job ID.
 
+The ALPHA root configuration is fixed:
+- `jobsRootName = "alpha.jobs.agi.eth"`
+- `jobsRootNode = namehash("alpha.jobs.agi.eth")`
+
 ## Ownership + delegation model (Model B)
 
 ### Ownership
@@ -79,8 +83,12 @@ The platform also authorizes the employer on creation and the assigned agent on 
 
 ### Wrapped root (`alpha.jobs.agi.eth` wrapped)
 - ENS Registry owner of `alpha.jobs.agi.eth` is NameWrapper.
-- NameWrapper owner of the root must be the platform contract (or approve it via `isApprovedForAll`).
+- NameWrapper owner of the root must be the platform contract **or** must approve it via `setApprovalForAll`.
 - Subnames are created via `NameWrapper.setSubnodeRecord(...)`.
+
+### Operational ownership requirements (summary)
+- **Unwrapped**: `ENSRegistry.owner(jobsRootNode)` must be `ENSJobPages` (or the configured controller).
+- **Wrapped**: `ENSRegistry.owner(jobsRootNode)` must be `NameWrapper`, and the wrapped owner must be `ENSJobPages` **or** have approved it via `setApprovalForAll`.
 
 ## Resolver requirements
 - `ENSJobPages` expects a PublicResolver that exposes `setAuthorisation(bytes32,address,bool)` and `setText(bytes32,string,string)`.
@@ -112,6 +120,7 @@ When disabled (default), the tokenURI behavior is unchanged and continues to use
 
 ## Post‑terminal lock (optional)
 `AGIJobManager.lockJobENS(jobId, burnFuses)` can be called after a terminal state to re‑revoke resolver authorizations and optionally attempt fuse burning (best‑effort).
+If the job was cancelled or delisted (and the job struct is cleared), the lock hook can still attempt fuse burning but may not have access to employer/agent addresses; authorizations were already revoked during terminalization.
 When `burnFuses` is true and the name is wrapped, `ENSJobPages` attempts to burn only:
 - `CANNOT_SET_RESOLVER`
 - `CANNOT_SET_TTL`


### PR DESCRIPTION
### Motivation
- Make ENS helper callbacks resilient so ENS integration remains strictly best-effort and never blocks job lifecycle or settlement when job data is missing or the hook view call reverts. 
- Clarify operational wiring and ownership expectations for the ALPHA namespace so operators can safely run platform-owned job subnames and optional fuse-burning locks.

### Description
- ENS hook hardening: `ENSJobPages.handleHook` now wraps `getJobCore` calls for REVOKE and LOCK hooks in `try/catch` and falls back to zero addresses when job data is unavailable, preserving best-effort behavior while still attempting authorisation revocation and fuse burning (file: `contracts/ens/ENSJobPages.sol`).
- Docs: updated `docs/ens-job-pages.md` to assert the ALPHA root config (`jobsRootName = "alpha.jobs.agi.eth"`, `jobsRootNode = namehash("alpha.jobs.agi.eth")`), clarify wrapped vs unwrapped operational ownership requirements (including `setApprovalForAll`), and note lock behavior when job structs have been cleared.
- Small behavioral note: the helper still attempts minimal fuse burning (`CANNOT_SET_RESOLVER` and `CANNOT_SET_TTL`) as a best-effort optional step and does not affect on-chain settlement flows.

### Testing
- Ran compilation: `npm run build` (Truffle compile) and it completed successfully.
- Ran linter: `npm run lint` and it completed (no blocking errors produced by the change).
- Ran full test suite: `npm test` which runs `truffle test` and additional checks; the test run completed successfully with the repo test suite passing (222 passing tests) and bytecode size checks performed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988b3c69790833397e40006ba0f40eb)