### PR TITLE
Optimize ENS calls, consolidate ownership checks, enforce AGI type cap, and refresh ABI

### DIFF
--- a/MAINNET_DEPLOYMENT_CHECKLIST.md
+++ b/MAINNET_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,11 @@
+# Mainnet Deployment Checklist
+
+- Transfer contract ownership to a multisig (e.g., Safe), not an EOA.
+- Decide whether to keep `useEnsJobTokenURI` disabled at launch; if enabling, confirm `ensJobPages` is the intended contract.
+- ENS configuration verification:
+  - Jobs root node is owned or wrapped by the expected entity.
+  - Resolver is set correctly for the root and job subdomains.
+  - Job manager address is configured in the ENS job pages contract (if used).
+- Run Slither and unit tests; include at least one invariant-style test focused on solvency
+  (contract balance >= lockedEscrow + locked*Bonds) and settlement flows.
+- Obtain an external audit or review before deploying funds at scale.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -840,6 +840,19 @@
     },
     {
       "inputs": [],
+      "name": "MAX_AGI_TYPES",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "MAX_VALIDATORS_PER_JOB",
       "outputs": [
         {


### PR DESCRIPTION
### Motivation

- Reduce runtime bytecode and call overhead for ENS integrations by replacing high-level ABI encodings with compact, gas-bounded call/staticcall sequences.
- Remove duplicated ownership-verification logic by consolidating agent/validator checks into a single parametrized verifier for clarity and maintainability.
- Enforce a conservative cap on AGI NFT types and provide a mainnet deployment checklist to guide safe launch procedures.

### Description

- Introduced `MAX_AGI_TYPES` and enforced it in `addAGIType`, preventing adding new AGI types beyond the configured cap and keeping payout validation intact.
- Replaced higher-level `abi.encodeWithSelector` usage with compact assembly payloads and bounded `call`/`staticcall` to `ensJobPages` and in `_callEnsJobPagesHook`/`_mintCompletionNFT`, and added `ENS_HOOK_GAS_LIMIT` and `ENS_URI_GAS_LIMIT` constants.
- Consolidated `_verifyOwnershipAgent` and `_verifyOwnershipValidator` into `_verifyOwnership` and simplified `_verifyOwnershipByRoot` to return a single boolean check, and updated call sites in `applyForJob` and `_recordValidatorVote`.
- Miscellaneous: added `nonReentrant` to `requestJobCompletion`, removed unused selector constants, replaced `_tryENSRevoke` uses with `_callEnsJobPagesHook`, added `MAINNET_DEPLOYMENT_CHECKLIST.md`, and refreshed the exported ABI at `docs/ui/abi/AGIJobManager.json`.

### Testing

- Ran `npm run ui:abi` to export and refresh `docs/ui/abi/AGIJobManager.json`, and committed the updated ABI file successfully.
- Ran `npx truffle compile` / `npm run test` (which executes `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`) and observed the full test suite pass with `226 passing` and the ABI smoke test passing.
- Verified contract runtime bytecode size via `node scripts/check-contract-sizes.js` to ensure `AGIJobManager` remains within the EIP-170 safety margin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ed32d1088333ae9e39f3ae9ed6df)