### PR TITLE
docs: add deterministic test coverage map and local validation snapshot

### DIFF
--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -81,3 +81,18 @@ npx truffle test --network test test/*dispute*.test.js
 | AGIType safety and broken ERC721 isolation | `test/agiTypes.safety.test.js` |
 | ENS hook best-effort integration | `test/ensHooks.integration.test.js` |
 | Identity config locking lifecycle | `test/identityConfig.locking.test.js` |
+
+
+## Coverage map (feature → suite)
+
+| Feature area | Primary suite(s) |
+| --- | --- |
+| Job lifecycle state transitions | `test/jobLifecycle.core.test.js`, `test/livenessTimeouts.test.js`, `test/jobStatus.test.js` |
+| Escrow + bond accounting invariants | `test/escrowAccounting.invariants.test.js`, `test/escrowAccounting.test.js`, `test/invariants.solvency.test.js` |
+| Validator voting, quorum, and challenge windows | `test/validatorVoting.bonds.test.js`, `test/validatorCap.test.js`, `test/livenessTimeouts.test.js` |
+| Disputes + stale dispute recovery | `test/disputes.moderator.test.js`, `test/disputeHardening.test.js` |
+| Pause + settlement pause controls | `test/pausing.accessControl.test.js`, `test/adminOps.test.js` |
+| AGIType ERC721 gating safety | `test/agiTypes.safety.test.js`, `test/agentPayoutSnapshot.truffle.test.js` |
+| ENS hook integration + fuse lock path | `test/ensHooks.integration.test.js`, `test/ensJobPagesHooks.test.js`, `test/ensJobPagesHelper.test.js` |
+| Identity lock and wiring freeze semantics | `test/identityConfig.locking.test.js`, `test/adminOps.test.js` |
+| Merkle/ENS access control and namespace checks | `test/merkleAllowlist.test.js`, `test/namespaceAlpha.test.js`, `test/deploymentWiring.test.js` |

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -33,3 +33,21 @@ When changing settlement, bonds, pauses, AGIType checks, or ENS hooks:
 - Update the corresponding new suite(s) above.
 - Re-run `npm run build`, `npm run size`, `npm run lint`, `npm test`.
 - Confirm bytecode size guard remains below EIP-170 threshold.
+
+
+## Validation snapshot (local)
+
+Commands executed for deterministic CI-parity validation:
+
+```bash
+npm install
+npm run lint
+npm run build
+npm run size
+npm test
+```
+
+Observed results:
+- Compile succeeded with pinned `solc 0.8.23`.
+- Bytecode guard reported `AGIJobManager runtime bytecode size: 24574 bytes` (below EIP-170 cap).
+- Full deterministic test suite passed (`260 passing`).


### PR DESCRIPTION
### Motivation
- Make test intent and risk coverage explicit so operators, integrators, and auditors can trace protocol risks to deterministic test suites without changing contract behavior.

### Description
- Add a feature→suite coverage map to `docs/TESTING.md` linking high‑risk areas (lifecycle, escrow/bonds, voting, disputes, pausing, AGIType safety, ENS hooks, identity locking, Merkle/ENS gating) to concrete test files. (`docs/TESTING.md`)
- Add a local CI‑parity validation snapshot to `docs/TEST_PLAN.md` documenting the canonical commands and observed outcomes (compile, bytecode size, full test pass count). (`docs/TEST_PLAN.md`)
- Scope is docs-only; no Solidity or runtime behavior changes were made.

### Testing
- Commands executed: `npm install`, `npm run lint`, `npm run build`, `npm run size`, `npm test` (as per `package.json`/CI runbook). 
- Results observed: compilation succeeded with `solc 0.8.23`, bytecode guard reported `AGIJobManager runtime bytecode size: 24574 bytes`, and the full deterministic test suite completed successfully (`260 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b8d20fcdc83339e64c9397e66b203)