### PR TITLE
Add regression tests and mocks for AGIType hardening and ENS fuse burning

### DIFF
--- a/contracts/test/MockHookCaller.sol
+++ b/contracts/test/MockHookCaller.sol
@@ -1,0 +1,12 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+interface IENSJobPagesLike {
+    function handleHook(uint8 hook, uint256 jobId) external;
+}
+
+contract MockHookCaller {
+    function callHandleHook(address target, uint8 hook, uint256 jobId) external {
+        IENSJobPagesLike(target).handleHook(hook, jobId);
+    }
+}

--- a/contracts/test/MockNoSupportsInterface.sol
+++ b/contracts/test/MockNoSupportsInterface.sol
@@ -1,0 +1,8 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockNoSupportsInterface {
+    function ping() external pure returns (uint256) {
+        return 1;
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide regression coverage that exercises AGIType hardening and ENS fuse-burning behavior so the previously implemented mainnet fixes are continuously validated. 
- Ensure `addAGIType` rejects non-contracts and contracts that do not properly implement ERC165/721, and that a broken AGIType cannot brick `applyForJob` via `getHighestPayoutPercentage`.
- Validate the ENS hook fallback path still burns child fuses via `setChildFuses` when `getJobCore` calls fail.

### Description
- Add `contracts/test/MockNoSupportsInterface.sol`, a minimal mock lacking `supportsInterface`, to test rejection paths for `addAGIType`.
- Add `contracts/test/MockHookCaller.sol`, a tiny forwarder that calls `ENSJobPages.handleHook` to force the hook fallback path during tests.
- Extend `test/adminOps.test.js` to assert `addAGIType` rejects EOAs / non-`supportsInterface` contracts / ERC165-only / ERC721-only responders and to strengthen the broken-AGI-type scenario by using `addAdditionalAgent` so `applyForJob` remains functional when a broken AGIType coexists with a valid one.
- Extend `test/ensJobPagesHelper.test.js` to call `handleHook(6, jobId)` via the `MockHookCaller` and assert the mock `NameWrapper` recorded a `setChildFuses` call with the expected parent node, labelhash, `LOCK_FUSES`, and `type(uint64).max` expiry.

### Testing
- Ran `npm install` followed by the full suite via `npm test`, which runs `truffle compile`, the Truffle tests and the project checks, and observed the test suite completed successfully with all tests passing.
- Ran the targeted helper test with `npx truffle test test/ensJobPagesHelper.test.js --network test` to validate the ENS hook behavior, which passed.
- Confirmed the bytecode size guard: `AGIJobManager` deployed bytecode reported as `24574` bytes which is under the EIP-170 limit (`24575`) and the size check passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aa18d62bc8333a98a17c015841d47)