### PR TITLE
Harden zero-transfer paths and preserve bytecode limit

### DIFF
--- a/docs/operator-runbook.md
+++ b/docs/operator-runbook.md
@@ -68,6 +68,7 @@ safe day‑to‑day operations, emergency procedures, and monitoring.
 - **Treasury/ops**: `AGIWithdrawn`, `Paused`, `Unpaused`, `RewardPoolContribution`
 - **Identity**: `IdentityConfigurationLocked`, `RootNodesUpdated`,
   `MerkleRootsUpdated`, `EnsRegistryUpdated`, `NameWrapperUpdated`
+- **ENS hooks**: `EnsHookAttempted` (ENS integration is auxiliary; hook failure does not affect settlement)
 - **Blacklists**: `AgentBlacklisted`, `ValidatorBlacklisted`
 
 ## Operational notes


### PR DESCRIPTION
### Motivation
- Eliminate ERC‑20 zero-transfer edge cases by ensuring the contract never issues meaningless `transfer`/`transferFrom` calls with amount `0` where configurable/rounded values may be zero.
- Keep `disputeInitiator` state non-misleading while preserving storage layout (no layout changes allowed).
- Add minimal ops/monitoring telemetry where bytecode budget allows and keep runtime bytecode under the EIP‑170 safety guard.

### Description
- Guarded outbound transfers by skipping zero-amount sends in the internal helper ` _t(address,uint256)` so the contract does not call `TransferUtils.safeTransfer(..., 0)`.
- Avoid calling `TransferUtils.safeTransferFromExact(...)` with `0` in agent/validator bond intake paths by making bond collection conditional so `applyForJob` and validator vote flows do not attempt 0-value `transferFrom` operations.
- Marked `disputeInitiator` as deprecated in the `Job` struct and removed attempts to set/clear it (keeps storage layout intact but avoids misleading state). No storage layout fields were added or removed.
- Per bytecode constraints, kept AGIJobManager event additions minimal/rolled back and instead applied a few compact refactors (named return variables, small control-flow reorders) to bring runtime bytecode under the repo guard; updated the operator runbook to mention ENS hook monitoring (`EnsHookAttempted`).

### Testing
- Ran `npm run build` (which invokes `truffle compile`); compilation completed successfully with the updated contract.
- Ran `npm run size` (repo bytecode guard); `AGIJobManager` runtime bytecode = `24572` bytes, which is within the enforced limit (≤ `24575` bytes).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0b393d6c833384b7d5be9470659c)