### PR TITLE
docs: streamline README quickstart and docs navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,19 +140,7 @@ flowchart LR
 | **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
 | **Validator** | Approve/disapprove jobs, earn payout share and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
 
-## Quick start (dev)
-
-```bash
-npm install
-```
-
-```bash
-npm run build
-```
-
-```bash
-npm test
-```
+## Developer testing references
 
 Testing runbooks and coverage planning:
 - [`docs/TESTING.md`](docs/TESTING.md)


### PR DESCRIPTION
### Motivation
- Align the README quickstart with the repository's canonical scripts and remove a duplicated conflicting quickstart block while preserving links to deeper testing/runbook docs.

### Description
- Remove the duplicate `Quick start (dev)` command block from `README.md`, retain the canonical `Quickstart` section (`npm install`, `npm run build`, `npm run test`), and rename the removed block to `Developer testing references` so testing/runbook links remain discoverable; change is limited to `README.md`.

### Testing
- Verified repository build and checks by running `npm install`, `npm run build`, `npm run test` (full suite: `260 passing`), `npm run lint`, and `npm run size`, all of which completed successfully, and re-ran `npm run build` and `npm run test` after the doc edit (again `260 passing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b981fed508333ba0f4da651448026)