### PR TITLE
Guard delistJob against reentrancy and add invariant + regression tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -673,7 +673,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit ValidatorBlacklisted(_validator, _status);
     }
 
-    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused {
+    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused nonReentrant {
         Job storage job = _job(_jobId);
         if (job.completed || job.assignedAgent != address(0)) revert InvalidState();
         _cancelJobAndRefund(_jobId, job);

--- a/contracts/test/HookERC20.sol
+++ b/contracts/test/HookERC20.sol
@@ -1,0 +1,21 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract HookERC20 is ERC20 {
+    constructor() ERC20("Hook AGI", "hAGI") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override {
+        super._afterTokenTransfer(from, to, amount);
+        if (from == address(0) || to == address(0) || to.code.length == 0) {
+            return;
+        }
+        (bool ok, ) = to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256)", from, amount));
+        ok;
+    }
+}

--- a/contracts/test/LibraryHarness.sol
+++ b/contracts/test/LibraryHarness.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../utils/BondMath.sol";
+import "../utils/ReputationMath.sol";
+import "../utils/ENSOwnership.sol";
+
+contract LibraryHarness {
+    function computeAgentBond(
+        uint256 payout,
+        uint256 duration,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond,
+        uint256 durationLimit
+    ) external pure returns (uint256) {
+        return BondMath.computeAgentBond(payout, duration, bps, minBond, maxBond, durationLimit);
+    }
+
+    function computeValidatorBond(
+        uint256 payout,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond
+    ) external pure returns (uint256) {
+        return BondMath.computeValidatorBond(payout, bps, minBond, maxBond);
+    }
+
+    function computeReputationPoints(
+        uint256 payout,
+        uint256 duration,
+        uint256 completionRequestedAt,
+        uint256 assignedAt,
+        bool repEligible
+    ) external pure returns (uint256) {
+        return ReputationMath.computeReputationPoints(
+            payout,
+            duration,
+            completionRequestedAt,
+            assignedAt,
+            repEligible
+        );
+    }
+
+    function verifyENSOwnership(
+        address ensAddress,
+        address nameWrapperAddress,
+        address claimant,
+        string memory subdomain,
+        bytes32 rootNode
+    ) external view returns (bool) {
+        return ENSOwnership.verifyENSOwnership(ensAddress, nameWrapperAddress, claimant, subdomain, rootNode);
+    }
+}

--- a/contracts/test/ReenteringEmployer.sol
+++ b/contracts/test/ReenteringEmployer.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IAGIJobManager {
+    function createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external;
+    function cancelJob(uint256 _jobId) external;
+    function nextJobId() external view returns (uint256);
+}
+
+contract ReenteringEmployer {
+    IAGIJobManager public jobManager;
+    uint256 public jobId;
+    bool public attempted;
+    bool public reentered;
+
+    constructor(address manager) {
+        jobManager = IAGIJobManager(manager);
+    }
+
+    function approveToken(address token, address spender, uint256 amount) external {
+        IERC20(token).approve(spender, amount);
+    }
+
+    function createJob(
+        string memory jobSpecURI,
+        uint256 payout,
+        uint256 duration,
+        string memory details
+    ) external {
+        jobId = jobManager.nextJobId();
+        jobManager.createJob(jobSpecURI, payout, duration, details);
+    }
+
+    function onTokenTransfer(address, uint256) external {
+        if (attempted) {
+            return;
+        }
+        attempted = true;
+        (bool ok, ) = address(jobManager).call(abi.encodeWithSignature("cancelJob(uint256)", jobId));
+        reentered = ok;
+    }
+}

--- a/test/delistJob.reentrancy.test.js
+++ b/test/delistJob.reentrancy.test.js
@@ -1,0 +1,65 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const HookERC20 = artifacts.require("HookERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const ReenteringEmployer = artifacts.require("ReenteringEmployer");
+
+const { expectCustomError } = require("./helpers/errors");
+const { buildInitConfig } = require("./helpers/deploy");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+
+contract("AGIJobManager delistJob reentrancy regression", (accounts) => {
+  const [owner, sponsor] = accounts;
+  let token;
+  let manager;
+  let employer;
+
+  beforeEach(async () => {
+    token = await HookERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    employer = await ReenteringEmployer.new(manager.address, { from: owner });
+
+    const payout = web3.utils.toBN(web3.utils.toWei("10"));
+    await token.mint(employer.address, payout, { from: owner });
+    await employer.approveToken(token.address, manager.address, payout, { from: sponsor });
+    await employer.createJob("ipfs://spec", payout, 1000, "details", { from: sponsor });
+  });
+
+  it("prevents double refunds when token hooks attempt reentrancy", async () => {
+    const payout = web3.utils.toBN(web3.utils.toWei("10"));
+    const before = await token.balanceOf(employer.address);
+
+    await manager.delistJob(0, { from: owner });
+
+    const after = await token.balanceOf(employer.address);
+    assert.strictEqual(after.sub(before).toString(), payout.toString());
+
+    const attempted = await employer.attempted();
+    const reentered = await employer.reentered();
+    assert.strictEqual(attempted, true);
+    assert.strictEqual(reentered, false);
+
+    await expectCustomError(manager.getJobCore(0), "JobNotFound");
+  });
+});

--- a/test/invariants.libs.test.js
+++ b/test/invariants.libs.test.js
@@ -1,0 +1,117 @@
+const assert = require("assert");
+
+const LibraryHarness = artifacts.require("LibraryHarness");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { toBN, toWei, soliditySha3, keccak256 } = web3.utils;
+
+contract("Library invariants", (accounts) => {
+  const [owner, claimant] = accounts;
+
+  it("computes validator bond within expected bounds", async () => {
+    const harness = await LibraryHarness.new({ from: owner });
+
+    const zeroBond = await harness.computeValidatorBond(0, 0, 0, 0);
+    assert.strictEqual(zeroBond.toString(), "0");
+
+    for (let i = 0; i < 30; i += 1) {
+      const payout = toBN(1 + i).mul(toBN(toWei("1")));
+      const bps = 100 + i;
+      const minBond = toBN(toWei("1"));
+      const maxBond = toBN(toWei("50"));
+      const bond = toBN(await harness.computeValidatorBond(payout, bps, minBond, maxBond));
+      assert.ok(bond.lte(payout), "bond exceeds payout");
+      assert.ok(bond.lte(maxBond), "bond exceeds max");
+      if (payout.gte(minBond)) {
+        assert.ok(bond.gte(minBond), "bond under min");
+      }
+    }
+  });
+
+  it("computes agent bond within expected bounds", async () => {
+    const harness = await LibraryHarness.new({ from: owner });
+
+    const zeroBond = await harness.computeAgentBond(0, 0, 0, 0, 0, 0);
+    assert.strictEqual(zeroBond.toString(), "0");
+
+    for (let i = 0; i < 30; i += 1) {
+      const payout = toBN(2 + i).mul(toBN(toWei("1")));
+      const duration = toBN(100 + i);
+      const bps = 200 + i;
+      const minBond = toBN(toWei("1"));
+      const maxBond = toBN(toWei("40"));
+      const durationLimit = toBN("1000");
+      const bond = toBN(await harness.computeAgentBond(
+        payout,
+        duration,
+        bps,
+        minBond,
+        maxBond,
+        durationLimit
+      ));
+      assert.ok(bond.lte(payout), "bond exceeds payout");
+      assert.ok(bond.lte(maxBond), "bond exceeds max");
+      if (payout.gte(minBond)) {
+        assert.ok(bond.gte(minBond), "bond under min");
+      }
+    }
+  });
+
+  it("computes reputation points without overflow and with sane bounds", async () => {
+    const harness = await LibraryHarness.new({ from: owner });
+
+    const zeroRep = await harness.computeReputationPoints(10, 10, 10, 10, false);
+    assert.strictEqual(zeroRep.toString(), "0");
+
+    const payout = toBN(toWei("1"));
+    const rep = toBN(await harness.computeReputationPoints(payout, 1000, 200, 100, true));
+    assert.ok(rep.lte(toBN("64")), "reputation is unexpectedly large");
+  });
+
+  it("verifies ENS ownership via resolver or name wrapper", async () => {
+    const harness = await LibraryHarness.new({ from: owner });
+    const registry = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockResolver.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    const rootNode = keccak256("root");
+    const subdomain = "alice";
+    const labelHash = keccak256(subdomain);
+    const subnode = soliditySha3(
+      { type: "bytes32", value: rootNode },
+      { type: "bytes32", value: labelHash }
+    );
+
+    const notOwned = await harness.verifyENSOwnership(
+      registry.address,
+      nameWrapper.address,
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(notOwned, false);
+
+    await registry.setResolver(subnode, resolver.address, { from: owner });
+    await resolver.setAddr(subnode, claimant, { from: owner });
+    const resolverOwned = await harness.verifyENSOwnership(
+      registry.address,
+      nameWrapper.address,
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(resolverOwned, true);
+
+    await nameWrapper.setOwner(toBN(subnode), claimant, { from: owner });
+    const wrapperOwned = await harness.verifyENSOwnership(
+      registry.address,
+      nameWrapper.address,
+      claimant,
+      subdomain,
+      rootNode
+    );
+    assert.strictEqual(wrapperOwned, true);
+  });
+});

--- a/test/invariants.solvency.test.js
+++ b/test/invariants.solvency.test.js
@@ -1,0 +1,207 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { computeAgentBond, computeValidatorBond, fundDisputeBond } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+async function assertSolvent(manager, token) {
+  const [lockedEscrow, lockedAgentBonds, lockedValidatorBonds, lockedDisputeBonds] = await Promise.all([
+    manager.lockedEscrow(),
+    manager.lockedAgentBonds(),
+    manager.lockedValidatorBonds(),
+    manager.lockedDisputeBonds(),
+  ]);
+  const lockedTotal = toBN(lockedEscrow)
+    .add(toBN(lockedAgentBonds))
+    .add(toBN(lockedValidatorBonds))
+    .add(toBN(lockedDisputeBonds));
+  const balance = toBN(await token.balanceOf(manager.address));
+  assert.ok(balance.gte(lockedTotal), "escrow is insolvent");
+  await manager.withdrawableAGI();
+}
+
+async function mintAndApprove(token, owner, account, spender, amount) {
+  await token.mint(account, amount, { from: owner });
+  await token.approve(spender, amount, { from: account });
+}
+
+contract("AGIJobManager solvency invariants", (accounts) => {
+  const [owner, employer, agent, validator, moderator] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(1, { from: owner });
+    await manager.setVoteQuorum(1, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await manager.setDisputeReviewPeriod(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+  });
+
+  it("maintains solvency across the happy path settlement", async () => {
+    const payout = toBN(toWei("100"));
+    const duration = toBN("1000");
+    const agentBond = await computeAgentBond(manager, payout, duration);
+    const validatorBond = await computeValidatorBond(manager, payout);
+
+    await mintAndApprove(token, owner, employer, manager.address, payout);
+    await mintAndApprove(token, owner, agent, manager.address, agentBond);
+    await mintAndApprove(token, owner, validator, manager.address, validatorBond);
+
+    await manager.createJob("ipfs://spec", payout, duration, "details", { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(0, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(0, "ipfs://done", { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.validateJob(0, "", EMPTY_PROOF, { from: validator });
+    await assertSolvent(manager, token);
+
+    await advanceTime(2);
+    await manager.finalizeJob(0, { from: employer });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency when disapprovals trigger employer refund", async () => {
+    const payout = toBN(toWei("50"));
+    const duration = toBN("800");
+    const agentBond = await computeAgentBond(manager, payout, duration);
+    const validatorBond = await computeValidatorBond(manager, payout);
+
+    await mintAndApprove(token, owner, employer, manager.address, payout);
+    await mintAndApprove(token, owner, agent, manager.address, agentBond);
+    await mintAndApprove(token, owner, validator, manager.address, validatorBond);
+
+    await manager.createJob("ipfs://spec", payout, duration, "details", { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(0, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(0, "ipfs://done", { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.disapproveJob(0, "", EMPTY_PROOF, { from: validator });
+    await assertSolvent(manager, token);
+
+    await manager.resolveDisputeWithCode(0, 2, "employer win", { from: moderator });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency across job expiration", async () => {
+    const payout = toBN(toWei("25"));
+    const duration = toBN("50");
+    const agentBond = await computeAgentBond(manager, payout, duration);
+
+    await mintAndApprove(token, owner, employer, manager.address, payout);
+    await mintAndApprove(token, owner, agent, manager.address, agentBond);
+
+    await manager.createJob("ipfs://spec", payout, duration, "details", { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(0, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await advanceTime(60);
+    await manager.expireJob(0, { from: employer });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency across dispute bond flows", async () => {
+    const payout = toBN(toWei("75"));
+    const duration = toBN("900");
+    const agentBond = await computeAgentBond(manager, payout, duration);
+
+    await mintAndApprove(token, owner, employer, manager.address, payout);
+    await mintAndApprove(token, owner, agent, manager.address, agentBond);
+    await fundDisputeBond(token, manager, employer, payout, owner);
+
+    await manager.createJob("ipfs://spec", payout, duration, "details", { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(0, "", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(0, "ipfs://done", { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.disputeJob(0, { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.resolveDisputeWithCode(0, 1, "agent win", { from: moderator });
+    await assertSolvent(manager, token);
+  });
+});


### PR DESCRIPTION
### Motivation
- Close a concrete mainnet safety hole: `delistJob` performed an external AGI transfer without `nonReentrant`, allowing callback-style tokens to enable double-refund reentrancy.  
- Add a regression that reproduces the callback/reentrant employer scenario to prevent regressions.  
- Add small invariant-style tests and a harness to exercise value-accounting and utility modules (`TransferUtils` flows, `BondMath`, `ReputationMath`, `ENSOwnership`) for increased confidence in escrow solvency and library correctness.  

### Description
- Add `nonReentrant` to `delistJob(uint256 _jobId)` so signature is now `external onlyOwner whenSettlementNotPaused nonReentrant` and behavior is otherwise unchanged (`contracts/AGIJobManager.sol`).  
- Add a hook-capable test ERC20 `HookERC20` that invokes `onTokenTransfer(address,uint256)` on recipients to simulate ERC777/ERC677-like callbacks (`contracts/test/HookERC20.sol`).  
- Add `ReenteringEmployer` test contract that acts as an employer and attempts to reenter `cancelJob` from its hook (`contracts/test/ReenteringEmployer.sol`).  
- Add `LibraryHarness` exposing thin wrappers for `BondMath`, `ReputationMath`, and `ENSOwnership` for unit/invariant testing (`contracts/test/LibraryHarness.sol`).  
- Add regression test `test/delistJob.reentrancy.test.js` that mints HookERC20, has the reentering employer create a job, and verifies only one refund occurs and reentry was attempted but blocked.  
- Add solvency/invariant integration tests `test/invariants.solvency.test.js` covering several settlement flows and asserting `agiToken.balanceOf(manager) >= lockedEscrow + lockedAgentBonds + lockedValidatorBonds + lockedDisputeBonds` after each step.  
- Add library invariants `test/invariants.libs.test.js` that exercise `BondMath`, `ReputationMath`, and `ENSOwnership` via the harness and small randomized loops and ENS mocks.  
- Changes are minimal and localized; no public/external interfaces were removed and no production logic (beyond the added modifier) was refactored.  

### Testing
- Attempted to run the test suite with `truffle test`, but `truffle` was not available in the environment (command not found).  
- Attempted `npx truffle test`; run failed early with a missing dependency error: `Cannot find module 'dotenv'` from `truffle-config.js`, so the new tests could not be executed in this runner.  
- All added contracts and tests are committed and ready; in a standard development/CI environment with project dependencies installed (`npm install` / configured env), running `npx truffle test` should execute the new regression and invariant tests and validate the prevention of double refunds and the library invariants.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698968af09d48333973093e7195f4774)