### PR TITLE
Harden AGIType & ENS handling and reduce AGIJobManager bytecode size

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -260,15 +260,10 @@ contract ENSJobPages is Ownable {
         _setAuthorisationBestEffort(jobId, node, agent, false);
 
         bool fusesBurned = false;
-        if (burnFuses && address(nameWrapper) != address(0)) {
-            try nameWrapper.isWrapped(node) returns (bool wrapped) {
-                if (wrapped) {
-                    try nameWrapper.burnFuses(node, LOCK_FUSES) returns (uint32) {
-                        fusesBurned = true;
-                    } catch {
-                        // solhint-disable-next-line no-empty-blocks
-                    }
-                }
+        if (burnFuses && _isWrappedRoot()) {
+            bytes32 labelhash = keccak256(bytes(jobEnsLabel(jobId)));
+            try nameWrapper.setChildFuses(jobsRootNode, labelhash, LOCK_FUSES, type(uint64).max) {
+                fusesBurned = true;
             } catch {
                 // solhint-disable-next-line no-empty-blocks
             }

--- a/contracts/ens/INameWrapper.sol
+++ b/contracts/ens/INameWrapper.sol
@@ -5,7 +5,7 @@ interface INameWrapper {
     function ownerOf(uint256 id) external view returns (address);
     function isApprovedForAll(address owner, address operator) external view returns (bool);
     function isWrapped(bytes32 node) external view returns (bool);
-    function burnFuses(bytes32 node, uint32 fuses) external returns (uint32);
+    function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external;
     function setSubnodeRecord(
         bytes32 parentNode,
         string calldata label,

--- a/contracts/test/MockBrokenERC721.sol
+++ b/contracts/test/MockBrokenERC721.sol
@@ -1,0 +1,14 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockBrokenERC721 {
+    error BalanceBroken();
+
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7 || interfaceId == 0x80ac58cd;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        revert BalanceBroken();
+    }
+}

--- a/contracts/test/MockERC165Only.sol
+++ b/contracts/test/MockERC165Only.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockERC165Only {
+    function supportsInterface(bytes4 interfaceId) external pure returns (bool) {
+        return interfaceId == 0x01ffc9a7;
+    }
+}

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -6,6 +6,11 @@ contract MockNameWrapper {
     mapping(address => mapping(address => bool)) private approvals;
     mapping(bytes32 => bool) private wrapped;
     mapping(bytes32 => uint32) private burnedFuses;
+    uint256 public setChildFusesCalls;
+    bytes32 public lastParentNode;
+    bytes32 public lastLabelhash;
+    uint32 public lastChildFuses;
+    uint64 public lastChildExpiry;
 
     function setOwner(uint256 id, address owner) external {
         owners[id] = owner;
@@ -31,6 +36,14 @@ contract MockNameWrapper {
         uint32 nextFuses = burnedFuses[node] | fuses;
         burnedFuses[node] = nextFuses;
         return nextFuses;
+    }
+
+    function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external {
+        setChildFusesCalls += 1;
+        lastParentNode = parentNode;
+        lastLabelhash = labelhash;
+        lastChildFuses = fuses;
+        lastChildExpiry = expiry;
     }
 
     function setSubnodeRecord(

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -3154,6 +3154,19 @@
       "inputs": [
         {
           "internalType": "address",
+          "name": "nftAddress",
+          "type": "address"
+        }
+      ],
+      "name": "disableAGIType",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
           "name": "agent",
           "type": "address"
         }

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -84,5 +84,14 @@ contract("ENSJobPages helper", (accounts) => {
     assert.equal(wrappedOwner, helper.address, "wrapped subnode should be owned by helper");
     const isWrapped = await nameWrapper.isWrapped(node);
     assert.equal(isWrapped, true, "subnode should be marked wrapped");
+
+    await helper.lockJobENS(jobId, employer, agent, true, { from: owner });
+    assert.equal((await nameWrapper.setChildFusesCalls()).toString(), "1", "should set child fuses");
+    assert.equal(await nameWrapper.lastParentNode(), rootNode, "parent node should be jobs root");
+    assert.equal(
+      await nameWrapper.lastLabelhash(),
+      web3.utils.keccak256(`job-${jobId}`),
+      "labelhash should match job label"
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent broken or non‑ERC721 AGI type contracts from breaking job flows and reduce contract runtime bytecode below the EIP‑170 safety guard. 
- Align ENS NameWrapper integration with current child‑fuse APIs and make fuse burning best‑effort. 

### Description
- Compact `_requireEmptyEscrow()` into a single bitwise non‑zero check across `lockedEscrow`, `lockedAgentBonds`, `lockedValidatorBonds`, and `lockedDisputeBonds` to preserve the invariant while reducing code size. 
- Introduced a compact low‑level helper ` _supportsERC721(address)` (replacing the prior dual `supportsInterface` checks) and fixed ABI encoding by left‑shifting the ERC721 interface id for the `staticcall`. 
- Refactored `addAGIType` flow to inline the payout/headroom checks, added `disableAGIType(address)` and changed `_updateAgiTypePayout` to return a `bool`; removed an unused import. 
- Made `getHighestPayoutPercentage` resilient to malformed/broken ERC721s by using a low‑level `staticcall` to `balanceOf` and treating failed or malformed responses as zero. 
- Updated ENS integration: added `setChildFuses` to `INameWrapper`, changed `ENSJobPages._lockJobENS` to compute `labelhash = keccak256(bytes(jobEnsLabel(jobId)))` and call `nameWrapper.setChildFuses(jobsRootNode, labelhash, LOCK_FUSES, type(uint64).max)` when the root is wrapped, and only mark `fusesBurned` on success. 
- Added test mocks and helpers: `MockERC165Only`, `MockBrokenERC721`, and extended `MockNameWrapper` to record `setChildFuses` calls; updated ABI and tests to cover the new behaviors. 

### Testing
- Ran `npx truffle compile --all` which compiled successfully and produced artifacts. 
- Ran targeted tests `npx truffle test test/adminOps.test.js test/ensJobPagesHelper.test.js --network test` and the updated tests passed (all assertions green after fixes). 
- Executed the bytecode size check via `npm run size` and confirmed `AGIJobManager` runtime bytecode is `24528 bytes`, under the configured `24575` limit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698a7c9c56188333bfb8fcf3eea9bb4f)