### PR TITLE
Harden ENS interactions, cap AGI types, and trim bytecode size

### DIFF
--- a/MAINNET_DEPLOYMENT_CHECKLIST.md
+++ b/MAINNET_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,11 @@
+# Mainnet Deployment Checklist
+
+- Transfer contract ownership to a multisig (e.g., Safe), not an EOA.
+- Decide whether to keep `useEnsJobTokenURI` disabled at launch; if enabling, confirm `ensJobPages` is the intended contract.
+- ENS configuration verification:
+  - Jobs root node is owned or wrapped by the expected entity.
+  - Resolver is set correctly for the root and job subdomains.
+  - Job manager address is configured in the ENS job pages contract (if used).
+- Run Slither and unit tests; include at least one invariant-style test focused on solvency
+  (contract balance >= lockedEscrow + locked*Bonds) and settlement flows.
+- Obtain an external audit or review before deploying funds at scale.


### PR DESCRIPTION
### Motivation
- Reduce contract bytecode to meet the mainnet size limit while hardening optional ENS integration and ownership checks.
- Make ENS hooks and job-token URI lookups best-effort and gas-capped to avoid reverts from external contracts.
- Simplify and tighten AGI type bookkeeping to enforce a cap and shrink on-chain logic.

### Description
- Introduce gas limits for ENS calls and URIs with `ENS_HOOK_GAS_LIMIT` and `ENS_URI_GAS_LIMIT` and guard all ENS interactions by checking `target.code.length` before calling or `staticcall` with the gas cap and optional handling of returned data; replace multiple small ENS helpers with `_callEnsJobPagesHook` and remove the old `_tryENSRevoke` indirection.
- Protect `requestJobCompletion` with `nonReentrant` and ensure ENS token URI lookup uses `staticcall{ gas: ENS_URI_GAS_LIMIT }` and only replaces the token URI when non-empty data is returned.
- Consolidate Merkle/ENS ownership checks into a single `_verifyOwnership` helper that accepts explicit roots and replace the previous agent/validator-specific variants; update `applyForJob` and validator vote paths to use the consolidated verifier.
- Enforce a hard cap on AGI types with `MAX_AGI_TYPES = 32` and inline the payout-calculation loop inside `addAGIType` to remove helper functions and reduce bytecode; update existing entries in-place when present.
- Remove an unused `_enforceValidatorCapacity` helper and replace with an inline capacity check at the call site, and refactor `_decrementActiveJob` placement to avoid duplication.
- Add `MAINNET_DEPLOYMENT_CHECKLIST.md` with operational guidance for a mainnet launch.
- All edits were made without changing `truffle-config.js` and `viaIR` remains `false` as required.

### Testing
- Ran `npx truffle compile`; compilation completed successfully with minor warnings about unused low-level call return values.
- Ran `npm run size` which reports `AGIJobManager runtime bytecode size: 24574 bytes`, which passes the `24575` byte limit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ed32d1088333ae9e39f3ae9ed6df)