### PR TITLE
Deprecate additionalAgentPayoutPercentage, add settlement pause, refresh ABI, and fix tests

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -93,6 +93,11 @@
     },
     {
       "inputs": [],
+      "name": "SettlementPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "TransferFailed",
       "type": "error"
     },
@@ -754,6 +759,25 @@
         }
       ],
       "name": "RootNodesUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "setter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "SettlementPauseSet",
       "type": "event"
     },
     {
@@ -1633,6 +1657,19 @@
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "settlementPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "bytes4",
@@ -1814,6 +1851,19 @@
     {
       "inputs": [],
       "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "setSettlementPaused",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -2404,7 +2454,7 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "_percentage",
+          "name": "",
           "type": "uint256"
         }
       ],

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,7 +79,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("ignores additional agent payout settings when validating reward headroom", async () => {
+  it("reverts deprecated additional agent payout settings", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(
         token.address,
         "ipfs://base",
@@ -95,9 +95,10 @@ contract("AGIJobManager economic safety", (accounts) => {
       { from: owner }
     );
 
-    await manager.setAdditionalAgentPayoutPercentage(90, { from: owner });
-    await manager.setValidationRewardPercentage(90, { from: owner });
-    assert.equal((await manager.validationRewardPercentage()).toString(), "90");
+    await expectCustomError(
+      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
+      "InvalidState"
+    );
   });
 
   it("settles successfully with safe payout configuration", async () => {


### PR DESCRIPTION
### Motivation
- Prevent deployment/config tooling and CI from breaking due to the now-deprecated `setAdditionalAgentPayoutPercentage` and to clearly ignore the deprecated config knob. 
- Add an explicit settlement pause control to safely stop settlement-related operations during maintenance or emergency state changes. 
- Keep the UI ABI in sync with contract changes and ensure tests correctly assert custom error reverts.

### Description
- Make `setAdditionalAgentPayoutPercentage` always revert with `InvalidState` and stop applying the deprecated `additionalAgentPayoutPercentage` from `scripts/postdeploy-config.js` (now logged as deprecated/ignored). 
- Introduce `settlementPaused` state, `SettlementPaused` error, `whenSettlementNotPaused` modifier, `setSettlementPaused` setter and `SettlementPauseSet` event, and apply the modifier to settlement-related functions including `resolveDispute`, `resolveDisputeWithCode`, `resolveStaleDispute`, `delistJob`, `cancelJob`, `expireJob`, `finalizeJob`, and `withdrawAGI`. 
- Add a set of internal helper functions (`_cancelJobAndRefund`, `_requireEmptyEscrow`, `_requireValidReviewPeriod`, `_requireActiveDispute`, `_requireJobUnsettled`, `_requireAssignedAgent`, `_requireNotCompletedOrExpired`, `_clearDispute`, and `_setAddressFlag`) and refactor address-flag setters to use `_setAddressFlag`, plus emit additional events on config updates. 
- Refresh the exported UI ABI (`docs/ui/abi/AGIJobManager.json`) to match the updated contract interface and update `test/economicSafety.test.js` to assert the deprecated-setter revert via a static call (`.call`) so the custom error decodes correctly.

### Testing
- Ran `npm run build` (Truffle compile) which completed successfully. 
- Ran `npm run ui:abi` which exported the updated ABI to `docs/ui/abi/AGIJobManager.json`. 
- Ran `npm run test` which executed the full test suite and the UI ABI checks, resulting in all tests passing (`226 passing`) and the ABI smoke test passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892f292be083338e917dbd5f8cd20d)