### PR TITLE
Harden zero-amount agent bond intake and keep bytecode within EIP-170 limit

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -426,7 +426,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         registry[account] = status;
     }
 
-
     function _validateValidatorThresholds(uint256 approvals, uint256 disapprovals) internal pure {
         if (
             approvals > MAX_VALIDATORS_PER_JOB ||
@@ -505,9 +504,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             agentBondMax,
             jobDurationLimit
         );
-        _tf(msg.sender, bond);
-        unchecked {
-            lockedAgentBonds += bond;
+        if (bond > 0) {
+            _tf(msg.sender, bond);
+            unchecked {
+                lockedAgentBonds += bond;
+            }
         }
         job.agentBondAmount = bond;
         job.assignedAgent = msg.sender;


### PR DESCRIPTION
### Motivation
- Prevent ERC20 implementations that revert on zero-value transfers from causing failures when agent bonds compute to 0 by avoiding meaningless `safeTransferFrom` calls and unnecessary accounting updates.
- Preserve dispute state hygiene and critical anti-reentrancy protections without changing storage layout or external APIs.
- Keep runtime bytecode below the EIP-170 safety limit while keeping compiler/truffle settings unchanged.

### Description
- Guard `applyForJob(...)` so the agent bond transfer and `lockedAgentBonds` accounting are performed only when `bond > 0` (skip the transfer and the accounting side-effect for zero bonds). This preserves the existing `job.agentBondAmount` assignment and other control flow unchanged.
- Confirmed `disputeInitiator` is set during `disputeJob(...)` and cleared in settlement paths (`_settleDisputeBond(...)`), and `delistJob(...)` is already protected by `nonReentrant`, so no storage layout or signature changes were made.
- Attempted lightweight telemetry additions were kept bytecode-aware; no invasive events or behavior changes were left that would exceed the runtime size guard.

### Testing
- Ran `npm run build` (Truffle compile): compilation succeeded (warnings only). ✅
- Ran the repo bytecode size check via `npm run size`: AGIJobManager runtime bytecode is 24,553 bytes which is under the 24,575 bytes threshold, so the size guard passes. ✅
- No other automated tests were added or changed to keep the diff minimal.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a31c699288333bfa02f536459c62b)