### PR TITLE
Harden bond transfers, dispute-initiator hygiene, and config telemetry

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -361,6 +361,25 @@
       "inputs": [
         {
           "indexed": true,
+          "internalType": "uint8",
+          "name": "key",
+          "type": "uint8"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "ConfigUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": true,
           "internalType": "uint256",
           "name": "jobId",
           "type": "uint256"


### PR DESCRIPTION
### Motivation
- Avoid zero-value ERC20 interactions during bond/payout flows and ensure transfers are skipped when amount is `0` to improve token compatibility.
- Keep dispute lifecycle state consistent by recording the dispute initiator when a dispute is posted and clearing it when the dispute bond is settled.
- Provide minimal on-chain telemetry for config updates while keeping runtime bytecode within the EIP-170 safety margin and keep the UI ABI in sync.

### Description
- Added a zero-amount guard to payouts with `function _t(address to, uint256 amount)` and introduced `_tf(address from, uint256 amount)` to short-circuit `transferFrom` calls when `amount == 0` and used it for agent and validator bond intake.
- Set `job.disputeInitiator = msg.sender` when charging a dispute bond in `disputeJob` and clear it with `job.disputeInitiator = address(0)` when the bond is settled in `_settleDisputeBond` to maintain dispute hygiene.
- Reinstated a `DeprecatedParameter` revert for the legacy `setAdditionalAgentPayoutPercentage` API and added a zero-amount guard to `contributeToRewardPool` to revert with `InvalidParameters()` when `amount == 0`.
- Emit a compact `ConfigUpdated(uint8 key, uint256 value)` event for a small set of configuration changes (used for `setMaxJobPayout`), and refreshed the exported UI ABI (`docs/ui/abi/AGIJobManager.json`) to match the contract.
- Minor refactors to keep gas/bytecode in budget (reused internal helpers and avoided larger event/ABI churn) without changing storage layout or public interfaces.

### Testing
- Ran `npm run ui:abi` to refresh the exported ABI, which completed successfully and updated `docs/ui/abi/AGIJobManager.json`.
- Ran the full test suite with `npm run test` (which runs `truffle test` and contract size checks) and the suite passed; test run reported `236 passing` and `0 failing`.
- Verified runtime bytecode size with `node scripts/check-bytecode-size.js`, producing `AGIJobManager runtime bytecode size: 24546 bytes`, which is within the EIP-170 safety margin.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a16e464b48333a9032f7cbca4c959)