### PR TITLE
Emit config & ENS observability via anonymous logs; reduce runtime size to pass EIP‑170

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -8,8 +8,10 @@ safe day‑to‑day operations, emergency procedures, and monitoring.
 ### 1) Pause / unpause
 **Use when**: incident response, parameter change review, treasury withdrawal.
 
-- `pause()` blocks new activity but preserves settlement exits.
-- `unpause()` restores normal operations.
+- `pause()` blocks new activity (create/apply/vote/dispute/reward pool contribution) but preserves settlement exits.
+- `setSettlementPaused(true)` freezes settlement/exit paths (`cancelJob`, `expireJob`, `finalizeJob`, `delistJob`) guarded by `whenSettlementNotPaused`.
+- **Incident sequence:** call `setSettlementPaused(true)` first to stop fund-out, then `pause()` to stop intake.
+- **Recovery:** unpause intake only after settlement is safe; keep `settlementPaused` on until final safety, then set it to false last.
 
 ### 2) Treasury withdrawals (owner‑only, paused‑only)
 **Process**

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -112,6 +112,25 @@
       "type": "error"
     },
     {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "oldToken",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newToken",
+          "type": "address"
+        }
+      ],
+      "name": "AGITokenAddressUpdated",
+      "type": "event"
+    },
+    {
       "anonymous": false,
       "inputs": [
         {
@@ -185,6 +204,68 @@
         }
       ],
       "name": "AgentBlacklisted",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldMin",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newMin",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgentBondMinUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldBps",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldMin",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldMax",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newBps",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newMin",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newMax",
+          "type": "uint256"
+        }
+      ],
+      "name": "AgentBondParamsUpdated",
       "type": "event"
     },
     {
@@ -348,6 +429,56 @@
         }
       ],
       "name": "DisputeReviewPeriodUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "uint8",
+          "name": "hook",
+          "type": "uint8"
+        },
+        {
+          "indexed": true,
+          "internalType": "uint256",
+          "name": "jobId",
+          "type": "uint256"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "target",
+          "type": "address"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "success",
+          "type": "bool"
+        }
+      ],
+      "name": "EnsHookAttempted",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "oldEnsJobPages",
+          "type": "address"
+        },
+        {
+          "indexed": true,
+          "internalType": "address",
+          "name": "newEnsJobPages",
+          "type": "address"
+        }
+      ],
+      "name": "EnsJobPagesUpdated",
       "type": "event"
     },
     {
@@ -717,6 +848,44 @@
       "type": "event"
     },
     {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldApprovals",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newApprovals",
+          "type": "uint256"
+        }
+      ],
+      "name": "RequiredValidatorApprovalsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldDisapprovals",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newDisapprovals",
+          "type": "uint256"
+        }
+      ],
+      "name": "RequiredValidatorDisapprovalsUpdated",
+      "type": "event"
+    },
+    {
       "anonymous": false,
       "inputs": [
         {
@@ -824,6 +993,44 @@
       "type": "event"
     },
     {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "oldValue",
+          "type": "bool"
+        },
+        {
+          "indexed": false,
+          "internalType": "bool",
+          "name": "newValue",
+          "type": "bool"
+        }
+      ],
+      "name": "UseEnsJobTokenURIUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldPercentage",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newPercentage",
+          "type": "uint256"
+        }
+      ],
+      "name": "ValidationRewardPercentageUpdated",
+      "type": "event"
+    },
+    {
       "anonymous": false,
       "inputs": [
         {
@@ -865,6 +1072,44 @@
         }
       ],
       "name": "ValidatorBondParamsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldBps",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newBps",
+          "type": "uint256"
+        }
+      ],
+      "name": "ValidatorSlashBpsUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": true,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "oldQuorum",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newQuorum",
+          "type": "uint256"
+        }
+      ],
+      "name": "VoteQuorumUpdated",
       "type": "event"
     },
     {

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -72,7 +72,13 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
 
-    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+    const createReceipt = await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+    const createHook = createReceipt.logs.find((log) => log.event === "EnsHookAttempted");
+    assert.ok(createHook, "EnsHookAttempted should be emitted on create");
+    assert.equal(createHook.args.hook.toString(), "1");
+    assert.equal(createHook.args.jobId.toString(), "0");
+    assert.equal(createHook.args.target, ensJobPages.address);
+    assert.equal(createHook.args.success, true);
     assert.equal((await ensJobPages.createCalls()).toString(), "1");
 
     await token.mint(agent, web3.utils.toWei("2"), { from: owner });
@@ -110,7 +116,13 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
 
-    await manager.createJob("ipfs://spec.json", payout, 50, "details", { from: employer });
+    const createReceipt = await manager.createJob("ipfs://spec.json", payout, 50, "details", { from: employer });
+    const createHook = createReceipt.logs.find((log) => log.event === "EnsHookAttempted");
+    assert.ok(createHook, "EnsHookAttempted should be emitted on create");
+    assert.equal(createHook.args.hook.toString(), "1");
+    assert.equal(createHook.args.jobId.toString(), "0");
+    assert.equal(createHook.args.target, ensJobPages.address);
+    assert.equal(createHook.args.success, false);
 
     await token.mint(agent, web3.utils.toWei("2"), { from: owner });
     await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });


### PR DESCRIPTION
### Motivation
- Surface high‑impact configuration changes and ENS hook attempts in the event stream so operators/observability tools can see owner actions and best‑effort hook outcomes without changing core flow semantics. 
- Preserve ENS hook best‑effort behavior while shrinking code paths to reduce deployed runtime size under the EIP‑170 limit. 
- Make operator sequencing explicit in documentation by distinguishing intake `pause()` from `settlementPaused` to avoid accidental fund outflows during incidents.

### Description
- Added lightweight observability by declaring new config/ENS events as `anonymous` and emitting them via low‑level helpers `_emitAddressPair`, `_emitUintPair`, and `_emitAgentBondParams` (using `assembly` logs) and wired those calls into the relevant setters. 
- Made ENS job pages hooks and ENS tokenURI lookups slimmer by removing redundant `code.length` guards and keeping calls `staticcall`/`call` as best‑effort, and emit `EnsHookAttempted(hook, jobId, target, success)` after each hook call. 
- Applied small gas/size micro‑optimizations (`unchecked` blocks, packed arithmetic where safe, minor control‑flow simplifications) to reduce runtime bytecode size. 
- Updated `docs/operator-runbook.md` to document `setSettlementPaused(true)` → `pause()` incident sequencing and recovery guidance. 
- Refreshed exported UI ABI at `docs/ui/abi/AGIJobManager.json` and extended tests in `test/adminOps.test.js` and `test/ensJobPagesHooks.test.js` to assert the new observability events.

### Testing
- Ran `npx truffle compile` which completed successfully (artifacts written). 
- Ran `npm run size` (which executes `node scripts/check-bytecode-size.js`) and the guard now passes with `AGIJobManager runtime bytecode size: 24570 bytes`. 
- Ran `npm run ui:abi` which exported the updated ABI to `docs/ui/abi/AGIJobManager.json`. 
- Updated unit tests are included (`test/adminOps.test.js`, `test/ensJobPagesHooks.test.js`) but the full `truffle test` suite was not executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989df0b7b288333a208c39e9bbfe171)