### PR TITLE
Update UI ABI export; add compact config/role events and harden transfers/bonds

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -360,6 +360,19 @@
       "anonymous": false,
       "inputs": [
         {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigUintUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
           "indexed": true,
           "internalType": "uint256",
           "name": "jobId",
@@ -902,6 +915,19 @@
         }
       ],
       "name": "RewardPoolContribution",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
+          "internalType": "address",
+          "name": "account",
+          "type": "address"
+        }
+      ],
+      "name": "RoleUpdated",
       "type": "event"
     },
     {


### PR DESCRIPTION
### Motivation
- Avoid ERC20 edge cases by preventing zero-amount transfers and make bond intake conditional to avoid unnecessary `safeTransferFromExact(..., 0)` calls.
- Improve operational telemetry for silent config/role changes with compact events that keep ABI/bytecode footprint small.
- Fix dispute state hygiene so `disputeInitiator` reflects who opened a dispute and is cleared when bonds are settled.

### Description
- Added `ConfigUintUpdated` and `RoleUpdated` events and wired them via small helpers `_emitConfigUint` and `_setRole`, and replaced use-sites of the old flag helper with `_setRole` to emit a compact role event.
- Prevent zero-value ERC20 transfers by returning early in `_t(address,uint256)` and make bond intake conditional (`if (bond > 0) ...`) in `applyForJob` and validator vote intake paths.
- Ensure `disputeInitiator` is set in `disputeJob(...)` and cleared in `_settleDisputeBond(...)` to avoid misleading state.
- Miscellaneous size- and gas-oriented micro-optimizations and defensive changes including selective `unchecked` blocks, compact control flow for time checks, minor payout/math rearrangements, and ABI/ABI-export updates (regenerated `docs/ui/abi/AGIJobManager.json`).

### Testing
- Ran `npx truffle compile`, `npm run ui:abi`, and `npm run test`, and the test suite completed with `236 passing` and the ABI sync issue resolved by exporting the updated ABI to `docs/ui/abi/AGIJobManager.json`.
- Contract bytecode size guard was run and the deployed bytecode stayed within the configured safety margin. Your CI commands: `npx truffle compile`, `npm run ui:abi`, `npm run test` all succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a0b393d6c833384b7d5be9470659c)