### PR TITLE
docs: add repository baseline and strengthen deploy runbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Core operator/integrator/auditor docs:
 - [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
 - [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
 - [`docs/GLOSSARY.md`](docs/GLOSSARY.md)
+- [`docs/REPOSITORY_BASELINE.md`](docs/REPOSITORY_BASELINE.md)
 
 ## Quickstart
 

--- a/docs/00_INDEX.md
+++ b/docs/00_INDEX.md
@@ -3,6 +3,7 @@
 Audience tags: **Operator / Owner**, **Integrator**, **Developer**, **Auditor**.
 
 ## Core protocol docs
+- [Repository Baseline](./REPOSITORY_BASELINE.md) — grounded inventory of scripts, deployment files, tests, and verified local commands. *(Operator / Developer / Auditor)*
 - [Architecture](./ARCHITECTURE.md) — system components, lifecycle, state model, trust boundaries. *(Operator / Integrator / Auditor)*
 - [Protocol Flow](./PROTOCOL_FLOW.md) — escrow accounting, bonds, validator voting, disputes, event map. *(Operator / Auditor / Developer)*
 - [Configuration](./CONFIGURATION.md) — owner-settable parameters, constraints, role matrix, identity lock behavior. *(Operator / Auditor)*

--- a/docs/DEPLOY_RUNBOOK.md
+++ b/docs/DEPLOY_RUNBOOK.md
@@ -20,6 +20,22 @@
 - Max payout and duration limits.
 - Validation reward and AGI type payout tiers.
 
+### Environment variables used by migration/config scripts
+`migrations/deploy-config.js` and `scripts/postdeploy-config.js` consume these variables when set:
+
+| Variable | Purpose | Required? |
+|---|---|---|
+| `AGI_TOKEN_ADDRESS` | AGI ERC20 address wired into constructor or updater | Required on non-mainnet; optional override on mainnet |
+| `AGI_ENS_REGISTRY` | ENS registry address | Required on non-mainnet; optional override on mainnet |
+| `AGI_NAMEWRAPPER` | NameWrapper address | Required on non-mainnet; optional override on mainnet |
+| `AGI_CLUB_ROOT_NODE` / `AGI_AGENT_ROOT_NODE` | Base namespace roots for validator/agent gating | Required on non-mainnet; optional override on mainnet |
+| `AGI_ALPHA_CLUB_ROOT_NODE` / `AGI_ALPHA_AGENT_ROOT_NODE` | Alpha namespace roots | Required on non-mainnet; optional override on mainnet |
+| `AGI_VALIDATOR_MERKLE_ROOT` / `AGI_AGENT_MERKLE_ROOT` | Optional membership roots | Optional (defaults exist in deploy config) |
+| `AGI_BASE_IPFS_URL` | Base URI prefix for scheme-less token metadata | Optional |
+| `LOCK_IDENTITY_CONFIG` or `LOCK_CONFIG` | Lock identity configuration immediately after deploy | Optional (`true`/`false`) |
+| `AGIJOBMANAGER_ADDRESS` | Target manager address for postdeploy/verify scripts | Required for postdeploy + verify runs |
+
+
 ### ENS ownership requirements
 - If root is unwrapped: ENS root owner must allow contract to set subnode records.
 - If root is wrapped: wrapper owner must be contract or grant `isApprovedForAll`.
@@ -55,6 +71,13 @@ Verify configured state:
 ```bash
 truffle exec scripts/verify-config.js --network <network> --address <AGIJOBMANAGER_ADDRESS>
 ```
+
+
+### Expected outputs / checkpoints
+- `truffle migrate` logs **"AGIJobManager deployment summary"** with token, ENS, NameWrapper, root nodes, and lock status.
+- `truffle exec scripts/postdeploy-config.js ...` logs each applied change and exits with code `0` on success.
+- `truffle exec scripts/verify-config.js ...` prints `PASS`/`FAIL` style checks per field and should end with no failures for a clean deployment.
+- `npm run size` should report `AGIJobManager` at or below the EIP-170 runtime limit.
 
 ## 3) Post-deploy config checklist
 - [ ] Set validator thresholds/quorum.

--- a/docs/REPOSITORY_BASELINE.md
+++ b/docs/REPOSITORY_BASELINE.md
@@ -1,0 +1,51 @@
+# Repository Baseline (HEAD Grounding)
+
+This document records the repository inventory and executable command surface as of current `HEAD`.
+
+## Repository inventory
+
+- **Core contracts**
+  - `contracts/AGIJobManager.sol`
+  - `contracts/ens/ENSJobPages.sol`
+  - `contracts/utils/*.sol`
+- **Deployment**
+  - `migrations/2_deploy_contracts.js`
+  - `migrations/deploy-config.js`
+  - `scripts/postdeploy-config.js`
+  - `scripts/verify-config.js`
+- **Tests**
+  - `test/*.test.js` (Truffle/Mocha suites)
+  - `test/AGIJobManager.test.js` (node-executed test entry used in `npm run test`)
+  - `ui-tests/` (UI ABI and smoke checks)
+- **CI workflow**
+  - `.github/workflows/ci.yml`
+
+## package.json scripts (source of truth)
+
+| Purpose | Command | Backing script |
+|---|---|---|
+| Install dependencies | `npm install` | npm default install behavior |
+| Compile/build | `npm run build` | `truffle compile` |
+| Full canonical test pipeline | `npm run test` | `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js` |
+| Lint Solidity | `npm run lint` | `solhint "contracts/**/*.sol"` |
+| Bytecode size check | `npm run size` | `node scripts/check-bytecode-size.js` |
+
+## Deployment command surface
+
+- `truffle migrate --network <network>` runs `migrations/2_deploy_contracts.js` and constructor wiring from `migrations/deploy-config.js`.
+- Post-deploy configuration and verification:
+  - `truffle exec scripts/postdeploy-config.js --network <network> --address <AGIJOBMANAGER_ADDRESS>`
+  - `truffle exec scripts/verify-config.js --network <network> --address <AGIJOBMANAGER_ADDRESS>`
+
+## Local verification executed
+
+The following commands were run locally against this repository state:
+
+1. `npm install`
+2. `npm run build`
+3. `npm run test`
+
+Observed results:
+- Build completed successfully on `solc 0.8.23` (Truffle compiler pin).
+- Full test pipeline passed (`260 passing`).
+- `scripts/check-contract-sizes.js` reported `AGIJobManager deployedBytecode size: 24574 bytes`.


### PR DESCRIPTION
### Motivation
- Provide a single, HEAD‑accurate reference that inventories the repository (contracts, scripts, tests, CI) so operators, integrators and auditors can ground runbook actions against the actual code. 
- Reduce deployment/operator friction and make deploy-day checks auditable by documenting the exact env vars consumed by migration/config scripts and the expected outputs to verify success.

### Description
- Add `docs/REPOSITORY_BASELINE.md` containing a grounded inventory, the `package.json` command surface, deployment command surface, and a short record of locally-executed verification steps. 
- Update the documentation index and README to link the new baseline (`docs/00_INDEX.md` and `README.md`) so audiences can find the grounding doc from the top-level docs list. 
- Strengthen `docs/DEPLOY_RUNBOOK.md` by adding an explicit table of environment variables consumed by `migrations/deploy-config.js` / `scripts/postdeploy-config.js` and an "Expected outputs / checkpoints" section that lists operator-visible success signals. 
- No Solidity contracts, compiler configuration, migrations, or runtime code were modified; changes are additive docs only.

### Testing
- Ran `npm install` which completed successfully. 
- Ran `npm run build` (Truffle compile) which completed successfully using `solc 0.8.23`. 
- Ran the full test pipeline via `npm run test` and observed the suite pass with `260 passing`. 
- Ran `npm run size` and observed `AGIJobManager runtime bytecode size: 24574 bytes` (within the documented EIP‑170 guidance). 
- Ran `npm run lint` (`solhint`) which executed to completion (npm emitted non‑fatal update‑check warnings but lint ran).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b981fed508333ba0f4da651448026)