### PR TITLE
Add deterministic CI-grade tests for lifecycle, voting, disputes, escrow and update test docs

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -67,3 +67,17 @@ npx truffle test --network test test/*dispute*.test.js
 | `TransferFailed` custom-error-style reverts | Token returned `false`, reverted, or under-delivered transfer amount | Validate approvals/balances; for fee-on-transfer tokens expect `safeTransferFromExact` to revert. |
 | Bytecode gate fails | Runtime crossed EIP-170 threshold | Run `npm run size`, inspect recent contract-size growth, avoid feature bloat in core contract. |
 | Flaky timeout tests | Missing deterministic block/time advancement | Add explicit time travel + mine step before timeout-sensitive actions. |
+
+
+## Added deterministic suites (mainnet-grade hardening)
+
+| Feature | Test file |
+| --- | --- |
+| Job lifecycle branch coverage | `test/jobLifecycle.core.test.js` |
+| Validator vote/bond accounting | `test/validatorVoting.bonds.test.js` |
+| Dispute + moderator flows | `test/disputes.moderator.test.js` |
+| Escrow/accounting invariants | `test/escrowAccounting.invariants.test.js` |
+| Pause/settlement gate controls | `test/pausing.accessControl.test.js` |
+| AGI type safety | `test/agiTypes.safety.test.js` |
+| ENS best-effort hooks | `test/ensHooks.integration.test.js` |
+| Identity lock semantics | `test/identityConfig.locking.test.js` |

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -51,3 +51,34 @@ Baseline result captured at HEAD:
 - If you change utility-library semantics (`contracts/utils/*`), update or add direct unit tests under:
   - `test/invariants.libs.test.js`
   - `test/utils.uri-transfer.test.js`
+
+
+## Mainnet-grade deterministic expansion (this change set)
+
+### New suites added
+
+- `test/jobLifecycle.core.test.js`: lifecycle branches (approval path, tie->dispute forcing, expiry branch) with explicit challenge/review time travel.
+- `test/validatorVoting.bonds.test.js`: single-validator vote safety, double-vote prevention, and validator-bond accounting checks.
+- `test/disputes.moderator.test.js`: moderator-only resolution paths, `NO_ACTION` retention semantics, and stale-dispute owner resolution.
+- `test/escrowAccounting.invariants.test.js`: bounded deterministic mixed-outcome loop asserting solvency/withdrawable accounting invariants after each terminal state.
+- `test/pausing.accessControl.test.js`: `whenNotPaused` and settlement pause gate checks.
+- `test/agiTypes.safety.test.js`: AGI type admission hardening and disabled/misbehaving type isolation.
+- `test/ensHooks.integration.test.js`: ENS hook best-effort behavior and owner-only fuse-burn semantics.
+- `test/identityConfig.locking.test.js`: identity-config mutability restrictions while obligations are live and after permanent locking.
+
+### Deterministic time travel policy
+
+- Time-sensitive flows use `@openzeppelin/test-helpers` `time.increase(...)` with explicit integer offsets.
+- No external RPC/ENS dependencies are used; all tests are local Ganache (`truffle test --network test`) with repository mocks.
+
+### Requirement-to-risk mapping
+
+| Mainnet risk | Added deterministic controls |
+| --- | --- |
+| Lifecycle branch regressions | `jobLifecycle.core`, `disputes.moderator` |
+| Validator bond/reward drift | `validatorVoting.bonds`, `escrowAccounting.invariants` |
+| Treasury solvency regressions | `escrowAccounting.invariants` |
+| Pause misconfiguration | `pausing.accessControl` |
+| AGI identity type bricking | `agiTypes.safety` |
+| ENS hook revert blast-radius | `ensHooks.integration` |
+| Owner identity lock misuse | `identityConfig.locking` |

--- a/test/agiTypes.safety.test.js
+++ b/test/agiTypes.safety.test.js
@@ -1,0 +1,48 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+const MockNoSupportsInterface = artifacts.require("MockNoSupportsInterface");
+const MockRevertingBalanceOf = artifacts.require("MockBrokenERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+
+contract("AGIJobManager AGI type safety", (accounts) => {
+  const [owner, user] = accounts;
+
+  async function deploy() {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    return AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, wrapper.address, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT), { from: owner });
+  }
+
+  it("rejects invalid AGI type addresses and non-ERC721 contracts", async () => {
+    const manager = await deploy();
+    await expectCustomError(manager.addAGIType.call("0x0000000000000000000000000000000000000000", 50, { from: owner }), "InvalidParameters");
+    await expectCustomError(manager.addAGIType.call(user, 50, { from: owner }), "InvalidParameters");
+
+    const non721 = await MockNoSupportsInterface.new({ from: owner });
+    await expectCustomError(manager.addAGIType.call(non721.address, 50, { from: owner }), "InvalidParameters");
+  });
+
+  it("ignores disabled and misbehaving AGI types when computing payout tiers", async () => {
+    const manager = await deploy();
+    const good = await MockERC721.new({ from: owner });
+    const bad = await MockRevertingBalanceOf.new({ from: owner });
+
+    await manager.addAGIType(good.address, 60, { from: owner });
+    await manager.addAGIType(bad.address, 90, { from: owner });
+    await manager.disableAGIType(bad.address, { from: owner });
+
+    await good.mint(user, { from: owner });
+    const payoutPct = await manager.getHighestPayoutPercentage(user);
+    assert.equal(payoutPct.toString(), "60", "disabled/reverting AGI type must not brick lookup");
+  });
+});

--- a/test/disputes.moderator.test.js
+++ b/test/disputes.moderator.test.js
@@ -1,0 +1,83 @@
+const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+const { fundAgents, fundDisputeBond } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager disputes moderator paths", (accounts) => {
+  const [owner, employer, agent, moderator, outsider] = accounts;
+  let manager;
+  let token;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+    manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, nameWrapper.address, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT), { from: owner });
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addModerator(moderator, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await manager.setDisputeReviewPeriod(1, { from: owner });
+
+    await fundAgents(token, manager, [agent], owner);
+  });
+
+  async function createDisputedJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs://job", payout, 1000, "details", { from: employer });
+    const jobId = tx.logs[0].args.jobId.toNumber();
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs://done", { from: agent });
+    await fundDisputeBond(token, manager, employer, payout, owner);
+    await manager.disputeJob(jobId, { from: employer });
+    return jobId;
+  }
+
+  it("enforces moderator access, NO_ACTION semantics, and stale resolution", async () => {
+    const payout = toBN(toWei("10"));
+    const jobId = await createDisputedJob(payout);
+
+    await expectCustomError(
+      manager.resolveDisputeWithCode.call(jobId, 0, "no-op", { from: outsider }),
+      "NotModerator"
+    );
+
+    await manager.resolveDisputeWithCode(jobId, 0, "no-op", { from: moderator });
+    let core = await manager.getJobCore(jobId);
+    assert.equal(core.disputed, true, "NO_ACTION keeps dispute active");
+
+    await time.increase(2);
+    await manager.resolveStaleDispute(jobId, true, { from: owner });
+    core = await manager.getJobCore(jobId);
+    assert.equal(core.disputed, false, "stale dispute should be closable");
+  });
+
+  it("applies explicit employer/agent outcomes via resolveDisputeWithCode", async () => {
+    const payout = toBN(toWei("12"));
+    const agentWinJob = await createDisputedJob(payout);
+    await manager.resolveDisputeWithCode(agentWinJob, 1, "agent wins", { from: moderator });
+    let settled = await manager.getJobCore(agentWinJob);
+    assert.equal(settled.completed, true);
+
+    const employerWinJob = await createDisputedJob(payout);
+    await manager.resolveDisputeWithCode(employerWinJob, 2, "employer wins", { from: moderator });
+    settled = await manager.getJobCore(employerWinJob);
+    assert.equal(settled.completed, true);
+  });
+});

--- a/test/ensHooks.integration.test.js
+++ b/test/ensHooks.integration.test.js
@@ -1,0 +1,76 @@
+const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockENSJobPages = artifacts.require("MockENSJobPages");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO32 = "0x" + "00".repeat(32);
+
+contract("AGIJobManager ENS hooks integration", (accounts) => {
+  const [owner, employer, agent, outsider] = accounts;
+
+  async function deployStack() {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, wrapper.address, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32), { from: owner });
+    const pages = await MockENSJobPages.new({ from: owner });
+    const nft = await MockERC721.new({ from: owner });
+
+    await manager.setEnsJobPages(pages.address, { from: owner });
+    await manager.addAGIType(nft.address, 80, { from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+
+    return { token, manager, pages };
+  }
+
+  it("fires best-effort hooks for create/assign/completion/revoke without bricking core flow", async () => {
+    const { token, manager, pages } = await deployStack();
+
+    const payout = web3.utils.toWei("8");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await pages.setRevertHook(1, true, { from: owner });
+    await manager.createJob("ipfs://spec", payout, 1000, "details", { from: employer });
+    await manager.applyForJob(0, "", [], { from: agent });
+    await manager.requestJobCompletion(0, "ipfs://done", { from: agent });
+
+    await time.increase((await manager.completionReviewPeriod()).addn(1));
+    await manager.finalizeJob(0, { from: employer });
+
+    assert.equal((await pages.assignCalls()).toString(), "1");
+    assert.equal((await pages.completionCalls()).toString(), "1");
+    assert.equal((await pages.revokeCalls()).toString(), "1");
+  });
+
+  it("restricts fuse burn to owner and tolerates hook failure", async () => {
+    const { token, manager, pages } = await deployStack();
+    const payout = web3.utils.toWei("5");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec", payout, 1, "details", { from: employer });
+    await manager.applyForJob(0, "", [], { from: agent });
+    await time.increase(2);
+    await manager.expireJob(0, { from: employer });
+
+    await expectCustomError(manager.lockJobENS.call(0, true, { from: outsider }), "NotAuthorized");
+
+    await pages.setRevertHook(6, true, { from: owner });
+    const tx = await manager.lockJobENS(0, true, { from: owner });
+    const lockEvent = tx.logs.find((l) => l.event === "EnsHookAttempted" && l.args.hook.toString() === "6");
+    assert(lockEvent, "burn fuse attempt should be emitted");
+    assert.equal(lockEvent.args.success, false, "fuse burn failure must be best-effort only");
+  });
+});

--- a/test/escrowAccounting.invariants.test.js
+++ b/test/escrowAccounting.invariants.test.js
@@ -1,0 +1,99 @@
+const assert = require("assert");
+const { expectRevert, time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents, fundValidators } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager escrow invariants", (accounts) => {
+  const [owner, employer, agent, v1, v2, v3] = accounts;
+  let manager;
+  let token;
+
+  async function assertSolventInvariant() {
+    const [bal, lockedEscrow, lockedAgentBonds, lockedValidatorBonds, lockedDisputeBonds, withdrawable] = await Promise.all([
+      token.balanceOf(manager.address),
+      manager.lockedEscrow(),
+      manager.lockedAgentBonds(),
+      manager.lockedValidatorBonds(),
+      manager.lockedDisputeBonds(),
+      manager.withdrawableAGI(),
+    ]);
+    const totalLocked = lockedEscrow.add(lockedAgentBonds).add(lockedValidatorBonds).add(lockedDisputeBonds);
+    assert(bal.gte(totalLocked), "contract must stay solvent against locked totals");
+    assert.equal(withdrawable.toString(), bal.sub(totalLocked).toString(), "withdrawable = balance - locked totals");
+  }
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+    manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, nameWrapper.address, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT), { from: owner });
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(v1, { from: owner });
+    await manager.addAdditionalValidator(v2, { from: owner });
+    await manager.addAdditionalValidator(v3, { from: owner });
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setVoteQuorum(2, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+
+    await fundAgents(token, manager, [agent], owner);
+    await fundValidators(token, manager, [v1, v2, v3], owner);
+  });
+
+  async function createJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs://job", payout, 1000, "details", { from: employer });
+    return tx.logs[0].args.jobId.toNumber();
+  }
+
+  it("holds accounting invariants across deterministic mixed-outcome loop", async () => {
+    const pattern = ["approve", "disapprove", "expire", "approve", "disapprove"];
+    for (let i = 0; i < pattern.length; i += 1) {
+      const payout = toBN(toWei((5 + i).toString()));
+      const jobId = await createJob(payout);
+      await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+
+      if (pattern[i] === "expire") {
+        await time.increase(1001);
+        await manager.expireJob(jobId, { from: employer });
+      } else {
+        await manager.requestJobCompletion(jobId, `ipfs://done/${i}`, { from: agent });
+        await manager.validateJob(jobId, "", EMPTY_PROOF, { from: v1 });
+        if (pattern[i] === "approve") {
+          await manager.validateJob(jobId, "", EMPTY_PROOF, { from: v2 });
+        } else {
+          await manager.disapproveJob(jobId, "", EMPTY_PROOF, { from: v2 });
+          await manager.disapproveJob(jobId, "", EMPTY_PROOF, { from: v3 });
+        }
+        await time.increase(2);
+        await manager.finalizeJob(jobId, { from: employer });
+      }
+      await assertSolventInvariant();
+    }
+  });
+
+  it("reverts withdraw when requested amount exceeds computed withdrawable", async () => {
+    const payout = toBN(toWei("9"));
+    await createJob(payout);
+    await manager.pause({ from: owner });
+    await manager.setSettlementPaused(false, { from: owner });
+    await expectRevert.unspecified(manager.withdrawAGI(toBN(1), { from: owner }));
+  });
+});

--- a/test/identityConfig.locking.test.js
+++ b/test/identityConfig.locking.test.js
@@ -1,0 +1,44 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+const { fundAgents } = require("./helpers/bonds");
+
+const ZERO = "0x" + "00".repeat(32);
+
+contract("AGIJobManager identity configuration locking", (accounts) => {
+  const [owner, employer, agent] = accounts;
+
+  it("rejects identity config updates while obligations are locked and after permanent lock", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, wrapper.address, ZERO, ZERO, ZERO, ZERO, ZERO, ZERO), { from: owner });
+
+    const nft = await MockERC721.new({ from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAGIType(nft.address, 80, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+
+    const payout = web3.utils.toWei("3");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    await manager.createJob("ipfs://job", payout, 1000, "details", { from: employer });
+
+    await expectCustomError(manager.updateAGITokenAddress.call(token.address, { from: owner }), "InvalidState");
+
+    await manager.cancelJob(0, { from: employer });
+    await manager.updateAGITokenAddress(token.address, { from: owner });
+
+    await manager.lockIdentityConfiguration({ from: owner });
+    await expectCustomError(manager.setEnsJobPages.call(ens.address, { from: owner }), "ConfigLocked");
+    assert.equal(await manager.lockIdentityConfig(), true);
+  });
+});

--- a/test/jobLifecycle.core.test.js
+++ b/test/jobLifecycle.core.test.js
@@ -1,0 +1,111 @@
+const assert = require("assert");
+const { expectRevert, time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+const { fundAgents, fundValidators } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager lifecycle core", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+      token.address,
+      "ipfs://base",
+      ens.address,
+      nameWrapper.address,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT,
+      ZERO_ROOT
+    ), { from: owner });
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 80, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.setVoteQuorum(2, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+
+    await fundAgents(token, manager, [agent], owner);
+    await fundValidators(token, manager, [validatorA, validatorB], owner);
+  });
+
+  async function createJob(payout, duration = 1000) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs://job", payout, duration, "details", { from: employer });
+    return tx.logs[0].args.jobId.toNumber();
+  }
+
+  it("validates create/apply/request/finalize transitions with challenge-window gating", async () => {
+    const payout = toBN(toWei("7"));
+    await expectCustomError(
+      manager.createJob.call("", payout, 1000, "details", { from: employer }),
+      "InvalidParameters"
+    );
+
+    const jobId = await createJob(payout, 1200);
+    assert.equal((await manager.lockedEscrow()).toString(), payout.toString());
+
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs://completion", { from: agent });
+
+    await manager.validateJob(jobId, "", EMPTY_PROOF, { from: validatorA });
+    await manager.validateJob(jobId, "", EMPTY_PROOF, { from: validatorB });
+
+    await expectCustomError(manager.finalizeJob.call(jobId, { from: employer }), "InvalidState");
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
+
+    const job = await manager.getJobCore(jobId);
+    assert.equal(job.completed, true, "job should settle as completed");
+    assert.equal((await manager.lockedEscrow()).toString(), "0", "escrow must unlock at terminal settlement");
+  });
+
+  it("forces dispute on tie/under-quorum and supports expiry path", async () => {
+    const payoutA = toBN(toWei("5"));
+    const payoutB = toBN(toWei("6"));
+    const tieJobId = await createJob(payoutA, 1000);
+    const expireJobId = await createJob(payoutB, 1);
+
+    await manager.applyForJob(tieJobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(tieJobId, "ipfs://c1", { from: agent });
+    await manager.validateJob(tieJobId, "", EMPTY_PROOF, { from: validatorA });
+    await manager.disapproveJob(tieJobId, "", EMPTY_PROOF, { from: validatorB });
+    await time.increase(2);
+    await manager.finalizeJob(tieJobId, { from: employer });
+    const tieJob = await manager.getJobCore(tieJobId);
+    assert.equal(tieJob.disputed, true, "under-quorum/tie should force dispute");
+
+    await manager.applyForJob(expireJobId, "", EMPTY_PROOF, { from: agent });
+    await time.increase(3);
+    await manager.expireJob(expireJobId, { from: employer });
+    const expired = await manager.getJobCore(expireJobId);
+    assert.equal(expired.expired, true, "expiry branch should mark job expired");
+  });
+});

--- a/test/pausing.accessControl.test.js
+++ b/test/pausing.accessControl.test.js
@@ -1,0 +1,48 @@
+const { expectRevert } = require("@openzeppelin/test-helpers");
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager pause & settlement pause access", (accounts) => {
+  const [owner, employer, agent] = accounts;
+
+  it("enforces whenNotPaused and settlement pause rules", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, wrapper.address, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT), { from: owner });
+    const nft = await MockERC721.new({ from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAGIType(nft.address, 80, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+
+    const payout = toBN(toWei("4"));
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.pause({ from: owner });
+    await expectRevert.unspecified(manager.createJob("ipfs://job", payout, 1000, "details", { from: employer }));
+
+    await manager.unpause({ from: owner });
+    const tx = await manager.createJob("ipfs://job", payout, 1000, "details", { from: employer });
+    const jobId = tx.logs[0].args.jobId.toNumber();
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+
+    await manager.setSettlementPaused(true, { from: owner });
+    await expectRevert.unspecified(manager.expireJob(jobId, { from: employer }));
+
+    await manager.pause({ from: owner });
+    await manager.setSettlementPaused(false, { from: owner });
+    await expectRevert.unspecified(manager.withdrawAGI(toBN(1), { from: owner }));
+  });
+});

--- a/test/validatorVoting.bonds.test.js
+++ b/test/validatorVoting.bonds.test.js
@@ -1,0 +1,89 @@
+const assert = require("assert");
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+const { fundAgents, fundValidators, computeValidatorBond } = require("./helpers/bonds");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+const EMPTY_PROOF = [];
+const { toBN, toWei } = web3.utils;
+
+contract("AGIJobManager validator voting and bonds", (accounts) => {
+  const [owner, employer, agent, validatorA, validatorB, validatorC] = accounts;
+  let token;
+  let manager;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+    manager = await AGIJobManager.new(...buildInitConfig(token.address, "ipfs://base", ens.address, nameWrapper.address, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT, ZERO_ROOT), { from: owner });
+
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 85, { from: owner });
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.addAdditionalValidator(validatorC, { from: owner });
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+    await manager.setVoteQuorum(2, { from: owner });
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+
+    await fundAgents(token, manager, [agent], owner);
+    await fundValidators(token, manager, [validatorA, validatorB, validatorC], owner);
+  });
+
+  async function createReadyJob(payout) {
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    const tx = await manager.createJob("ipfs://job", payout, 1000, "details", { from: employer });
+    const jobId = tx.logs[0].args.jobId.toNumber();
+    await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
+    await manager.requestJobCompletion(jobId, "ipfs://done", { from: agent });
+    return jobId;
+  }
+
+  it("prevents double-voting and keeps validator bond sizing consistent", async () => {
+    const payout = toBN(toWei("20"));
+    const jobId = await createReadyJob(payout);
+    const expectedBond = await computeValidatorBond(manager, payout);
+
+    await manager.validateJob(jobId, "", EMPTY_PROOF, { from: validatorA });
+    assert.equal((await manager.lockedValidatorBonds()).toString(), expectedBond.toString());
+
+    await expectCustomError(manager.validateJob.call(jobId, "", EMPTY_PROOF, { from: validatorA }), "InvalidState");
+
+    await manager.disapproveJob(jobId, "", EMPTY_PROOF, { from: validatorB });
+    assert.equal((await manager.lockedValidatorBonds()).toString(), expectedBond.muln(2).toString());
+  });
+
+  it("rewards a correct validator on finalize once quorum is met", async () => {
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setVoteQuorum(1, { from: owner });
+    const payout = toBN(toWei("30"));
+    const jobId = await createReadyJob(payout);
+
+    const balA0 = await token.balanceOf(validatorA);
+    const balB0 = await token.balanceOf(validatorB);
+    await manager.validateJob(jobId, "", EMPTY_PROOF, { from: validatorA });
+
+    await time.increase(2);
+    await manager.finalizeJob(jobId, { from: employer });
+
+    const balA1 = await token.balanceOf(validatorA);
+    const balB1 = await token.balanceOf(validatorB);
+    assert(balA1.gt(balA0), "correct validator should be rewarded");
+    assert.equal(balB1.toString(), balB0.toString(), "non-participating validator should be unchanged");
+  });
+});


### PR DESCRIPTION
### Motivation
- Improve mainnet‑grade assurance by adding deterministic, CI‑friendly tests that exercise lifecycle branches, validator voting, disputes, escrow invariants, pause/settlement gates, AGI type safety, ENS hooks, and identity‑config locking.
- Capture operational test plan and runbook mapping so operators/auditors can reproduce deterministic runs and understand which risks are covered.
- Keep production contracts unchanged while increasing test coverage to catch regressions early in CI.

### Description
- Added eight focused Truffle/Mocha suites under `test/` covering lifecycle, validator voting/bonds, moderator disputes, escrow accounting invariants, pausing/settlement access, AGI type safety, ENS hooks integration, and identity configuration locking.
- Updated `docs/TEST_PLAN.md` and `docs/TESTING.md` to include a “Mainnet‑grade deterministic expansion” section, a deterministic time‑travel policy, and a coverage matrix linking tests to risks.
- Tests use existing test helpers and repository mocks (no external RPC/ENS calls), `@openzeppelin/test-helpers` time helpers, and explicit BN math to ensure determinism.
- No production Solidity contract logic was modified; changes are limited to tests and documentation.

### Testing
- Ran compilation with `npm run build` (Truffle compile) and it completed successfully against pinned `solc 0.8.23`.
- Ran the new focused test set with `npx truffle test --network test` for the added suites (`test/jobLifecycle.core.test.js`, `test/validatorVoting.bonds.test.js`, `test/disputes.moderator.test.js`, `test/escrowAccounting.invariants.test.js`, `test/pausing.accessControl.test.js`, `test/agiTypes.safety.test.js`, `test/ensHooks.integration.test.js`, `test/identityConfig.locking.test.js`) and observed the suites pass (final run: `14 passing`).
- Performed bytecode size guard with `npm run size` which reports `AGIJobManager runtime bytecode size: 24574 bytes` (below the EIP‑170 cap).
- Executed linter via `npm run lint` as part of the verification run; no new contract changes were introduced that affect linter expectations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6ae20aa08333a42557972ed2545a)