### PR TITLE
Update deployment & test docs to reflect repo scripts and latest local run

### DIFF
--- a/docs/mainnet-deployment-and-security-overview.md
+++ b/docs/mainnet-deployment-and-security-overview.md
@@ -161,11 +161,11 @@ node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.dep
 ```
 
 ## 9) Verification & deployment guide (Truffle‑first)
-**Build & test**
+**Build & test (repo scripts)**
 ```bash
-npm ci
-npx truffle compile
-npx truffle test --network test
+npm install
+npm run build
+npm test
 ```
 
 **Deployment entrypoint**

--- a/docs/test-status.md
+++ b/docs/test-status.md
@@ -7,44 +7,29 @@ failures. Warnings are treated as failures for audit readiness.
 - OS: Linux (container)
 - Node: v20.19.6
 - Truffle: v5.11.5
+- Ganache: v7.9.1
 - Solidity (solc‑js): 0.8.23
 
 ## Install status
 ```bash
-npm ci
-```
-**Result:** failed on Linux because `fsevents@2.3.2` is macOS‑only
-(`EBADPLATFORM`). The command also emitted `npm warn Unknown env config "http-proxy"`.
-
-```bash
-npm install --omit=optional
+npm install
 ```
 **Result:** succeeded, but emitted warnings treated as failures:
 - `npm warn Unknown env config "http-proxy"`.
 - Multiple deprecation warnings from transitive dependencies.
-- `npm audit` reports vulnerabilities (27 low, 12 moderate, 19 high, 7 critical).
+- `npm audit` reports vulnerabilities (28 low, 12 moderate, 35 high, 13 critical).
 
 ## Build + test commands
 ```bash
-npx truffle compile
+npm run build
 ```
 **Result:** succeeded, but emitted compiler warnings treated as failures:
 - Name shadowing warning in `contracts/test/MockENSRegistry.sol` (`setOwner` argument).
 - Name shadowing warning in `contracts/test/MockPublicResolver.sol` (`setAuthorisation` argument).
-- Low‑level call return value unused in `contracts/AGIJobManager.sol` (`ensJobPages.call`).
 
 ```bash
-npx truffle test
+npm test
 ```
-**Result:** failed with `CONNECTION ERROR: Couldn't connect to node http://127.0.0.1:8545`.
-This happens because the default Truffle network expects a local node on port 8545.
-
-```bash
-npx truffle test --network test
-```
-**Result:** passed (`226 passing`).
-
-**Smallest next fix (for the failing command):**
-- Run tests against the configured in‑process Ganache network with
-  `npx truffle test --network test`, or start a local JSON‑RPC node on
-  `http://127.0.0.1:8545` before running `npx truffle test`.
+**Result:** passed (`226 passing`), but emitted warnings treated as failures:
+- `npm warn Unknown env config "http-proxy"`.
+- The same compiler warnings from `npm run build`.


### PR DESCRIPTION
### Motivation
- Bring the mainnet deployment guide in-line with the repository's actual build/test npm scripts for reproducible instructions.
- Record the real local build/test outcomes (including warnings and audit results) so auditors/operators see current test status and actionable next steps.
- Replace an outdated `npm ci` troubleshooting entry with the current `npm install` behavior and compiler warning guidance to reduce confusion for maintainers.

### Description
- Updated `docs/mainnet-deployment-and-security-overview.md` to recommend the repository's canonical commands (`npm install`, `npm run build`, `npm test`) instead of a raw `npm ci`/`truffle` sequence. 
- Updated `docs/test-status.md` with a fresh local run summary showing environment details, `npm install`/`npm run build` outcomes, and that `npm test` completes the suite. 
- Rewrote `docs/KNOWN_ISSUES.md` to document current install warnings (including the `http-proxy` config and dependency deprecations) and the Solidity name-shadowing compiler warnings in test mocks, with minimal remediation advice. 
- The changes are documentation-only and do not modify any contract logic or tests.

### Testing
- Ran `npm install`; result: succeeded but produced warnings and an `npm audit` report (88 vulnerabilities: 28 low, 12 moderate, 35 high, 13 critical) which is recorded in docs. 
- Ran `npm run build` (Truffle compile); result: compiled successfully with compiler warnings about name-shadowing in test mock contracts, and artifacts written with `solc 0.8.23` as pinned in `truffle-config.js`. 
- Ran `npm test`; result: full test suite passed (`226 passing`) and the bytecode size guard succeeded (AGIJobManager deployedBytecode size within the EIP‑170 limit); warnings from install/build were observed and are documented as audit-readiness concerns.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698903e820c48333902a7e20cb7db879)