### PR TITLE
Align deprecated parameter revert and ABI artifacts

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -83,6 +83,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     error InsolventEscrowBalance();
     error ConfigLocked();
     error SettlementPaused();
+    error DeprecatedParameter();
 
     /// @notice Canonical dispute resolution codes (numeric ordering is stable; do not reorder).
     /// @dev 0 = NO_ACTION (log only; dispute remains active)
@@ -790,8 +791,9 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         challengePeriodAfterApproval = period;
         emit ChallengePeriodAfterApprovalUpdated(oldPeriod, period);
     }
+    /// @notice Deprecated and unused in payout logic.
     function setAdditionalAgentPayoutPercentage(uint256) external onlyOwner {
-        revert InvalidState();
+        revert DeprecatedParameter();
     }
     function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner { termsAndConditionsIpfsHash = _hash; }
     function updateContactEmail(string calldata _email) external onlyOwner { contactEmail = _email; }

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -48,6 +48,11 @@
     },
     {
       "inputs": [],
+      "name": "DeprecatedParameter",
+      "type": "error"
+    },
+    {
+      "inputs": [],
       "name": "IneligibleAgentPayout",
       "type": "error"
     },

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -97,7 +97,7 @@ contract("AGIJobManager economic safety", (accounts) => {
 
     await expectCustomError(
       manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
-      "InvalidState"
+      "DeprecatedParameter"
     );
   });
 


### PR DESCRIPTION
### Motivation
- The legacy `setAdditionalAgentPayoutPercentage` setter is deprecated and should explicitly surface a dedicated error, and tests/ABI need to reflect that change.

### Description
- Add the `DeprecatedParameter` custom error to `AGIJobManager` and make `setAdditionalAgentPayoutPercentage` revert with `DeprecatedParameter` instead of `InvalidState`.
- Update the test in `test/economicSafety.test.js` to expect `DeprecatedParameter` for the deprecated setter.
- Regenerate the UI ABI snapshot at `docs/ui/abi/AGIJobManager.json` so the exported ABI includes the new custom error.

### Testing
- Ran `npm run ui:abi` to export the updated ABI snapshot, which produced `docs/ui/abi/AGIJobManager.json` successfully.
- Ran the full test suite with `npm run test`, which completed the Truffle compilation and test run and passed all automated tests (`226 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989522ecbcc8333a966f15a717533eb)