### PR TITLE
Skip zero-value dispute bond transfers and preserve disputeInitiator hygiene

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -626,9 +626,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (bond < DISPUTE_BOND_MIN) bond = DISPUTE_BOND_MIN;
         if (bond > DISPUTE_BOND_MAX) bond = DISPUTE_BOND_MAX;
         if (bond > job.payout) bond = job.payout;
-        TransferUtils.safeTransferFromExact(address(agiToken), msg.sender, address(this), bond);
-        unchecked {
-            lockedDisputeBonds += bond;
+        if (bond > 0) {
+            TransferUtils.safeTransferFromExact(address(agiToken), msg.sender, address(this), bond);
+            unchecked {
+                lockedDisputeBonds += bond;
+            }
         }
         job.disputeBondAmount = bond;
         job.disputeInitiator = msg.sender;


### PR DESCRIPTION
### Motivation
- Prevent ERC20 tokens that revert on zero-value transfers from breaking the dispute flow and ensure dispute initiator state does not show stale data to indexers/operators.

### Description
- Add an `if (bond > 0)` guard in `disputeJob` so `TransferUtils.safeTransferFromExact(...)` and `lockedDisputeBonds` are only executed/updated for non-zero dispute bonds.
- Left validator vote logic unchanged because `_recordValidatorVote` uses `_tf(...)` which already no-ops on zero amounts, so no additional changes were necessary for validator bonds.
- No changes to public/external function signatures or dispute settlement semantics; `disputeInitiator` is still set in `disputeJob` and cleared in `_settleDisputeBond` as required.

### Testing
- Attempted `npm run build` (invokes `truffle compile`) but it failed because `truffle` is not installed in the execution environment; build did not run.
- Attempted `npm test` which also failed for the same missing `truffle` binary and thus tests could not be executed here.
- Ran `npm run size` which reported missing Truffle artifacts due to the compile step not running.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a4c976e2883338c4563698a7f4a1b)