### PR TITLE
Fix Solidity warnings and update UI ABI

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -856,7 +856,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit ChallengePeriodAfterApprovalUpdated(oldPeriod, period);
     }
     /// @notice Deprecated and unused in payout logic.
-    function setAdditionalAgentPayoutPercentage(uint256) external onlyOwner {
+    function setAdditionalAgentPayoutPercentage(uint256) external view onlyOwner {
         revert DeprecatedParameter();
     }
     function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner { termsAndConditionsIpfsHash = _hash; }

--- a/contracts/test/MockENSRegistry.sol
+++ b/contracts/test/MockENSRegistry.sol
@@ -5,8 +5,8 @@ contract MockENSRegistry {
     mapping(bytes32 => address) private owners;
     mapping(bytes32 => address) private resolvers;
 
-    function setOwner(bytes32 node, address owner) external {
-        owners[node] = owner;
+    function setOwner(bytes32 node, address newOwner) external {
+        owners[node] = newOwner;
     }
 
     function owner(bytes32 node) external view returns (address) {

--- a/contracts/test/MockPublicResolver.sol
+++ b/contracts/test/MockPublicResolver.sol
@@ -5,8 +5,8 @@ contract MockPublicResolver {
     mapping(bytes32 => mapping(address => bool)) private authorisations;
     mapping(bytes32 => mapping(bytes32 => string)) private textRecords;
 
-    function setAuthorisation(bytes32 node, address target, bool isAuthorised) external {
-        authorisations[node][target] = isAuthorised;
+    function setAuthorisation(bytes32 node, address target, bool authorised) external {
+        authorisations[node][target] = authorised;
     }
 
     function isAuthorised(bytes32 node, address target) external view returns (bool) {

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2729,7 +2729,7 @@
       ],
       "name": "setAdditionalAgentPayoutPercentage",
       "outputs": [],
-      "stateMutability": "nonpayable",
+      "stateMutability": "view",
       "type": "function"
     },
     {


### PR DESCRIPTION
### Motivation
- Eliminate specific Solidity compiler warnings (parameter name collisions and a mutability warning for a revert-only setter) and keep the exported UI ABI in sync with the code.

### Description
- Renamed the `owner` parameter to `newOwner` in `contracts/test/MockENSRegistry.sol` to avoid collision with `owner(bytes32)`.
- Renamed the `isAuthorised` parameter to `authorised` in `contracts/test/MockPublicResolver.sol` to avoid collision with `isAuthorised(...)`.
- Marked the deprecated setter as `view` in `contracts/AGIJobManager.sol` by changing `function setAdditionalAgentPayoutPercentage(uint256) external onlyOwner` to `function setAdditionalAgentPayoutPercentage(uint256) external view onlyOwner { revert DeprecatedParameter(); }` to address the mutability warning while preserving the revert behavior.
- Updated the exported UI ABI at `docs/ui/abi/AGIJobManager.json` so the ABI reflects the `view` mutability for `setAdditionalAgentPayoutPercentage`.
- No changes to function names, parameter ordering, types, visibility (aside from adding `view`), or runtime behavior beyond renaming parameter identifiers.

### Testing
- Ran `npm run build` (invokes `truffle compile`) which completed successfully.
- Ran `npm run ui:abi` to export the ABI to `docs/ui/abi/AGIJobManager.json` which succeeded.
- Ran `npm run test` which executed the full test suite and UI ABI sync; all automated tests passed (`236 passing`) and the ABI sync check succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a386003208333bf56b3bf24aaf603)