### PR TITLE
Align docs with contract behaviour: mainnet security, ENS identity, architecture, and test status

### DIFF
--- a/docs/TEST_STATUS.md
+++ b/docs/TEST_STATUS.md
@@ -14,6 +14,9 @@ Node v20.19.6
 ## Root cause
 `truffle test` defaults to the `development` network (localhost:8545). No Ganache node was running at that address in this environment.
 
+## Passing command
+- `npx truffle test --network test` (`226 passing`)
+
 ## Smallest fix required
 Either:
 1. Run a local node: `npx ganache -p 8545`, then re-run `npx truffle test`, **or**

--- a/docs/ens-identity-and-namespaces.md
+++ b/docs/ens-identity-and-namespaces.md
@@ -49,19 +49,13 @@ AGIJobManager validates **agents** and **validators** via a layered model:
 2) **ENS namespace ownership**
    - The contract stores **root nodes** for the agent and club namespaces.
    - It derives a subnode from the supplied `subdomain` and checks ownership.
+   - Ownership checks are satisfied if **either**:
+     - `NameWrapper.ownerOf(subnode) == claimant`, **or**
+     - the ENS resolver’s `addr(subnode)` returns the claimant address.
 
-3) **NameWrapper ownership**
-   - The contract checks `NameWrapper.ownerOf(subnode)` for direct ownership.
-
-4) **Resolver address match**
-   - The contract checks the ENS resolver’s `addr(subnode)` for address matches.
-
-5) **Explicit allowlists & blacklists**
-   - `additionalAgents` / `additionalValidators` are explicit overrides.
+3) **Explicit allow/deny overrides**
+   - `additionalAgents` / `additionalValidators` are explicit allowlist overrides.
    - `blacklistedAgents` / `blacklistedValidators` override everything else.
-
-When ownership checks succeed, an `OwnershipVerified` event is emitted for the
-claimant and subdomain.
 
 ## Root nodes and namespace mapping
 

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -1,7 +1,7 @@
 # Test status (local)
 
 This file records the latest local test outcomes and any environment‑specific
-failures.
+failures. Warnings are treated as failures for audit readiness.
 
 ## Environment
 - OS: Linux (container)
@@ -19,19 +19,19 @@ npm ci
 ```bash
 npm install --omit=optional
 ```
-**Result:** succeeded (with deprecation warnings). Used as a fallback to install
-dependencies after `npm ci` failed on Linux.
+**Result:** succeeded, but emitted warnings treated as failures:
+- `npm warn Unknown env config "http-proxy"`.
+- Multiple deprecation warnings from transitive dependencies.
+- `npm audit` reports vulnerabilities (27 low, 12 moderate, 19 high, 7 critical).
 
-## Test commands
-```bash
-npx truffle version
-```
-**Result:** succeeded.
-
+## Build + test commands
 ```bash
 npx truffle compile
 ```
-**Result:** succeeded. No compile warnings reported.
+**Result:** succeeded, but emitted compiler warnings treated as failures:
+- Name shadowing warning in `contracts/test/MockENSRegistry.sol` (`setOwner` argument).
+- Name shadowing warning in `contracts/test/MockPublicResolver.sol` (`setAuthorisation` argument).
+- Low‑level call return value unused in `contracts/AGIJobManager.sol` (`ensJobPages.call`).
 
 ```bash
 npx truffle test
@@ -42,7 +42,7 @@ This happens because the default Truffle network expects a local node on port 85
 ```bash
 npx truffle test --network test
 ```
-**Result:** passed (`193 passing`).
+**Result:** passed (`226 passing`).
 
 **Smallest next fix (for the failing command):**
 - Run tests against the configured in‑process Ganache network with


### PR DESCRIPTION
### Motivation
- Ensure repository documentation is accurate and security/audit friendly by matching prose to the current contract code (owner powers, identity lock name, pause semantics, escrow invariants, and reputation math).
- Clarify identity verification (ENS/NameWrapper + Merkle + overrides) and the ENS namespace grammar so auditors can reason about identity gating.
- Record exact local test outcomes and environment caveats so CI and auditors reproduce and understand passing vs failing commands.

### Description
- Updated `docs/mainnet-deployment-and-security-overview.md` to reflect code-accurate escrow accounting (include `lockedDisputeBonds` in treasury/withdrawable math), the one-time identity lock naming `lockIdentityConfiguration()` / `lockIdentityConfig`, what is locked vs adjustable after lock, pause semantics (table form), monitoring events, and added a short note that `additionalAgentPayoutPercentage` is currently unused.
- Updated `docs/ens-identity-and-namespaces.md` to document the layered identity checks implemented on-chain and to state that ownership is satisfied if either `NameWrapper.ownerOf(subnode) == claimant` or the ENS resolver `addr(subnode)` returns the claimant, and documented root nodes used by the contract and allowlist override rules.
- Updated `docs/architecture.md` and README job lifecycle/state-machine text to show agent-win vs employer-win terminal paths, clarify when NFTs are minted (agent-win only) and when refunds occur (employer-win), and document `finalizeJob` behaviour (anyone may finalize when no validators voted and default is agent win) and the owner stale-dispute path.
- Updated test-status/known-issues docs (`docs/test-status.md`, `docs/TEST_STATUS.md`, `docs/KNOWN_ISSUES.md`) to record exact local commands run, environment failures, compiler warnings, and that tests pass when run against the in-process Ganache provider (`--network test`).
- Small README updates to link and surface the authoritative docs and to include the `lockedDisputeBonds` change in trust notes.

### Testing
- Commands run: `npm ci` (failed on Linux due to macOS-only optional `fsevents`), `npm install --omit=optional` (succeeded with warnings), `npx truffle compile` (succeeded but emitted Solidity warnings), `npx truffle test` (failed due to no local node at `127.0.0.1:8545`), and `npx truffle test --network test` (passed).
- Exact observed results: `npm ci` → EBADPLATFORM (fsevents), `npm install --omit=optional` → succeeded but many deprecation/audit warnings, `npx truffle compile` → compiled successfully with a few warnings (name shadowing in mocks, unused low-level call return in ENS hook), `npx truffle test` → CONNECTION ERROR (no local RPC), `npx truffle test --network test` → `226 passing`.
- Notes: the repo includes a bytecode size guard (`test/bytecodeSize.test.js`) and compilation used `solc` pinned in `truffle-config.js` (solc `0.8.23`, optimizer runs = `50`, `viaIR = false`), which were observed during `npx truffle compile`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988e3578cd08333a791e7561def428f)