### PR TITLE
Deprecate additionalAgentPayoutPercentage, add settlement pause, refresh ABI and tests

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -93,6 +93,11 @@
     },
     {
       "inputs": [],
+      "name": "SettlementPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "TransferFailed",
       "type": "error"
     },
@@ -754,6 +759,25 @@
         }
       ],
       "name": "RootNodesUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "setter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "SettlementPauseSet",
       "type": "event"
     },
     {
@@ -1633,6 +1657,19 @@
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "settlementPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "bytes4",
@@ -1814,6 +1851,19 @@
     {
       "inputs": [],
       "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "setSettlementPaused",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -2404,7 +2454,7 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "_percentage",
+          "name": "",
           "type": "uint256"
         }
       ],

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,7 +79,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("ignores additional agent payout settings when validating reward headroom", async () => {
+  it("reverts deprecated additional agent payout settings", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(
         token.address,
         "ipfs://base",
@@ -95,9 +95,10 @@ contract("AGIJobManager economic safety", (accounts) => {
       { from: owner }
     );
 
-    await manager.setAdditionalAgentPayoutPercentage(90, { from: owner });
-    await manager.setValidationRewardPercentage(90, { from: owner });
-    assert.equal((await manager.validationRewardPercentage()).toString(), "90");
+    await expectCustomError(
+      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
+      "InvalidState"
+    );
   });
 
   it("settles successfully with safe payout configuration", async () => {


### PR DESCRIPTION
### Motivation
- Remove the deprecated `additionalAgentPayoutPercentage` runtime/config knob and ensure tooling/tests no longer rely on it to avoid runtime errors. 
- Add a settlement pause control to allow owner-level suspension of dispute/settlement flows. 
- Keep CI/UI artifacts and tests in sync with the contract changes by exporting the updated ABI and adjusting tests that referenced the deprecated setter.

### Description
- Contracts: in `contracts/AGIJobManager.sol` deprecate `setAdditionalAgentPayoutPercentage` by making it always revert with `InvalidState`, add `SettlementPaused` error, `settlementPaused` state, `setSettlementPaused` setter, `SettlementPauseSet` event, `whenSettlementNotPaused` modifier, and apply the modifier to dispute/settlement sensitive functions; introduce several internal helper functions and small refactors to centralize validations and emissions. 
- Scripts: update `scripts/postdeploy-config.js` to ignore and warn on `additionalAgentPayoutPercentage` in configs and simplify headroom ordering logic so deploy tooling no longer attempts to call the deprecated setter. 
- Tests & docs: update `test/economicSafety.test.js` to assert the deprecated setter reverts via `.call` expecting `InvalidState`, and refresh `docs/ui/abi/AGIJobManager.json` to reflect the ABI changes (new error/event, `settlementPaused` getter and `setSettlementPaused` function, and adjusted parameter signature). 

### Testing
- Ran `npm run test`, which completed successfully with the test suite passing (226 passing). 
- Exported the updated ABI using `npm run ui:abi` and compiled contracts via `npm run build` during validation; both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892f292be083338e917dbd5f8cd20d)