### PR TITLE
Add MAX_AGI_TYPES, tighten ENS calls with assembly, consolidate ownership checks, and update exported ABI

### DIFF
--- a/MAINNET_DEPLOYMENT_CHECKLIST.md
+++ b/MAINNET_DEPLOYMENT_CHECKLIST.md
@@ -1,0 +1,11 @@
+# Mainnet Deployment Checklist
+
+- Transfer contract ownership to a multisig (e.g., Safe), not an EOA.
+- Decide whether to keep `useEnsJobTokenURI` disabled at launch; if enabling, confirm `ensJobPages` is the intended contract.
+- ENS configuration verification:
+  - Jobs root node is owned or wrapped by the expected entity.
+  - Resolver is set correctly for the root and job subdomains.
+  - Job manager address is configured in the ENS job pages contract (if used).
+- Run Slither and unit tests; include at least one invariant-style test focused on solvency
+  (contract balance >= lockedEscrow + locked*Bonds) and settlement flows.
+- Obtain an external audit or review before deploying funds at scale.

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -840,6 +840,19 @@
     },
     {
       "inputs": [],
+      "name": "MAX_AGI_TYPES",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
       "name": "MAX_VALIDATORS_PER_JOB",
       "outputs": [
         {


### PR DESCRIPTION
### Motivation
- Keep ENS interactions best-effort and gas-bounded while reducing high-level ABI call overhead and preserving behavior.  
- Consolidate duplicated ownership verification logic to simplify and reduce code size and potential maintenance burden.  
- Add a hard cap for AGI-type registrations to avoid unbounded growth of the `agiTypes` array.  
- Fix UI ABI drift by refreshing the exported ABI after contract changes so UI sync tests pass.

### Description
- Introduced `MAX_AGI_TYPES = 32` and enforced the cap in `addAGIType` to prevent growing `agiTypes` beyond the limit.  
- Replaced higher-level `abi.encodeWithSelector` / `call` sites for ENS hooks and token URI lookup with compact assembly payloads and bounded `call`/`staticcall` using `ENS_HOOK_GAS_LIMIT` and `ENS_URI_GAS_LIMIT`.  
- Removed runtime selector/constants and inlined the 4-byte selector values into assembly payloads to reduce generated bytecode and overhead.  
- Consolidated `_verifyOwnershipAgent` and `_verifyOwnershipValidator` into a single parametrized `_verifyOwnership` and kept `_verifyOwnershipByRoot` with a zero-root guard to simplify ownership checks.  
- Added `nonReentrant` to `requestJobCompletion` and switched ENS revoke attempts to `_callEnsJobPagesHook` calls throughout terminal flows.  
- Updated the UI ABI by exporting and committing `docs/ui/abi/AGIJobManager.json` to include the new `MAX_AGI_TYPES` getter.

### Testing
- Ran `npx truffle compile` which completed successfully.  
- Ran `npm run ui:abi` to export the ABI and committed `docs/ui/abi/AGIJobManager.json`.  
- Ran the full test command `npm run test` (which runs `truffle test`, node JS tests, and `scripts/check-contract-sizes.js`) and observed `226 passing` tests, UI ABI sync passing, and the bytecode size guard confirming `AGIJobManager` deployed bytecode is `24533 bytes` (within the safety margin).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6988ed32d1088333ae9e39f3ae9ed6df)