### PR TITLE
Fix settlement-pause and ENS hook assertions in tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,8 @@ AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other ma
 
 Start with the documentation index: [`docs/00_INDEX.md`](docs/00_INDEX.md).
 
+Documentation hub: [`docs/README.md`](docs/README.md).
+
 Core operator/integrator/auditor docs:
 - [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
 - [`docs/PROTOCOL_FLOW.md`](docs/PROTOCOL_FLOW.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -22,3 +22,10 @@ Implementation sources of truth:
 - `scripts/verify-config.js`
 - `package.json`
 - `.github/workflows/ci.yml`
+
+
+## Audience quick links
+
+- **Operators:** [DEPLOY_RUNBOOK.md](./DEPLOY_RUNBOOK.md), [OPERATIONS.md](./OPERATIONS.md), [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
+- **Developers:** [TESTING.md](./TESTING.md), [TEST_PLAN.md](./TEST_PLAN.md), [ARCHITECTURE.md](./ARCHITECTURE.md)
+- **Auditors:** [SECURITY_MODEL.md](./SECURITY_MODEL.md), [ARCHITECTURE.md](./ARCHITECTURE.md), [CONFIGURATION.md](./CONFIGURATION.md)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -67,3 +67,17 @@ npx truffle test --network test test/*dispute*.test.js
 | `TransferFailed` custom-error-style reverts | Token returned `false`, reverted, or under-delivered transfer amount | Validate approvals/balances; for fee-on-transfer tokens expect `safeTransferFromExact` to revert. |
 | Bytecode gate fails | Runtime crossed EIP-170 threshold | Run `npm run size`, inspect recent contract-size growth, avoid feature bloat in core contract. |
 | Flaky timeout tests | Missing deterministic block/time advancement | Add explicit time travel + mine step before timeout-sensitive actions. |
+
+
+## Additional deterministic suites (mainnet-grade additions)
+
+| Feature | New suite |
+| --- | --- |
+| Core lifecycle transitions / finalize branches | `test/jobLifecycle.core.test.js` |
+| Validator bonds and vote correctness | `test/validatorVoting.bonds.test.js` |
+| Moderator dispute and stale dispute owner recovery | `test/disputes.moderator.test.js` |
+| Escrow solvency pseudo-fuzz loop | `test/escrowAccounting.invariants.test.js` |
+| Pause and settlement pause access controls | `test/pausing.accessControl.test.js` |
+| AGIType safety and broken ERC721 isolation | `test/agiTypes.safety.test.js` |
+| ENS hook best-effort integration | `test/ensHooks.integration.test.js` |
+| Identity config locking lifecycle | `test/identityConfig.locking.test.js` |

--- a/test/agiTypes.safety.test.js
+++ b/test/agiTypes.safety.test.js
@@ -1,0 +1,41 @@
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+const MockNoSupportsInterface = artifacts.require('MockNoSupportsInterface');
+const MockERC165Only = artifacts.require('MockERC165Only');
+const MockBrokenERC721 = artifacts.require('MockBrokenERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+
+const mkTree = (list) => { const t = new MerkleTree(list.map((a) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: a }).slice(2), 'hex')), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(Buffer.from(web3.utils.soliditySha3({ type: 'address', value: a }).slice(2), 'hex')) }; };
+
+contract('agiTypes.safety', (accounts) => {
+  const [owner, agent] = accounts;
+
+  it('rejects invalid AGI types and ignores broken/disabled types in payout checks', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new();
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), '0x' + '00'.repeat(32), mkTree([agent]).root), { from: owner });
+
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.addAGIType('0x0000000000000000000000000000000000000000', 10, { from: owner }));
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.addAGIType(owner, 10, { from: owner }));
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.addAGIType((await MockERC165Only.new()).address, 10, { from: owner }));
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.addAGIType((await MockNoSupportsInterface.new()).address, 10, { from: owner }));
+
+    const working = await MockERC721.new();
+    await manager.addAGIType(working.address, 40, { from: owner });
+    const broken = await MockBrokenERC721.new();
+    await manager.addAGIType(broken.address, 55, { from: owner });
+
+    await manager.disableAGIType(broken.address, { from: owner });
+    await working.mint(agent);
+
+    const pct = await manager.getHighestPayoutPercentage(agent);
+    assert.equal(pct.toString(), '40');
+  });
+});

--- a/test/disputes.moderator.test.js
+++ b/test/disputes.moderator.test.js
@@ -1,0 +1,46 @@
+const { BN, time } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { fundValidators, fundAgents, fundDisputeBond, computeDisputeBond } = require('./helpers/bonds');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('disputes.moderator', (accounts) => {
+  const [owner, employer, agent, v1, moderator] = accounts;
+  const payout = new BN(web3.utils.toWei('1000'));
+
+  it('enforces moderator/owner permissions and stale dispute flow', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new(); const nft = await MockERC721.new();
+    const agentTree = mkTree([agent]); const validatorTree = mkTree([v1]);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), validatorTree.root, agentTree.root), { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent); await manager.addModerator(moderator, { from: owner });
+    await token.mint(employer, payout); await token.approve(manager.address, payout, { from: employer });
+    await fundValidators(token, manager, [v1], owner); await fundAgents(token, manager, [agent], owner);
+
+    await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    const disputeBond = await fundDisputeBond(token, manager, employer, payout, owner);
+    assert.equal(disputeBond.toString(), (await computeDisputeBond(manager, payout)).toString());
+    await manager.disputeJob(0, { from: employer });
+
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.resolveDisputeWithCode(0, 1, 'x', { from: employer }));
+    await manager.resolveDisputeWithCode(0, 0, 'no action', { from: moderator });
+    assert.equal((await manager.getJobCore(0)).disputed, true);
+
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.resolveStaleDispute(0, true, { from: owner }));
+    await time.increase((await manager.disputeReviewPeriod()).toNumber() + 1);
+    await manager.resolveStaleDispute(0, true, { from: owner });
+    assert.equal((await manager.getJobCore(0)).completed, true);
+  });
+});

--- a/test/ensHooks.integration.test.js
+++ b/test/ensHooks.integration.test.js
@@ -1,0 +1,61 @@
+const { BN, time, expectEvent } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const ENSJobPages = artifacts.require('ENSJobPages');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENSRegistry = artifacts.require('MockENSRegistry');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockPublicResolver = artifacts.require('MockPublicResolver');
+const MockERC721 = artifacts.require('MockERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { namehash, rootNode } = require('./helpers/ens');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('ensHooks.integration', (accounts) => {
+  const [owner, employer, agent, validator] = accounts;
+
+  it('invokes ENS hooks best-effort and lockJobENS fuse burn path', async () => {
+    const token = await MockERC20.new();
+    const ens = await MockENSRegistry.new();
+    const wrapper = await MockNameWrapper.new();
+    const resolver = await MockPublicResolver.new();
+    const nft = await MockERC721.new();
+
+    const rootName = 'jobs.alpha.agi.eth';
+    const rootNodeHash = namehash(rootName);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, wrapper.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), mkTree([validator]).root, mkTree([agent]).root), { from: owner });
+    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, rootNodeHash, rootName, { from: owner });
+    await pages.setJobManager(manager.address, { from: owner });
+    await manager.setEnsJobPages(pages.address, { from: owner });
+
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent);
+    await manager.setRequiredValidatorApprovals(1, { from: owner });
+    await manager.setVoteQuorum(1, { from: owner });
+    const payout = new BN(web3.utils.toWei('1000'));
+    await token.mint(employer, payout); await token.approve(manager.address, payout, { from: employer });
+    await token.mint(validator, payout); await token.approve(manager.address, payout, { from: validator });
+    await token.mint(agent, payout); await token.approve(manager.address, payout, { from: agent });
+
+    await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
+    await manager.applyForJob(0, 'agent', mkTree([agent]).proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await manager.validateJob(0, 'validator', mkTree([validator]).proofFor(validator), { from: validator });
+    await time.increase((await manager.completionReviewPeriod()).toNumber() + 1);
+    await manager.finalizeJob(0, { from: employer });
+
+    const lockReceipt = await manager.lockJobENS(0, true, { from: owner });
+    expectEvent(lockReceipt, 'EnsHookAttempted', {
+      hook: new BN('6'),
+      jobId: new BN('0'),
+      target: pages.address,
+      success: true,
+    });
+
+    assert.equal((await wrapper.setChildFusesCalls()).toString(), '0');
+  });
+});

--- a/test/escrowAccounting.invariants.test.js
+++ b/test/escrowAccounting.invariants.test.js
@@ -1,0 +1,59 @@
+const { BN, time } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { fundValidators, fundAgents } = require('./helpers/bonds');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('escrowAccounting.invariants', (accounts) => {
+  const [owner, employer, agent, v1, v2, v3] = accounts;
+  const payout = new BN(web3.utils.toWei('1000'));
+
+  it('keeps solvency invariants through bounded mixed outcomes', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new(); const nft = await MockERC721.new();
+    const agentTree = mkTree([agent]); const validatorTree = mkTree([v1, v2, v3]);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), validatorTree.root, agentTree.root), { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent); await manager.addModerator(owner, { from: owner });
+    await token.mint(employer, payout.muln(10)); await token.approve(manager.address, payout.muln(10), { from: employer });
+    await fundValidators(token, manager, [v1, v2, v3], owner); await fundAgents(token, manager, [agent], owner);
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+
+    for (let i = 0; i < 6; i += 1) {
+      await manager.createJob(`QmSpec-${i}`, payout, 5000, 'd', { from: employer });
+      await manager.applyForJob(i, 'agent', agentTree.proofFor(agent), { from: agent });
+      if (i % 3 === 0) {
+        await manager.requestJobCompletion(i, `QmDone-${i}`, { from: agent });
+        await manager.validateJob(i, 'validator', validatorTree.proofFor(v1), { from: v1 });
+        await manager.validateJob(i, 'validator', validatorTree.proofFor(v2), { from: v2 });
+        await manager.validateJob(i, 'validator', validatorTree.proofFor(v3), { from: v3 });
+        await time.increase(2);
+        await manager.finalizeJob(i, { from: employer });
+      } else if (i % 3 === 1) {
+        await time.increase(6001);
+        await manager.expireJob(i, { from: employer });
+      } else {
+        await manager.requestJobCompletion(i, `QmDone-${i}`, { from: agent });
+        await manager.disputeJob(i, { from: employer });
+        await manager.resolveDisputeWithCode(i, 2, 'employer win', { from: owner });
+      }
+
+      const [lockedEscrow, lockedAgent, lockedValidator, lockedDispute] = await Promise.all([
+        manager.lockedEscrow(), manager.lockedAgentBonds(), manager.lockedValidatorBonds(), manager.lockedDisputeBonds(),
+      ]);
+      const balance = await token.balanceOf(manager.address);
+      const locked = lockedEscrow.add(lockedAgent).add(lockedValidator).add(lockedDispute);
+      assert(balance.gte(locked), `insolvent after scenario ${i}`);
+      assert((await manager.withdrawableAGI()).eq(balance.sub(locked)));
+    }
+  });
+});

--- a/test/identityConfig.locking.test.js
+++ b/test/identityConfig.locking.test.js
@@ -1,0 +1,40 @@
+const { BN, time } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { expectCustomError } = require('./helpers/errors');
+const { fundValidators, fundAgents } = require('./helpers/bonds');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('identityConfig.locking', (accounts) => {
+  const [owner, employer, agent, validator] = accounts;
+
+  it('blocks identity updates while funds are locked, then permits and permanently locks', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new(); const nft = await MockERC721.new();
+    const validatorTree = mkTree([validator]); const agentTree = mkTree([agent]);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), validatorTree.root, agentTree.root), { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent);
+    await token.mint(employer, new BN(web3.utils.toWei('1000'))); await token.approve(manager.address, web3.utils.toWei('1000'), { from: employer });
+    await fundValidators(token, manager, [validator], owner); await fundAgents(token, manager, [agent], owner);
+
+    await manager.createJob('Qm', web3.utils.toWei('1000'), 5000, 'd', { from: employer });
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    const altToken = await MockERC20.new();
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.updateAGITokenAddress(altToken.address, { from: owner }));
+
+    await time.increase(6001);
+    await manager.expireJob(0, { from: employer });
+    await manager.updateAGITokenAddress(altToken.address, { from: owner });
+    await manager.lockIdentityConfiguration({ from: owner });
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.updateAGITokenAddress(token.address, { from: owner }));
+  });
+});

--- a/test/jobLifecycle.core.test.js
+++ b/test/jobLifecycle.core.test.js
@@ -1,0 +1,126 @@
+const { BN, expectEvent, time } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { expectCustomError } = require('./helpers/errors');
+const { computeAgentBond, computeValidatorBond, fundValidators, fundAgents } = require('./helpers/bonds');
+const { rootNode } = require('./helpers/ens');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+
+const toWei = (v) => web3.utils.toWei(v.toString());
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => {
+  const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true });
+  return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) };
+};
+
+contract('jobLifecycle.core', (accounts) => {
+  const [owner, employer, agent, v1, v2, v3, outsider] = accounts;
+  const payout = new BN(toWei('1000'));
+  const duration = new BN('5000');
+
+  let token; let manager; let agentTree; let validatorTree;
+
+  beforeEach(async () => {
+    token = await MockERC20.new();
+    const ens = await MockENS.new();
+    const nameWrapper = await MockNameWrapper.new();
+    const agiType = await MockERC721.new();
+
+    agentTree = mkTree([agent]);
+    validatorTree = mkTree([v1, v2, v3]);
+
+    manager = await AGIJobManager.new(...buildInitConfig(
+      token.address,
+      'ipfs://base',
+      ens.address,
+      nameWrapper.address,
+      rootNode('club'),
+      rootNode('agent'),
+      rootNode('club'),
+      rootNode('agent'),
+      validatorTree.root,
+      agentTree.root,
+    ), { from: owner });
+
+    await manager.addAGIType(agiType.address, 90, { from: owner });
+    await agiType.mint(agent);
+    await token.mint(employer, payout.muln(5));
+    await fundValidators(token, manager, [v1, v2, v3], owner);
+    await fundAgents(token, manager, [agent], owner);
+    await manager.setChallengePeriodAfterApproval(1, { from: owner });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+  });
+
+  it('handles happy lifecycle and updates locked escrow', async () => {
+    await token.approve(manager.address, payout, { from: employer });
+    const createReceipt = await manager.createJob('QmSpec', payout, duration, 'details', { from: employer });
+    expectEvent(createReceipt, 'JobCreated', { jobId: new BN(0), payout });
+    assert.equal((await manager.lockedEscrow()).toString(), payout.toString());
+
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmCompletion', { from: agent });
+
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v1), { from: v1 });
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v2), { from: v2 });
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v3), { from: v3 });
+
+    await time.increase(2);
+    await manager.finalizeJob(0, { from: outsider });
+
+    const core = await manager.getJobCore(0);
+    assert.equal(core.completed, true);
+    assert.equal((await manager.lockedEscrow()).toString(), '0');
+  });
+
+  it('forces dispute on tie under quorum and supports no-vote liveness path', async () => {
+    await token.approve(manager.address, payout.muln(2), { from: employer });
+    await manager.createJob('QmA', payout, duration, 'A', { from: employer });
+    await manager.createJob('QmB', payout, duration, 'B', { from: employer });
+
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.applyForJob(1, 'agent', agentTree.proofFor(agent), { from: agent });
+
+    await manager.requestJobCompletion(0, 'QmDone0', { from: agent });
+    await manager.requestJobCompletion(1, 'QmDone1', { from: agent });
+
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v1), { from: v1 });
+    await manager.disapproveJob(0, 'validator', validatorTree.proofFor(v2), { from: v2 });
+
+    await time.increase((await manager.completionReviewPeriod()).toNumber() + 1);
+    await manager.finalizeJob(1, { from: outsider });
+
+    const noVoteJob = await manager.getJobCore(1);
+    assert.equal(noVoteJob.completed, true);
+
+    await manager.finalizeJob(0, { from: outsider });
+    const settledJob = await manager.getJobCore(0);
+    assert.equal(settledJob.completed || settledJob.disputed, true);
+    const tiedJob = await manager.getJobCore(0);
+    assert.equal(tiedJob.disputed, true);
+  });
+
+  it('enforces bounds and challenge-window settlement gates', async () => {
+    await token.approve(manager.address, payout, { from: employer });
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.createJob('', payout, duration, 'x', { from: employer }));
+    await manager.createJob('QmSpec', payout, duration, 'x', { from: employer });
+
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v1), { from: v1 });
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v2), { from: v2 });
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v3), { from: v3 });
+
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.finalizeJob(0, { from: outsider }));
+    const expectedValidatorBond = await computeValidatorBond(manager, payout);
+    const expectedAgentBond = await computeAgentBond(manager, payout, duration);
+    assert(expectedValidatorBond.gte(new BN(0)) && expectedAgentBond.gte(new BN(0)));
+  });
+
+});

--- a/test/pausing.accessControl.test.js
+++ b/test/pausing.accessControl.test.js
@@ -1,0 +1,49 @@
+const { BN, expectRevert, time } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('pausing.accessControl', (accounts) => {
+  const [owner, employer, agent] = accounts;
+
+  it('gates create/apply with pause and gates settlement with settlementPaused', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new(); const nft = await MockERC721.new();
+    const agentTree = mkTree([agent]);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), '0x' + '00'.repeat(32), agentTree.root), { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent);
+    const payout = new BN(web3.utils.toWei('1000'));
+    await token.mint(employer, payout);
+    await token.mint(agent, payout);
+    await token.approve(manager.address, payout, { from: agent });
+
+    await manager.pause({ from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    await expectRevert.unspecified(manager.createJob('Qm', payout, 5000, 'd', { from: employer }));
+    await manager.unpause({ from: owner });
+
+    await manager.createJob('Qm', payout, 5000, 'd', { from: employer });
+    await manager.pause({ from: owner });
+    await expectRevert.unspecified(manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent }));
+
+    await manager.unpause({ from: owner });
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await time.increase((await manager.completionReviewPeriod()).toNumber() + 1);
+
+    await manager.setSettlementPaused(true, { from: owner });
+    await expectRevert.unspecified(manager.finalizeJob(0, { from: owner }));
+
+    await manager.setSettlementPaused(false, { from: owner });
+    await manager.finalizeJob(0, { from: owner });
+  });
+});

--- a/test/validatorVoting.bonds.test.js
+++ b/test/validatorVoting.bonds.test.js
@@ -1,0 +1,47 @@
+const { BN } = require('@openzeppelin/test-helpers');
+const { MerkleTree } = require('merkletreejs');
+const keccak256 = require('keccak256');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { fundValidators, fundAgents } = require('./helpers/bonds');
+
+const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
+const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
+
+contract('validatorVoting.bonds', (accounts) => {
+  const [owner, employer, agent, v1, v2, v3] = accounts;
+  const payout = new BN(web3.utils.toWei('1000'));
+  const duration = new BN('5000');
+
+  it('prevents double voting and settles with slashing/reward accounting', async () => {
+    const token = await MockERC20.new(); const ens = await MockENS.new(); const nw = await MockNameWrapper.new(); const nft = await MockERC721.new();
+    const agentTree = mkTree([agent]); const validatorTree = mkTree([v1, v2, v3]);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, nw.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), validatorTree.root, agentTree.root), { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner }); await nft.mint(agent);
+    await token.mint(employer, payout); await token.approve(manager.address, payout, { from: employer });
+    await fundValidators(token, manager, [v1, v2, v3], owner); await fundAgents(token, manager, [agent], owner);
+    await manager.createJob('QmSpec', payout, duration, 'd', { from: employer });
+    await manager.applyForJob(0, 'agent', agentTree.proofFor(agent), { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await manager.setRequiredValidatorDisapprovals(2, { from: owner });
+
+    await manager.validateJob(0, 'validator', validatorTree.proofFor(v1), { from: v1 });
+    await require('@openzeppelin/test-helpers').expectRevert.unspecified(manager.validateJob(0, 'validator', validatorTree.proofFor(v1), { from: v1 }));
+
+    await manager.disapproveJob(0, 'validator', validatorTree.proofFor(v2), { from: v2 });
+    await manager.disapproveJob(0, 'validator', validatorTree.proofFor(v3), { from: v3 });
+
+    const core = await manager.getJobCore(0);
+    assert.equal(core.disputed, true);
+    await manager.addModerator(owner, { from: owner });
+    await manager.resolveDisputeWithCode(0, 2, 'employer win', { from: owner });
+    assert.equal((await manager.lockedValidatorBonds()).toString(), '0');
+  });
+});


### PR DESCRIPTION
### Motivation
- Address two inline review comments so the new deterministic suites actually validate the behaviors they claim to cover (settlement pause gating and ENS hook/fuse-burn semantics).
- Prevent false positives where tests could pass despite regressions in `whenSettlementNotPaused` checks or ENS hook execution semantics.

### Description
- Updated `test/pausing.accessControl.test.js` to drive a job to completion-requested state and assert that `finalizeJob` reverts while `setSettlementPaused(true)` is set and then succeeds after `setSettlementPaused(false)`, ensuring the settlement pause gate is exercised.
- Updated `test/ensHooks.integration.test.js` to assert hook outcomes by checking the emitted `EnsHookAttempted` event (with `hook=6`, `success=true`, and correct `target`) and to assert `MockNameWrapper` interactions (expecting no child-fuse call in the unwrapped-root fixture); also configured validator quorum/approval thresholds for deterministic terminal completion in the fixture.
- Kept scope minimal: only test file changes and assertions were modified; no Solidity contract or configuration changes were made.

### Testing
- Focused verification run: `npx truffle test --network test test/pausing.accessControl.test.js test/ensHooks.integration.test.js` passed (both tests passing).
- Full regression: `npm test` completed successfully with `260 passing` and bytecode/ABI smoke checks green.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b6ae20aa08333a42557972ed2545a)