### PR TITLE
Document settlementPaused sequencing in break-glass runbook

### DIFF
--- a/docs/deployment-checklist.md
+++ b/docs/deployment-checklist.md
@@ -104,7 +104,8 @@ Critical wiring includes the AGI token address, ENS registry, NameWrapper, and E
 ## 6) Break-glass runbook (after lock)
 
 After lock, operators should only use:
-- `pause()` / `unpause()` for incident response.
+- `setSettlementPaused(true)` first to freeze settlement fund-out during incidents; clear only after settlement safety is confirmed.
+- `pause()` / `unpause()` to stop intake once settlement is frozen; re-enable intake last after settlement is safe.
 - `resolveStaleDispute()` (owner‑only after `disputeReviewPeriod`; pause optional) for dispute recovery.
 - Optional moderator rotation if required.
 - Surplus withdrawals (`withdrawAGI`) while paused; escrowed funds and bonds remain reserved (`lockedEscrow`, `lockedAgentBonds`, `lockedValidatorBonds`).


### PR DESCRIPTION
### Motivation
- Clarify operator runbook to explicitly include the `settlementPaused` control and the recommended incident sequencing so on-chain gating (`whenSettlementNotPaused` vs `whenNotPaused`) is reflected in ops docs.

### Description
- Update `docs/deployment-checklist.md` break-glass section to instruct operators to call `setSettlementPaused(true)` first to freeze fund-out paths, then use `pause()` to stop intake, and to re-enable intake only after `settlementPaused` is cleared and settlement safety is confirmed.

### Testing
- No automated tests were run because this is a docs-only change; the edit is intentionally minimal and aligned to existing contract modifiers (`whenSettlementNotPaused` / `whenNotPaused`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a000e308c8333bb6f463ac7f0d4c9)