### PR TITLE
Enforce payout bounds and clarify retained platform revenue

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -911,6 +911,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
                 revert InvalidParameters();
             }
         }
+        if (agentPayout + validatorBudget > job.payout) {
+            revert InvalidParameters();
+        }
         uint256 retained;
         unchecked {
             retained = job.payout - agentPayout - validatorBudget;


### PR DESCRIPTION
### Motivation
- Ensure the retained platform revenue computed on agent-win reflects the actual on-chain residual and guard against parameter combinations that would make agent+validator allocations exceed the job payout.

### Description
- Added an explicit bounds check in `_completeJob` to `revert InvalidParameters()` if `agentPayout + validatorBudget > job.payout`, and left the existing `PlatformRevenueAccrued` emission and payout/withdrawal mechanics unchanged.

### Testing
- Attempted to run the full test suite with `npm test`, but the run failed because `truffle` is not available in the execution environment (error: `truffle: not found`).
- The repository contains unit tests that cover these behaviors (`test/platformRevenue.test.js` and `test/ensJobPagesHooks.test.js`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988d6d7ee4c833396d59fdaa90623f1)