### PR TITLE
Harden AGIType handling, ENS fuse update, add AGIType disable, and restore AGI token-update guard

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -260,15 +260,10 @@ contract ENSJobPages is Ownable {
         _setAuthorisationBestEffort(jobId, node, agent, false);
 
         bool fusesBurned = false;
-        if (burnFuses && address(nameWrapper) != address(0)) {
-            try nameWrapper.isWrapped(node) returns (bool wrapped) {
-                if (wrapped) {
-                    try nameWrapper.burnFuses(node, LOCK_FUSES) returns (uint32) {
-                        fusesBurned = true;
-                    } catch {
-                        // solhint-disable-next-line no-empty-blocks
-                    }
-                }
+        if (burnFuses && _isWrappedRoot()) {
+            bytes32 labelHash = keccak256(bytes(jobEnsLabel(jobId)));
+            try nameWrapper.setChildFuses(jobsRootNode, labelHash, LOCK_FUSES, type(uint64).max) {
+                fusesBurned = true;
             } catch {
                 // solhint-disable-next-line no-empty-blocks
             }

--- a/contracts/ens/INameWrapper.sol
+++ b/contracts/ens/INameWrapper.sol
@@ -6,6 +6,7 @@ interface INameWrapper {
     function isApprovedForAll(address owner, address operator) external view returns (bool);
     function isWrapped(bytes32 node) external view returns (bool);
     function burnFuses(bytes32 node, uint32 fuses) external returns (uint32);
+    function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external;
     function setSubnodeRecord(
         bytes32 parentNode,
         string calldata label,

--- a/contracts/test/MockBrokenERC721.sol
+++ b/contracts/test/MockBrokenERC721.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockBrokenERC721 {
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7 || interfaceId == 0x80ac58cd;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        revert("broken");
+    }
+}

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -6,6 +6,11 @@ contract MockNameWrapper {
     mapping(address => mapping(address => bool)) private approvals;
     mapping(bytes32 => bool) private wrapped;
     mapping(bytes32 => uint32) private burnedFuses;
+    uint256 public setChildFusesCalls;
+    bytes32 public lastParentNode;
+    bytes32 public lastLabelhash;
+    uint32 public lastFuses;
+    uint64 public lastExpiry;
 
     function setOwner(uint256 id, address owner) external {
         owners[id] = owner;
@@ -31,6 +36,14 @@ contract MockNameWrapper {
         uint32 nextFuses = burnedFuses[node] | fuses;
         burnedFuses[node] = nextFuses;
         return nextFuses;
+    }
+
+    function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external {
+        setChildFusesCalls += 1;
+        lastParentNode = parentNode;
+        lastLabelhash = labelhash;
+        lastFuses = fuses;
+        lastExpiry = expiry;
     }
 
     function setSubnodeRecord(

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -3154,6 +3154,19 @@
       "inputs": [
         {
           "internalType": "address",
+          "name": "nftAddress",
+          "type": "address"
+        }
+      ],
+      "name": "disableAGIType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
           "name": "agent",
           "type": "address"
         }

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -84,5 +84,11 @@ contract("ENSJobPages helper", (accounts) => {
     assert.equal(wrappedOwner, helper.address, "wrapped subnode should be owned by helper");
     const isWrapped = await nameWrapper.isWrapped(node);
     assert.equal(isWrapped, true, "subnode should be marked wrapped");
+
+    await helper.lockJobENS(jobId, employer, agent, true, { from: owner });
+    assert.equal((await nameWrapper.setChildFusesCalls()).toString(), "1");
+    assert.equal(await nameWrapper.lastParentNode(), rootNode);
+    assert.equal(await nameWrapper.lastLabelhash(), web3.utils.keccak256(`job-${jobId}`));
+    assert.equal((await nameWrapper.lastFuses()).toString(), "24");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent malformed or misbehaving AGIType NFT contracts from breaking payout snapshotting and job flows by treating broken ERC721s as zero-balance rather than allowing view reverts. 
- Ensure identity configuration updates are gated by real live locked obligations and preserve the token-switch guard to avoid permanently stranded old-token balances. 
- Make ENS fuse-burning work with the current NameWrapper API when the root is wrapped and enable testing of that path.

### Description
- Strengthened empty-escrow guard by checking live obligations (`lockedEscrow | lockedAgentBonds | lockedValidatorBonds | lockedDisputeBonds`) inside `_requireEmptyEscrow()` instead of relying on `nextJobId` alone. 
- Hardened `addAGIType(address,uint256)` to reject zero address, non-contract addresses, and require ERC165 + ERC721 support via a compact `_supportsInterface` assembly helper, and enforce payout headroom rules. 
- Added `disableAGIType(address)` to disable an AGIType in-place by setting its `payoutPercentage` to `0` and emitting `AGITypeUpdated(nftAddress, 0)`. 
- Rewrote `getHighestPayoutPercentage(address)` to skip disabled entries and call NFT `balanceOf` with a safe low-level `staticcall` (selector `0x70a08231`), treating failures or malformed returns as zero balance to avoid view reverts. 
- Restored the token-switch guard in `updateAGITokenAddress` by reintroducing the `if (nextJobId != 0) revert InvalidState();` check to prevent swapping the AGI token after jobs have been created. 
- ENS updates: replaced the prior `burnFuses` attempt with a call to `nameWrapper.setChildFuses(jobsRootNode, labelhash, LOCK_FUSES, type(uint64).max)` when the root is wrapped, updated `INameWrapper` to include the `setChildFuses` signature, and only mark `fusesBurned=true` on success. 
- Tests & mocks: added `MockBrokenERC721` (declares ERC165/ERC721 but `revert`s on `balanceOf`) and extended `MockNameWrapper` to record `setChildFuses` calls; added/updated tests to cover AGIType validation, safe snapshotting, disable behavior, identity-config gating by live locks, and ENS fuse behavior (`test/economicSafety.test.js`, `test/adminOps.test.js`, `test/ensJobPagesHelper.test.js`). 
- Updated ABI export (`docs/ui/abi/AGIJobManager.json`) to include `disableAGIType`.

### Testing
- Added unit tests under `test/` that exercise the new AGIType validation, broken-ERC721 resilience, `disableAGIType`, ENS `setChildFuses` behavior, and identity-config gating, but the full test suite was not executed locally. 
- An attempt to run `npm test` failed because the `truffle` binary was not found (command exited with code `127`), so compilation and automated tests were not completed in this environment. 
- All test files and mocks have been included so CI or a local environment with Truffle can run the full suite (`npm test`) to validate the changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a8000fad08333a57a76384eaecc77)