### PR TITLE
Docs: clarify intake pause vs settlementPaused and update runbook

### DIFF
--- a/docs/ParameterSafety.md
+++ b/docs/ParameterSafety.md
@@ -153,7 +153,8 @@ Below are plausible misconfiguration or operational failures that can trap funds
 ## Recovery playbook (operator runbook)
 
 1. **Stop the bleeding:**
-   - Call `pause()` if misconfiguration is causing failed settlements or unexpected behavior.
+   - Call `setSettlementPaused(true)` to freeze settlement/fund‑moving paths first.
+   - Optionally call `pause()` to stop new intake if misconfiguration is causing failed settlements or unexpected behavior.
 
 2. **Fix misconfiguration:**
    - Adjust validator thresholds (`setRequiredValidatorApprovals`, `setRequiredValidatorDisapprovals`).
@@ -170,6 +171,7 @@ Below are plausible misconfiguration or operational failures that can trap funds
 4. **Validate recovery:**
    - Use `getJobCore(jobId)` and `getJobValidation(jobId)` to confirm lifecycle flags.
    - Confirm contract token balance is ≥ expected payout obligations.
+   - Only unset `settlementPaused` after settlement math/invariants are confirmed safe; unpause intake last if you want conservative safety.
 
 ## Optional hardening ideas (no code changes in this task)
 

--- a/docs/trust-model-and-security-overview.md
+++ b/docs/trust-model-and-security-overview.md
@@ -51,16 +51,17 @@ and settlement invariants.
 
 ## 3) Pause semantics (blocked vs allowed)
 
-Pausing is intended to stop new risk while preserving exits/settlement.
+Pausing is intended to stop new risk while preserving exits/settlement. The contract
+also has a **separate** `settlementPaused` switch for emergency settlement freezes.
 
-**Blocked while paused**
+**Blocked while paused (intake pause via `pause()`/`unpause()`)**
 | Category | Functions |
 | --- | --- |
 | Job creation & onboarding | `createJob`, `applyForJob` |
 | Validation & dispute entry | `validateJob`, `disapproveJob`, `disputeJob` |
 | Reward pool funding | `contributeToRewardPool` |
 
-**Allowed while paused**
+**Allowed while paused (intake pause)**
 | Category | Functions |
 | --- | --- |
 | Completion submission | `requestJobCompletion` |
@@ -70,8 +71,16 @@ Pausing is intended to stop new risk while preserving exits/settlement.
 | Owner job delist | `delistJob` (owner‑only, unassigned only) |
 | Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
 
-**Rationale**: Pause is used to halt new obligations and risky actions, not to
-trap users or prevent settlement/exit paths.
+**Blocked while settlementPaused (emergency settlement freeze via `setSettlementPaused`)**
+| Category | Functions |
+| --- | --- |
+| Settlement & exits | `finalizeJob`, `cancelJob`, `expireJob` |
+| Dispute resolution | `resolveDispute`, `resolveDisputeWithCode`, `resolveStaleDispute` |
+| Owner job delist | `delistJob` (owner‑only, unassigned only) |
+| Treasury withdrawal | `withdrawAGI` (owner‑only, paused‑only) |
+
+**Rationale**: `pause()` halts new obligations and risky actions, while
+`settlementPaused` is a best‑effort freeze on fund‑moving/terminal paths.
 
 ## 4) Identity configuration lock (scope and guarantees)
 


### PR DESCRIPTION
### Motivation
- Make operator guidance explicit about the separate emergency settlement freeze (`settlementPaused`) vs the intake pause (`pause()`/`unpause()`), and prescribe safe ordering for incident response so operator actions match on‑chain gating.

### Description
- Update `docs/trust-model-and-security-overview.md` and `docs/ParameterSafety.md` to (a) document `settlementPaused` as a separate control with the functions it blocks and (b) update the recovery playbook to call `setSettlementPaused(true)` first and only unset it after settlement invariants are validated; the contract `AGIJobManager.sol` was audited and already contains the requested setter events and `EnsHookAttempted`, so no contract code changes were required.

### Testing
- Docs-only change; no automated tests were run, and the change was validated by inspecting the updated docs and confirming the contract already implements the expected events and ENS hook emission.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6989f99618e48333a4809c6b9f395a71)