### PR TITLE
Skip deprecated additionalAgentPayout in postdeploy config and update tests

### DIFF
--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,7 +79,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("ignores additional agent payout settings when validating reward headroom", async () => {
+  it("reverts deprecated additional agent payout updates without blocking validation rewards", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(
         token.address,
         "ipfs://base",
@@ -95,7 +95,10 @@ contract("AGIJobManager economic safety", (accounts) => {
       { from: owner }
     );
 
-    await manager.setAdditionalAgentPayoutPercentage(90, { from: owner });
+    await expectCustomError(
+      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
+      "InvalidState"
+    );
     await manager.setValidationRewardPercentage(90, { from: owner });
     assert.equal((await manager.validationRewardPercentage()).toString(), "90");
   });


### PR DESCRIPTION
### Motivation
- Prevent the post-deploy configuration flow and CI from failing after `setAdditionalAgentPayoutPercentage` was intentionally disabled on-chain by adapting tooling and tests to the deprecation.

### Description
- Update `scripts/postdeploy-config.js` to skip any provided `additionalAgentPayoutPercentage` and log a clear message instead of attempting the now-reverting on-chain setter, and simplify headroom ordering logic to ignore the deprecated knob.
- Modify `test/economicSafety.test.js` to assert that calling the deprecated `setAdditionalAgentPayoutPercentage` reverts with `InvalidState` while still allowing validation reward updates to proceed.
- Remove the on-script creation/verification of the deprecated setter operation so post-deploy plans and ordering logic no longer depend on the removed on-chain behavior.

### Testing
- Ran `npm run build`, which compiled the contracts successfully and produced artifacts in `build/contracts`.
- Ran `npm run size`, which reported `AGIJobManager runtime bytecode size: 24558 bytes` and is under the 24576-byte limit required for mainnet.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892f292be083338e917dbd5f8cd20d)