### PR TITLE
Handle empty deployedBytecode in full artifact scan and validate missing bytecode for targeted bytecode checks

### DIFF
--- a/scripts/check-bytecode-size.js
+++ b/scripts/check-bytecode-size.js
@@ -7,10 +7,20 @@ const defaultContracts = ["AGIJobManager"];
 
 function deployedSizeBytes(artifact) {
   const deployedBytecode =
-    artifact.deployedBytecode || artifact.evm?.deployedBytecode?.object || "";
+    artifact.deployedBytecode || artifact.evm?.deployedBytecode?.object;
+  if (!deployedBytecode) {
+    throw new Error(
+      `Missing deployedBytecode in artifact for ${artifact.contractName || "unknown"}`
+    );
+  }
   const hex = deployedBytecode.startsWith("0x")
     ? deployedBytecode.slice(2)
     : deployedBytecode;
+  if (!hex) {
+    throw new Error(
+      `Empty deployedBytecode in artifact for ${artifact.contractName || "unknown"}`
+    );
+  }
   return hex.length / 2;
 }
 

--- a/scripts/check-contract-sizes.js
+++ b/scripts/check-contract-sizes.js
@@ -7,10 +7,18 @@ const IGNORED_CONTRACTS = new Set();
 
 function deployedSizeBytes(artifact) {
   const deployedBytecode =
-    artifact.deployedBytecode || artifact.evm?.deployedBytecode?.object || "";
+    artifact.deployedBytecode || artifact.evm?.deployedBytecode?.object;
+  if (!deployedBytecode) {
+    throw new Error(
+      `Missing deployedBytecode in artifact for ${artifact.contractName || "unknown"}`
+    );
+  }
   const hex = deployedBytecode.startsWith("0x")
     ? deployedBytecode.slice(2)
     : deployedBytecode;
+  if (!hex) {
+    return 0;
+  }
   return hex.length / 2;
 }
 


### PR DESCRIPTION
### Motivation
- Prevent false positives from stale or missing Truffle artifacts while allowing valid interface/abstract artifacts with empty runtime code to be treated as 0 bytes.
- Surface real artifact generation problems quickly for targeted `BYTECODE_CONTRACTS` checks so CI fails with actionable messages instead of reporting incorrect sizes.

### Description
- In `scripts/check-contract-sizes.js` the `deployedSizeBytes` helper now returns `0` when `deployedBytecode` exists but is empty (e.g., `"0x"`), so interfaces/abstracts are treated as 0-byte artifacts instead of throwing.
- In `scripts/check-bytecode-size.js` the `deployedSizeBytes` helper was made stricter by throwing a clear error when `deployedBytecode` is missing or empty for targeted `BYTECODE_CONTRACTS`, ensuring those checks fail fast if artifacts are not generated correctly.
- Both scripts still compute and log sizes and preserve the existing "oversize"/exit-on-failure behavior for non-ignored contracts.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698921dbf0b083339f2884940ce622e4)