### PR TITLE
Fix ENS hook calldata buffer

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1071,10 +1071,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             return;
         }
         assembly {
-            mstore(0x00, 0x1f76f7a200000000000000000000000000000000000000000000000000000000)
-            mstore(0x04, hook)
-            mstore(0x24, jobId)
-            pop(call(ENS_HOOK_GAS_LIMIT, target, 0, 0x00, 0x44, 0, 0))
+            let ptr := mload(0x40)
+            mstore(ptr, 0x1f76f7a200000000000000000000000000000000000000000000000000000000)
+            mstore(add(ptr, 0x04), hook)
+            mstore(add(ptr, 0x24), jobId)
+            pop(call(ENS_HOOK_GAS_LIMIT, target, 0, ptr, 0x44, 0, 0))
         }
     }
 


### PR DESCRIPTION
### Motivation
- Avoid corrupting Solidity free-memory pointer by preventing writes to `0x00..0x44` in the ENS hook call, which could break later ABI encoding and events.

### Description
- In `contracts/AGIJobManager.sol` ` _callEnsJobPagesHook` replaced the assembly that wrote to fixed memory with a safe scratch buffer allocated via `let ptr := mload(0x40)` and `mstore` at `ptr`, `add(ptr, 0x04)`, and `add(ptr, 0x24)`, then `pop(call(ENS_HOOK_GAS_LIMIT, target, 0, ptr, 0x44, 0, 0))`, preserving the early-return guard, `ENS_HOOK_GAS_LIMIT` gas cap, best-effort semantics, exact selector/layout, and not updating the free-memory pointer.

### Testing
- No automated tests were run on this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989113b90488333bbf02d5c35d4a1bf)