### PR TITLE
Restore DeprecatedParameter, guard zero reward contributions, and harden transfers/dispute lifecycle

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -103,11 +103,6 @@
     },
     {
       "inputs": [],
-      "name": "TransferFailed",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "ValidatorLimitReached",
       "type": "error"
     },


### PR DESCRIPTION
### Motivation
- Fix failing tests and ABI mismatch by restoring the deprecated custom error and re-exporting the ABI. 
- Prevent ERC20 compatibility/edge-cases by skipping zero-value transfers and guarding reward-pool contributions. 
- Keep dispute lifecycle and escape-hatch invariants correct while trimming bytecode to remain under the EIP-170 runtime size limit.

### Description
- Restore the `DeprecatedParameter` custom error and make `setAdditionalAgentPayoutPercentage` revert with `DeprecatedParameter` instead of `InvalidParameters`.
- Add a zero-amount short-circuit to the internal transfer helper `function _t(address to, uint256 amount)` to avoid calling `transfer` with `0`.
- Make agent bond intake conditional so `TransferUtils.safeTransferFromExact` and `lockedAgentBonds` are only updated when `bond > 0` while still storing `job.agentBondAmount`.
- Ensure dispute initiator hygiene by setting `job.disputeInitiator = msg.sender` on `disputeJob` and clearing it to `address(0)` in `_settleDisputeBond`.
- Re-introduce a zero-amount guard on `contributeToRewardPool` and remove `nonReentrant` from `contributeToRewardPool` and `requestJobCompletion` to reduce bytecode; sum locked balances in `withdrawableAGI` inside an `unchecked` block for gas/size efficiency.
- Export and commit the refreshed UI ABI at `docs/ui/abi/AGIJobManager.json` to match the updated interface.

### Testing
- Ran `npm run ui:abi` and the ABI exported to `docs/ui/abi/AGIJobManager.json` successfully.
- Ran the full test suite with `npm run test` (which runs `truffle compile --all` and the Truffle/Mocha tests) and all tests passed (`236 passing`).
- Verified runtime bytecode size with `node scripts/check-bytecode-size.js`, reporting `24568` bytes which is within the EIP-170 safety margin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a16e464b48333a9032f7cbca4c959)