### PR TITLE
Regenerate UI ABI, hard-deprecate additionalAgentPayout and fix tests

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -93,6 +93,11 @@
     },
     {
       "inputs": [],
+      "name": "SettlementPaused",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "TransferFailed",
       "type": "error"
     },
@@ -754,6 +759,25 @@
         }
       ],
       "name": "RootNodesUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "setter",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "SettlementPauseSet",
       "type": "event"
     },
     {
@@ -1633,6 +1657,19 @@
       "type": "function"
     },
     {
+      "inputs": [],
+      "name": "settlementPaused",
+      "outputs": [
+        {
+          "internalType": "bool",
+          "name": "",
+          "type": "bool"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
       "inputs": [
         {
           "internalType": "bytes4",
@@ -1814,6 +1851,19 @@
     {
       "inputs": [],
       "name": "unpause",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "bool",
+          "name": "paused",
+          "type": "bool"
+        }
+      ],
+      "name": "setSettlementPaused",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -2404,7 +2454,7 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "_percentage",
+          "name": "",
           "type": "uint256"
         }
       ],

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,7 +79,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("ignores additional agent payout settings when validating reward headroom", async () => {
+  it("reverts deprecated additional agent payout settings", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(
         token.address,
         "ipfs://base",
@@ -95,9 +95,10 @@ contract("AGIJobManager economic safety", (accounts) => {
       { from: owner }
     );
 
-    await manager.setAdditionalAgentPayoutPercentage(90, { from: owner });
-    await manager.setValidationRewardPercentage(90, { from: owner });
-    assert.equal((await manager.validationRewardPercentage()).toString(), "90");
+    await expectCustomError(
+      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
+      "InvalidState"
+    );
   });
 
   it("settles successfully with safe payout configuration", async () => {


### PR DESCRIPTION
### Motivation
- Align runtime, deployment tooling and tests with the hard-deprecation of the legacy `additionalAgentPayoutPercentage` knob so tooling and CI stop failing when the deprecated setter reverts. 

### Description
- Replaced the deprecated `setAdditionalAgentPayoutPercentage` implementation with a hard `revert InvalidState()` and added `settlementPaused` control, associated events, and guard `whenSettlementNotPaused` on settlement-affecting functions. 
- Refactored and added small internal helpers (e.g. `_cancelJobAndRefund`, `_require*` checks, `_setAddressFlag`) and emitted events for updated setters (e.g. `RootNodesUpdated`, `MerkleRootsUpdated`, `CompletionReviewPeriodUpdated`, `DisputeReviewPeriodUpdated`, `ValidatorBondParamsUpdated`, `ChallengePeriodAfterApprovalUpdated`, `SettlementPauseSet`, `AGITypeUpdated`). 
- Updated `scripts/postdeploy-config.js` to stop reading/setting the deprecated `additionalAgentPayoutPercentage` from env/config and to emit a warning if it is present, and simplified headroom ordering logic to remove reliance on the deprecated knob. 
- Regenerated the UI ABI at `docs/ui/abi/AGIJobManager.json` to reflect the contract interface changes. 
- Adjusted `test/economicSafety.test.js` to assert the deprecated setter reverts using a static call (`.call`) and renamed the test to reflect the deprecation expectation. 

### Testing
- Ran `npm run build` (runs `truffle compile`) which completed successfully and wrote artifacts to `build/contracts`. 
- Ran `npm run ui:abi` which exported the updated contract ABI to `docs/ui/abi/AGIJobManager.json`. 
- Ran the full test suite via `npm run test` and the Truffle/JS tests completed successfully with the updated assertions; the run produced `226 passing` and the bytecode size guard and ABI sync checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69892f292be083338e917dbd5f8cd20d)