### PR TITLE
Harden ENS hooks and cap AGI types

### DIFF
--- a/MAINNET_DEPLOYMENT_CHECKLIST.md
+++ b/MAINNET_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,13 @@
+# Mainnet Deployment Checklist (AGIJobManager)
+
+- Ensure contract ownership is a multisig (e.g., Safe) **before** funding on mainnet.
+- Decide whether to enable `useEnsJobTokenURI` at launch:
+  - If disabled, job completion NFTs will use `jobCompletionURI`.
+  - If enabled, verify `ensJobPages` is correct and resilient; misconfiguration should not halt core flows.
+- ENS configuration verification:
+  - `jobsRoot` is configured as expected in ENS.
+  - Resolver is set and returns the expected records.
+  - `jobManager` is set to this deployed contract.
+- Run Slither and unit tests; include at least one solvency invariant:
+  - `balance >= lockedEscrow + lockedAgentBonds + lockedValidatorBonds`.
+- Obtain an external review/audit before scaling TVL materially.


### PR DESCRIPTION
### Motivation

- Prevent ENS misconfiguration or hostile ENS implementations from DoS-ing or gas-griefing core flows and NFT minting. 
- Limit growth of `agiTypes` to avoid unbounded iteration/gas issues over time. 
- Add minimal reentrancy hardening where external ENS hooks may be triggered. 
- Provide a short mainnet checklist for safe operational deployment.

### Description

- Added `ENS_HOOK_GAS_LIMIT = 500_000` and `ENS_URI_GAS_LIMIT = 200_000` constants to bound ENS external calls. 
- Hardened `_callEnsJobPagesHook(uint8,uint256)` to return early if `ensJobPages` is unset or has no code, and to perform the call with the `ENS_HOOK_GAS_LIMIT` gas cap while ignoring the result. 
- Hardened ENS URI lookup in `_mintCompletionNFT` to only attempt the `staticcall` when `ensJobPages` is non-zero and has code, to use the `ENS_URI_GAS_LIMIT` gas cap, and to preserve existing semantics (only overwrite token URI when call succeeds and returns a non-empty string). 
- Added `nonReentrant` modifier to `requestJobCompletion(...)` to reduce reentrancy surface when ENS hooks are invoked. 
- Introduced `MAX_AGI_TYPES = 32` and enforced the limit in `addAGIType(...)` only for NEW entries while allowing updates to existing types to continue to work. 
- Added `MAINNET_DEPLOYMENT_CHECKLIST.md` with practical operational guidance (multisig owner, ENS verification, solvency invariant, Slither + unit tests, external review). 

### Testing

- No automated tests were executed as part of this change set; recommend running the unit test suite and Slither (including the suggested solvency invariant) before mainnet deployment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988f117bfc48333a62151bc0f1664b9)