### PR TITLE
Prevent delistJob reentrancy and fix invariant tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -673,7 +673,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit ValidatorBlacklisted(_validator, _status);
     }
 
-    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused {
+    function delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused nonReentrant {
         Job storage job = _job(_jobId);
         if (job.completed || job.assignedAgent != address(0)) revert InvalidState();
         _cancelJobAndRefund(_jobId, job);

--- a/contracts/test/HookToken.sol
+++ b/contracts/test/HookToken.sol
@@ -1,0 +1,24 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/ERC20.sol";
+
+contract HookToken is ERC20 {
+    constructor() ERC20("Hook AGI", "hAGI") {}
+
+    function mint(address to, uint256 amount) external {
+        _mint(to, amount);
+    }
+
+    function _afterTokenTransfer(address from, address to, uint256 amount) internal override {
+        super._afterTokenTransfer(from, to, amount);
+        if (from == address(0)) {
+            return;
+        }
+        if (to.code.length == 0) {
+            return;
+        }
+        (bool ok, ) = to.call(abi.encodeWithSignature("onTokenTransfer(address,uint256)", from, amount));
+        ok;
+    }
+}

--- a/contracts/test/ReenteringEmployer.sol
+++ b/contracts/test/ReenteringEmployer.sol
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface AGIJobManagerLike {
+    function createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external;
+}
+
+contract ReenteringEmployer {
+    AGIJobManagerLike public jobManager;
+    IERC20 public token;
+    uint256 public jobId;
+    bool public attempted;
+    bool public reentered;
+
+    constructor(address manager, address agiToken) {
+        jobManager = AGIJobManagerLike(manager);
+        token = IERC20(agiToken);
+    }
+
+    function setJobId(uint256 _jobId) external {
+        jobId = _jobId;
+    }
+
+    function createJob(string memory spec, uint256 payout, uint256 duration, string memory details) external {
+        token.approve(address(jobManager), payout);
+        jobManager.createJob(spec, payout, duration, details);
+    }
+
+    function onTokenTransfer(address, uint256) external {
+        if (attempted) {
+            return;
+        }
+        attempted = true;
+        (bool ok, ) = address(jobManager).call(abi.encodeWithSignature("cancelJob(uint256)", jobId));
+        reentered = ok;
+    }
+}

--- a/contracts/test/UtilsHarness.sol
+++ b/contracts/test/UtilsHarness.sol
@@ -1,0 +1,54 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "../utils/BondMath.sol";
+import "../utils/ReputationMath.sol";
+import "../utils/ENSOwnership.sol";
+
+contract UtilsHarness {
+    function computeValidatorBond(
+        uint256 payout,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond
+    ) external pure returns (uint256) {
+        return BondMath.computeValidatorBond(payout, bps, minBond, maxBond);
+    }
+
+    function computeAgentBond(
+        uint256 payout,
+        uint256 duration,
+        uint256 bps,
+        uint256 minBond,
+        uint256 maxBond,
+        uint256 durationLimit
+    ) external pure returns (uint256) {
+        return BondMath.computeAgentBond(payout, duration, bps, minBond, maxBond, durationLimit);
+    }
+
+    function computeReputationPoints(
+        uint256 payout,
+        uint256 duration,
+        uint256 completionRequestedAt,
+        uint256 assignedAt,
+        bool repEligible
+    ) external pure returns (uint256) {
+        return ReputationMath.computeReputationPoints(
+            payout,
+            duration,
+            completionRequestedAt,
+            assignedAt,
+            repEligible
+        );
+    }
+
+    function verifyENSOwnership(
+        address ensAddress,
+        address nameWrapperAddress,
+        address claimant,
+        string memory subdomain,
+        bytes32 rootNode
+    ) external view returns (bool) {
+        return ENSOwnership.verifyENSOwnership(ensAddress, nameWrapperAddress, claimant, subdomain, rootNode);
+    }
+}

--- a/test/delistJob.reentrancy.test.js
+++ b/test/delistJob.reentrancy.test.js
@@ -1,0 +1,65 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const HookToken = artifacts.require("HookToken");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const ReenteringEmployer = artifacts.require("ReenteringEmployer");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager delistJob reentrancy regression", (accounts) => {
+  const [owner] = accounts;
+  let token;
+  let manager;
+  let employer;
+
+  beforeEach(async () => {
+    token = await HookToken.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    employer = await ReenteringEmployer.new(manager.address, token.address, { from: owner });
+  });
+
+  it("refunds once and blocks reentrancy during delistJob", async () => {
+    const payout = toBN(toWei("10"));
+    await token.mint(employer.address, payout, { from: owner });
+
+    const jobId = await manager.nextJobId();
+    await employer.setJobId(jobId, { from: owner });
+    await employer.createJob("ipfs-spec", payout, 3600, "details", { from: owner });
+
+    const balanceAfterCreate = await token.balanceOf(employer.address);
+    assert.equal(balanceAfterCreate.toString(), "0", "employer should escrow payout");
+
+    await manager.delistJob(jobId, { from: owner });
+
+    const balanceAfterRefund = await token.balanceOf(employer.address);
+    assert.equal(balanceAfterRefund.toString(), payout.toString(), "refund should occur once");
+
+    assert.equal(await employer.attempted(), true, "employer should attempt reentrancy");
+    assert.equal(await employer.reentered(), false, "reentrancy should be blocked");
+
+    await expectCustomError(manager.getJobCore(jobId), "JobNotFound");
+  });
+});

--- a/test/invariants.libs.test.js
+++ b/test/invariants.libs.test.js
@@ -1,0 +1,127 @@
+const assert = require("assert");
+
+const UtilsHarness = artifacts.require("UtilsHarness");
+const BondMath = artifacts.require("BondMath");
+const ENSOwnership = artifacts.require("ENSOwnership");
+const ReputationMath = artifacts.require("ReputationMath");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockResolver = artifacts.require("MockResolver");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { rootNode, subnode, setNameWrapperOwnership, setResolverOwnership } = require("./helpers/ens");
+
+const { toBN, toWei } = web3.utils;
+
+contract("Utility library invariants", (accounts) => {
+  const [owner, claimant, other] = accounts;
+  let harness;
+
+  beforeEach(async () => {
+    const bondMath = await BondMath.new({ from: owner });
+    const ensOwnership = await ENSOwnership.new({ from: owner });
+    const reputationMath = await ReputationMath.new({ from: owner });
+    await UtilsHarness.link(BondMath, bondMath.address);
+    await UtilsHarness.link(ENSOwnership, ensOwnership.address);
+    await UtilsHarness.link(ReputationMath, reputationMath.address);
+    harness = await UtilsHarness.new({ from: owner });
+  });
+
+  it("computes validator bonds within bounds", async () => {
+    const payout = toBN(toWei("5"));
+    const minBond = toBN(toWei("1"));
+    const maxBond = toBN(toWei("3"));
+    const bps = toBN("2000");
+
+    const bond = await harness.computeValidatorBond.call(payout, bps, minBond, maxBond);
+    assert.ok(bond.lte(payout), "bond should not exceed payout");
+    assert.ok(bond.lte(maxBond), "bond should not exceed max bond");
+    assert.ok(bond.gte(minBond), "bond should be at least the min bond");
+
+    const zeroBond = await harness.computeValidatorBond.call(payout, 0, 0, 0);
+    assert.equal(zeroBond.toString(), "0", "zero params should return zero bond");
+  });
+
+  it("computes agent bonds within bounds across varied inputs", async () => {
+    const durationLimit = toBN("10000");
+    for (let i = 1; i <= 30; i += 1) {
+      const payout = toBN(toWei(`${i}`));
+      const duration = toBN(1000 + i);
+      const bps = toBN(100 + i);
+      const minBond = toBN(toWei("1"));
+      const maxBond = toBN(toWei("50"));
+
+      const bond = await harness.computeAgentBond.call(
+        payout,
+        duration,
+        bps,
+        minBond,
+        maxBond,
+        durationLimit
+      );
+      assert.ok(bond.lte(payout), "bond should not exceed payout");
+      assert.ok(bond.lte(maxBond), "bond should not exceed max bond");
+      if (payout.gte(minBond)) {
+        assert.ok(bond.gte(minBond), "bond should be at least the min bond when payout allows");
+      }
+    }
+  });
+
+  it("computes reputation points without overflow for small payouts", async () => {
+    const points = await harness.computeReputationPoints.call(
+      toBN(toWei("2")),
+      toBN("3600"),
+      toBN("2000"),
+      toBN("0"),
+      true
+    );
+    assert.ok(points.lt(toBN("1000")), "reputation points should be bounded for small payouts");
+
+    const zeroPoints = await harness.computeReputationPoints.call(
+      toBN(toWei("2")),
+      toBN("3600"),
+      toBN("2000"),
+      toBN("0"),
+      false
+    );
+    assert.equal(zeroPoints.toString(), "0", "ineligible reputation should return zero");
+  });
+
+  it("verifies ENS ownership for wrapped and resolver-backed records", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockResolver.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    const root = rootNode("club-root");
+    const label = "alice";
+    const node = subnode(root, label);
+
+    const notOwned = await harness.verifyENSOwnership.call(
+      ens.address,
+      nameWrapper.address,
+      claimant,
+      label,
+      root
+    );
+    assert.equal(notOwned, false, "unowned records should return false");
+
+    await setNameWrapperOwnership(nameWrapper, root, label, claimant);
+    const wrappedOwned = await harness.verifyENSOwnership.call(
+      ens.address,
+      nameWrapper.address,
+      claimant,
+      label,
+      root
+    );
+    assert.equal(wrappedOwned, true, "wrapped ownership should be true");
+
+    await setResolverOwnership(ens, resolver, root, label, other);
+    const resolverOwned = await harness.verifyENSOwnership.call(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      other,
+      label,
+      root
+    );
+    assert.equal(resolverOwned, true, "resolver ownership should be true");
+  });
+});

--- a/test/invariants.solvency.test.js
+++ b/test/invariants.solvency.test.js
@@ -1,0 +1,192 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents, fundValidators, fundDisputeBond } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+async function advanceTime(seconds) {
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_increaseTime",
+        params: [seconds],
+        id: Date.now(),
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+
+  await new Promise((resolve, reject) => {
+    web3.currentProvider.send(
+      {
+        jsonrpc: "2.0",
+        method: "evm_mine",
+        params: [],
+        id: Date.now() + 1,
+      },
+      (error) => {
+        if (error) return reject(error);
+        resolve();
+      }
+    );
+  });
+}
+
+async function assertSolvent(manager, token) {
+  const [
+    balance,
+    lockedEscrow,
+    lockedAgentBonds,
+    lockedValidatorBonds,
+    lockedDisputeBonds,
+  ] = await Promise.all([
+    token.balanceOf(manager.address),
+    manager.lockedEscrow(),
+    manager.lockedAgentBonds(),
+    manager.lockedValidatorBonds(),
+    manager.lockedDisputeBonds(),
+  ]);
+  const lockedTotal = lockedEscrow
+    .add(lockedAgentBonds)
+    .add(lockedValidatorBonds)
+    .add(lockedDisputeBonds);
+  assert.ok(balance.gte(lockedTotal), "escrow solvency invariant failed");
+
+  const withdrawable = await manager.withdrawableAGI();
+  assert.ok(withdrawable.gte(toBN(0)), "withdrawableAGI should not revert");
+}
+
+contract("AGIJobManager solvency invariants", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB, moderator] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        nameWrapper.address,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner }
+    );
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.setVoteQuorum(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+
+    await fundValidators(token, manager, [validatorA, validatorB], owner);
+    await fundAgents(token, manager, [agent], owner);
+  });
+
+  async function createJob(payout, duration = 3600) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs-spec", payout, duration, "details", { from: employer });
+    return tx.logs.find((log) => log.event === "JobCreated").args.jobId.toNumber();
+  }
+
+  it("maintains solvency through the happy path", async () => {
+    const payout = toBN(toWei("12"));
+    const jobId = await createJob(payout);
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.validateJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await assertSolvent(manager, token);
+
+    await advanceTime(2);
+    await manager.finalizeJob(jobId, { from: employer });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency when validator disapprovals trigger employer refunds", async () => {
+    const payout = toBN(toWei("8"));
+    const jobId = await createJob(payout);
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.disapproveJob(jobId, "validator-a", EMPTY_PROOF, { from: validatorA });
+    await assertSolvent(manager, token);
+
+    await advanceTime(2);
+    await manager.finalizeJob(jobId, { from: employer });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency when jobs expire", async () => {
+    const payout = toBN(toWei("6"));
+    const jobId = await createJob(payout, 10);
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await advanceTime(20);
+    await manager.expireJob(jobId, { from: employer });
+    await assertSolvent(manager, token);
+  });
+
+  it("maintains solvency through disputes and moderator resolution", async () => {
+    const payout = toBN(toWei("9"));
+    const jobId = await createJob(payout);
+    await assertSolvent(manager, token);
+
+    await manager.applyForJob(jobId, "agent", EMPTY_PROOF, { from: agent });
+    await assertSolvent(manager, token);
+
+    await manager.requestJobCompletion(jobId, "ipfs-complete", { from: agent });
+    await assertSolvent(manager, token);
+
+    await fundDisputeBond(token, manager, employer, payout, owner);
+    await manager.disputeJob(jobId, { from: employer });
+    await assertSolvent(manager, token);
+
+    await manager.resolveDisputeWithCode(jobId, 2, "employer win", { from: moderator });
+    await assertSolvent(manager, token);
+  });
+});


### PR DESCRIPTION
### Motivation
- Close a reentrancy vector where `delistJob` could be reentered via token transfer hooks from a contract employer. 
- Add regression coverage that simulates transfer hooks and an employer attempting to reenter on refunds. 
- Fix failing invariant tests caused by unlinked library references and a brittle dispute-flow test path so the test suite can run reliably.

### Description
- Production: append `nonReentrant` to `function delistJob(uint256 _jobId)` in `contracts/AGIJobManager.sol` to protect the refund path. 
- Tests & harness: add `contracts/test/HookToken.sol`, `contracts/test/ReenteringEmployer.sol`, and `contracts/test/UtilsHarness.sol` to support the reentrancy regression and to expose `BondMath`, `ReputationMath`, and `ENSOwnership` utility functions for test assertions. 
- Test suites: add `test/delistJob.reentrancy.test.js`, `test/invariants.libs.test.js`, and `test/invariants.solvency.test.js` to cover the delist reentrancy regression and library/invariant checks. 
- Test fixes: link `BondMath`, `ENSOwnership`, and `ReputationMath` into `UtilsHarness` before deployment in `test/invariants.libs.test.js` and simplify the dispute flow in `test/invariants.solvency.test.js` to avoid a double-dispute revert while preserving solvency assertions.

### Testing
- Ran the repo test script with `npm run test` (Truffle compile + Truffle tests + node checks) and observed the full test suite pass. 
- Test summary: the suite completed with all automated checks including ABI smoke and contract size guards and reported `235 passing` with no remaining failures. 
- Verified the new reentrancy regression test demonstrates a single refund and that the reentrancy attempt on delist is blocked by the `nonReentrant` guard.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698968af09d48333973093e7195f4774)