### PR TITLE
Harden AGIType handling, fix escrow guard, align ENS fuse API, and add tests

### DIFF
--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -385,12 +385,14 @@ contract("AGIJobManager admin ops", (accounts) => {
     const freshType = await MockERC721.new({ from: owner });
     await manager.addAGIType(freshType.address, 15, { from: owner });
 
+    await freshType.mint(other, { from: owner });
+    assert.equal((await manager.getHighestPayoutPercentage(other)).toString(), "15", "new type should apply before disable");
+
     await manager.disableAGIType(freshType.address, { from: owner });
-    assert.equal((await manager.getHighestPayoutPercentage(agent)).toString(), "92", "disabled type ignored");
+    assert.equal((await manager.getHighestPayoutPercentage(other)).toString(), "0", "disabled type should be ignored");
 
     await manager.addAGIType(freshType.address, 25, { from: owner });
-    await freshType.mint(agent, { from: owner });
-    assert.equal((await manager.getHighestPayoutPercentage(agent)).toString(), "92", "existing higher type still wins");
+    assert.equal((await manager.getHighestPayoutPercentage(other)).toString(), "25", "re-enabled type should apply updated payout");
 
     await expectCustomError(
       manager.disableAGIType.call(validator, { from: owner }),


### PR DESCRIPTION
### Motivation
- Prevent misconfigured AGI types from permanently breaking `applyForJob()` by avoiding external reverts when probing NFT contracts. 
- Ensure identity configuration gating reflects real outstanding obligations rather than `nextJobId` so config updates become available once all obligations clear. 
- Align ENS helper fuse-burning to the NameWrapper API so fuse burns actually execute when root is wrapped.

### Description
- Hardened AGIType validation and safe checks in `contracts/AGIJobManager.sol`: implemented a tiny assembly-based `_supportsERC721` that low-level `staticcall`s `supportsInterface(0x01ffc9a7)` and `supportsInterface(0x80ac58cd)` and checks `extcodesize` before accepting an `nftAddress`, and replaced direct `IERC721.balanceOf` with a safe inline-assembly `staticcall` to selector `0x70a08231` that treats failures/short returns as zero balance.
- Added owner-only emergency disable path `disableAGIType(address nftAddress)` which updates the existing `agiTypes` entry in-place to set `payoutPercentage = 0` (emits `AGITypeUpdated(nftAddress, 0)`) and re-enables by calling `addAGIType(...)` later; `_updateAgiTypePayout` is used to find/update entries without external calls.
- Fixed escrow guard in `AGIJobManager._requireEmptyEscrow()` to gate only on real locked obligations (`lockedEscrow`, `lockedAgentBonds`, `lockedValidatorBonds`, `lockedDisputeBonds`) and removed any dependence on `nextJobId` so identity config ops are callable once obligations clear.
- Aligned ENS fuse burning: added/kept the modern `setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry)` signature in `contracts/ens/INameWrapper.sol` and updated `contracts/ens/ENSJobPages.sol` to attempt `nameWrapper.setChildFuses(jobsRootNode, labelhash, LOCK_FUSES, type(uint64).max)` (best-effort, only when `_isWrappedRoot()`), setting `fusesBurned = true` only on success.
- Tests: added a focused Truffle test in `test/adminOps.test.js` covering disable + re-enable flow for an AGI type and confirming disabling unknown types reverts with `InvalidParameters`.

### Testing
- Ran full test suite with `npm test` (Truffle compile + all tests + ABI smoke + `scripts/check-contract-sizes.js`) and observed all tests passing (`241 passing`).
- Confirmed `AGIJobManager` deployed bytecode size is `24574` bytes, which is under the EIP-170 limit (`< 24575`), and the repository size-guard check passes.
- The new regression test `it("can disable and later re-enable an AGI type")` in `test/adminOps.test.js` ran and passed as part of the suite.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698aac255680833380b5981c2e665a73)