### PR TITLE
Guard delistJob against reentrancy and add invariant/regression tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -673,7 +673,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit ValidatorBlacklisted(_validator, _status);
     }
 
-    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused {
+    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused nonReentrant {
         Job storage job = _job(_jobId);
         if (job.completed || job.assignedAgent != address(0)) revert InvalidState();
         _cancelJobAndRefund(_jobId, job);

--- a/contracts/test/HookERC20.sol
+++ b/contracts/test/HookERC20.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract HookERC20 is ERC20 {
+    constructor() ERC20("Hook AGI", "hAGI") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override {
+        super._afterTokenTransfer(from, to, amount);
+        if (from == address(0) || to == address(0)) {
+            return;
+        }
+        if (to.code.length == 0) {
+            return;
+        }
+        (bool success, ) = to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256)", from, amount));
+        success;
+    }
+}

--- a/contracts/test/LibraryHarness.sol
+++ b/contracts/test/LibraryHarness.sol
@@ -1,0 +1,48 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../utils/BondMath.sol";
+import "../utils/ReputationMath.sol";
+import "../utils/ENSOwnership.sol";
+
+contract LibraryHarness {
+    function computeValidatorBond(
+        uint256 payout,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond
+    ) external pure returns (uint256) {
+        return BondMath.computeValidatorBond(payout, bps, minBond, maxBond);
+    }
+
+    function computeAgentBond(
+        uint256 payout,
+        uint256 duration,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond,
+        uint256 durationLimit
+    ) external pure returns (uint256) {
+        return BondMath.computeAgentBond(payout, duration, bps, minBond, maxBond, durationLimit);
+    }
+
+    function computeReputationPoints(
+        uint256 payout,
+        uint256 duration,
+        uint256 completionRequestedAt,
+        uint256 assignedAt,
+        bool repEligible
+    ) external pure returns (uint256) {
+        return ReputationMath.computeReputationPoints(payout, duration, completionRequestedAt, assignedAt, repEligible);
+    }
+
+    function verifyENSOwnership(
+        address ensAddress,
+        address nameWrapperAddress,
+        address claimant,
+        string memory subdomain,
+        bytes32 rootNode
+    ) external view returns (bool) {
+        return ENSOwnership.verifyENSOwnership(ensAddress, nameWrapperAddress, claimant, subdomain, rootNode);
+    }
+}

--- a/contracts/test/ReentrantEmployer.sol
+++ b/contracts/test/ReentrantEmployer.sol
@@ -1,0 +1,42 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IJobManager {
+    function nextJobId() external view returns (uint256);
+    function createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external;
+}
+
+interface IERC20Like {
+    function approve(address spender, uint256 amount) external returns (bool);
+}
+
+contract ReentrantEmployer {
+    IJobManager public immutable jobManager;
+    uint256 public jobId;
+    bool public attempted;
+    bool public reentered;
+
+    constructor(address manager) {
+        jobManager = IJobManager(manager);
+    }
+
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20Like(token).approve(spender, amount);
+    }
+
+    function createJob(string memory jobSpecURI, uint256 payout, uint256 duration, string memory details) external returns (uint256) {
+        uint256 nextId = jobManager.nextJobId();
+        jobManager.createJob(jobSpecURI, payout, duration, details);
+        jobId = nextId;
+        return nextId;
+    }
+
+    function onTokenTransfer(address, uint256) external {
+        if (attempted) {
+            return;
+        }
+        attempted = true;
+        (bool success, ) = address(jobManager).call(abi.encodeWithSignature("cancelJob(uint256)", jobId));
+        reentered = success;
+    }
+}

--- a/test/delistJob.reentrancy.test.js
+++ b/test/delistJob.reentrancy.test.js
@@ -1,0 +1,64 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const HookERC20 = artifacts.require("HookERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const ReentrantEmployer = artifacts.require("ReentrantEmployer");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager delistJob reentrancy regression", (accounts) => {
+  const [owner] = accounts;
+  let token;
+  let manager;
+  let employer;
+
+  beforeEach(async () => {
+    token = await HookERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    employer = await ReentrantEmployer.new(manager.address, { from: owner });
+  });
+
+  it("blocks double refunds when token hook reenters cancelJob", async () => {
+    const payout = toBN(toWei("100"));
+    const duration = toBN("3600");
+
+    await token.mint(employer.address, payout, { from: owner });
+    await employer.approveToken(token.address, manager.address, payout, { from: owner });
+
+    await employer.createJob("ipfs://job", payout, duration, "details", { from: owner });
+    const jobId = await employer.jobId();
+
+    const balanceBefore = await token.balanceOf(employer.address);
+    await manager.delistJob(jobId, { from: owner });
+    const balanceAfter = await token.balanceOf(employer.address);
+
+    assert.strictEqual(balanceAfter.sub(balanceBefore).toString(), payout.toString());
+    assert.strictEqual(await employer.attempted(), true);
+    assert.strictEqual(await employer.reentered(), false);
+
+    await expectCustomError(manager.getJobCore(jobId), "JobNotFound");
+  });
+});

--- a/test/invariants.libs.test.js
+++ b/test/invariants.libs.test.js
@@ -1,0 +1,144 @@
+const assert = require("assert");
+
+const LibraryHarness = artifacts.require("LibraryHarness");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { toBN } = web3.utils;
+
+function makeRng(seed) {
+  let value = seed;
+  return (max) => {
+    value = (value * 1103515245 + 12345) % 0x80000000;
+    return value % max;
+  };
+}
+
+contract("Library invariants", (accounts) => {
+  const [claimant] = accounts;
+  let harness;
+
+  beforeEach(async () => {
+    harness = await LibraryHarness.new();
+  });
+
+  it("enforces validator bond bounds", async () => {
+    const rand = makeRng(1337);
+
+    for (let i = 0; i < 30; i += 1) {
+      const payout = toBN(rand(1_000_000) + 1);
+      const bps = toBN(rand(10_001));
+      const minBond = toBN(rand(10_000));
+      const maxBond = minBond.add(toBN(rand(10_000)));
+
+      const bond = await harness.computeValidatorBond(payout, bps, minBond, maxBond);
+      if (bps.isZero() && minBond.isZero() && maxBond.isZero()) {
+        assert.strictEqual(bond.toString(), "0");
+        continue;
+      }
+      assert(toBN(bond).lte(payout));
+      assert(toBN(bond).lte(maxBond));
+      if (payout.gte(minBond)) {
+        assert(toBN(bond).gte(minBond));
+      }
+    }
+  });
+
+  it("enforces agent bond bounds", async () => {
+    const rand = makeRng(2024);
+
+    for (let i = 0; i < 30; i += 1) {
+      const payout = toBN(rand(1_000_000) + 1);
+      const duration = toBN(rand(10_000));
+      const bps = toBN(rand(10_001));
+      const minBond = toBN(rand(10_000));
+      const maxBond = minBond.add(toBN(rand(10_000)));
+      const durationLimit = toBN(rand(20_000) + 1);
+
+      const bond = await harness.computeAgentBond(
+        payout,
+        duration,
+        bps,
+        minBond,
+        maxBond,
+        durationLimit
+      );
+      if (bps.isZero() && minBond.isZero() && maxBond.isZero()) {
+        assert.strictEqual(bond.toString(), "0");
+        continue;
+      }
+      assert(toBN(bond).lte(payout));
+      assert(toBN(bond).lte(maxBond));
+      if (payout.gte(minBond)) {
+        assert(toBN(bond).gte(minBond));
+      }
+    }
+  });
+
+  it("computes reasonable reputation points", async () => {
+    const repZero = await harness.computeReputationPoints(1000, 100, 50, 10, false);
+    assert.strictEqual(repZero.toString(), "0");
+
+    const repSmall = await harness.computeReputationPoints(
+      toBN("1000000000000000000"),
+      100,
+      80,
+      10,
+      true
+    );
+    assert(toBN(repSmall).lte(toBN("64")));
+
+    const rand = makeRng(88);
+    for (let i = 0; i < 25; i += 1) {
+      const payout = toBN(rand(1_000_000_000));
+      const duration = toBN(rand(10_000) + 1);
+      const assignedAt = toBN(rand(1000));
+      const completionRequestedAt = assignedAt.add(toBN(rand(2000)));
+      await harness.computeReputationPoints(payout, duration, completionRequestedAt, assignedAt, true);
+    }
+  });
+
+  it("verifies ENS ownership via resolver and name wrapper", async () => {
+    const ens = await MockENSRegistry.new();
+    const resolver = await MockResolver.new();
+    const nameWrapper = await MockNameWrapper.new();
+    const rootNode = web3.utils.keccak256("root");
+    const subdomain = "worker";
+    const labelHash = web3.utils.keccak256(subdomain);
+    const subnode = web3.utils.soliditySha3(
+      { t: "bytes32", v: rootNode },
+      { t: "bytes32", v: labelHash }
+    );
+
+    const missing = await harness.verifyENSOwnership(
+      ens.address,
+      nameWrapper.address,
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(missing, false);
+
+    await ens.setResolver(subnode, resolver.address);
+    await resolver.setAddr(subnode, claimant);
+    const viaResolver = await harness.verifyENSOwnership(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(viaResolver, true);
+
+    await nameWrapper.setOwner(toBN(subnode), claimant);
+    const viaWrapper = await harness.verifyENSOwnership(
+      ens.address,
+      nameWrapper.address,
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(viaWrapper, true);
+  });
+});

--- a/test/invariants.solvency.test.js
+++ b/test/invariants.solvency.test.js
@@ -1,0 +1,200 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundValidators, fundAgents, fundDisputeBond } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+async function assertSolvent(token, manager) {
+  const [
+    balance,
+    lockedEscrow,
+    lockedAgentBonds,
+    lockedValidatorBonds,
+    lockedDisputeBonds,
+  ] = await Promise.all([
+    token.balanceOf(manager.address),
+    manager.lockedEscrow(),
+    manager.lockedAgentBonds(),
+    manager.lockedValidatorBonds(),
+    manager.lockedDisputeBonds(),
+  ]);
+  const lockedTotal = lockedEscrow
+    .add(lockedAgentBonds)
+    .add(lockedValidatorBonds)
+    .add(lockedDisputeBonds);
+  assert(
+    balance.gte(lockedTotal),
+    `insolvent: balance ${balance.toString()} < locked ${lockedTotal.toString()}`
+  );
+  await manager.withdrawableAGI();
+}
+
+async function createJob(manager, token, employer, payout, duration, owner) {
+  await token.mint(employer, payout, { from: owner });
+  await token.approve(manager.address, payout, { from: employer });
+  const jobId = await manager.nextJobId();
+  await manager.createJob("ipfs://job", payout, duration, "details", { from: employer });
+  return jobId;
+}
+
+contract("AGIJobManager solvency invariants", (accounts) => {
+  const [owner, employer, agent, validator, moderator] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setVoteQuorum(1, { from: owner });
+
+    await fundAgents(token, manager, [agent], owner);
+    await fundValidators(token, manager, [validator], owner);
+  });
+
+  it("maintains solvency during happy-path settlement", async () => {
+    const payout = toBN(toWei("100"));
+    const duration = toBN("3600");
+
+    const jobId = await createJob(manager, token, employer, payout, duration, owner);
+    await assertSolvent(token, manager);
+
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(token, manager);
+
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+    await assertSolvent(token, manager);
+
+    await manager.validateJob(jobId, "", EMPTY_PROOF, { from: validator });
+    await assertSolvent(token, manager);
+
+    const challengePeriod = await manager.challengePeriodAfterApproval();
+    await advanceTime(challengePeriod.toNumber() + 1);
+    await manager.finalizeJob(jobId, { from: owner });
+    await assertSolvent(token, manager);
+  });
+
+  it("maintains solvency when employer is refunded after disapproval", async () => {
+    const payout = toBN(toWei("50"));
+    const duration = toBN("1800");
+
+    const jobId = await createJob(manager, token, employer, payout, duration, owner);
+    await assertSolvent(token, manager);
+
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(token, manager);
+
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+    await assertSolvent(token, manager);
+
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.disapproveJob(jobId, "", EMPTY_PROOF, { from: validator });
+    await assertSolvent(token, manager);
+
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await advanceTime(reviewPeriod.toNumber() + 1);
+    await manager.finalizeJob(jobId, { from: owner });
+    await assertSolvent(token, manager);
+  });
+
+  it("maintains solvency through expiration", async () => {
+    const payout = toBN(toWei("25"));
+    const duration = toBN("1000");
+
+    const jobId = await createJob(manager, token, employer, payout, duration, owner);
+    await assertSolvent(token, manager);
+
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(token, manager);
+
+    await advanceTime(duration.toNumber() + 1);
+    await manager.expireJob(jobId, { from: owner });
+    await assertSolvent(token, manager);
+  });
+
+  it("maintains solvency through disputes and resolution", async () => {
+    const payout = toBN(toWei("75"));
+    const duration = toBN("2400");
+
+    const jobId = await createJob(manager, token, employer, payout, duration, owner);
+    await assertSolvent(token, manager);
+
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(token, manager);
+
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+    await assertSolvent(token, manager);
+
+    await fundDisputeBond(token, manager, employer, payout, owner);
+    await manager.disputeJob(jobId, { from: employer });
+    await assertSolvent(token, manager);
+
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
+    await assertSolvent(token, manager);
+  });
+});


### PR DESCRIPTION
### Motivation

- Close a concrete mainnet blocker by preventing a reentrancy/double-refund vector in `delistJob` that issues an external token refund to an employer contract during cancellation. 
- Add focused regression and invariant-style tests to exercise value-accounting and utility modules (`TransferUtils` flows, `BondMath`, `ReputationMath`, `ENSOwnership`) so the contract has stronger safety coverage for business-operated escrow posture.

### Description

- Added the `nonReentrant` modifier to `delistJob(uint256 _jobId)` in `contracts/AGIJobManager.sol` to prevent refund reentrancy while preserving existing semantics and modifier order (`external onlyOwner whenSettlementNotPaused nonReentrant`).
- Added a hook-capable test ERC20 mock `contracts/test/HookERC20.sol` that calls `onTokenTransfer(address,uint256)` on recipients when transferring to contracts to simulate callback-style token behavior without reverting on hook failure.
- Added a reentrant-employer test helper `contracts/test/ReentrantEmployer.sol` that implements `onTokenTransfer` and attempts to reenter `cancelJob(jobId)` once to validate reentrancy resistance.
- Added a small `LibraryHarness` contract (`contracts/test/LibraryHarness.sol`) exposing `BondMath`, `ReputationMath`, and `ENSOwnership` wrappers for unit testing.
- Added regression and invariant tests:
  - `test/delistJob.reentrancy.test.js` reproduces a hook-based token refund path and asserts only one refund occurs and that a reentrancy attempt was observed but did not succeed.
  - `test/invariants.solvency.test.js` provides several short integration scenarios asserting the solvency invariant `agiToken.balanceOf(manager) >= lockedEscrow + lockedAgentBonds + lockedValidatorBonds + lockedDisputeBonds` and that `withdrawableAGI()` does not revert across flows (happy path, refund path, expiration, dispute resolution).
  - `test/invariants.libs.test.js` runs small randomized loops and sanity checks against `BondMath.compute*`, `ReputationMath.computeReputationPoints`, and `ENSOwnership.verifyENSOwnership` via the harness and test ENS/resolver/name-wrapper mocks.
- Kept changes minimal and localized and preserved public/external interfaces; no production behavior besides the added `nonReentrant` modifier was changed.

### Testing

- Added automated tests (new files: `test/delistJob.reentrancy.test.js`, `test/invariants.solvency.test.js`, `test/invariants.libs.test.js`) and test-only contracts (`HookERC20.sol`, `ReentrantEmployer.sol`, `LibraryHarness.sol`).
- Attempted to run the test suite with `truffle test` in the environment, but the command failed because `truffle` is not installed here (automated run: `truffle test` -> `bash: command not found: truffle`).
- All test files and production change are present in the branch and ready for local CI execution; please run `truffle test` in a standard dev environment to execute the added tests (they were written to be Truffle-compatible and use existing repo test helpers).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698968af09d48333973093e7195f4774)