### PR TITLE
docs: add repository inventory and streamline top-level docs navigation

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ Core operator/integrator/auditor docs:
 - [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
 - [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
 - [`docs/GLOSSARY.md`](docs/GLOSSARY.md)
+- [`docs/REPOSITORY_INVENTORY.md`](docs/REPOSITORY_INVENTORY.md)
 
 ## Quickstart
 
@@ -139,32 +140,6 @@ flowchart LR
 | **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
 | **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
 | **Validator** | Approve/disapprove jobs, earn payout share and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
-
-## Quick start (dev)
-
-```bash
-npm install
-```
-
-```bash
-npm run build
-```
-
-```bash
-npm test
-```
-
-Testing runbooks and coverage planning:
-- [`docs/TESTING.md`](docs/TESTING.md)
-- [`docs/TEST_PLAN.md`](docs/TEST_PLAN.md)
-- [`docs/ARCHITECTURE_TESTS.md`](docs/ARCHITECTURE_TESTS.md)
-
-Additional verified checks:
-
-```bash
-npm run lint
-npm run size
-```
 
 ## Deploy & Ops
 

--- a/docs/00_INDEX.md
+++ b/docs/00_INDEX.md
@@ -14,6 +14,7 @@ Audience tags: **Operator / Owner**, **Integrator**, **Developer**, **Auditor**.
 ## Operations docs
 - [Deploy Runbook](./DEPLOY_RUNBOOK.md) — pre-deploy checklist, exact migration/config scripts, smoke tests, lockdown steps. *(Operator / Owner)*
 - [Testing Guide](./TESTING.md) — how CI and local test checks are executed. *(Developer / Auditor)*
+- [Repository Inventory](./REPOSITORY_INVENTORY.md) — codebase map, script inventory, and verified command list at HEAD. *(Operator / Developer / Auditor)*
 
 ## Source-of-truth implementation files
 - `contracts/AGIJobManager.sol`

--- a/docs/README.md
+++ b/docs/README.md
@@ -12,6 +12,7 @@ Primary operator/auditor references:
 - [Security Model](./SECURITY_MODEL.md)
 - [Troubleshooting](./TROUBLESHOOTING.md)
 - [Glossary](./GLOSSARY.md)
+- [Repository Inventory](./REPOSITORY_INVENTORY.md)
 
 Implementation sources of truth:
 - `contracts/AGIJobManager.sol`

--- a/docs/REPOSITORY_INVENTORY.md
+++ b/docs/REPOSITORY_INVENTORY.md
@@ -1,0 +1,62 @@
+# Repository Inventory and Verified Commands
+
+This file documents the current repository surface at HEAD and the canonical local/CI commands that were verified against the codebase.
+
+## 1) Repository map (implementation-focused)
+
+| Area | Path(s) | Notes |
+|---|---|---|
+| Core contract | `contracts/AGIJobManager.sol` | Escrow, lifecycle, voting, disputes, NFT issuance, owner controls |
+| ENS integration | `contracts/ens/ENSJobPages.sol` + `contracts/ens/I*.sol` | Optional ENS hook target used by AGIJobManager best-effort calls |
+| Utility libraries | `contracts/utils/*.sol` | `BondMath`, `ReputationMath`, `ENSOwnership`, `TransferUtils`, `UriUtils` |
+| Deployment | `migrations/2_deploy_contracts.js`, `migrations/deploy-config.js` | Truffle deployment + network/environment wiring |
+| Post-deploy scripts | `scripts/postdeploy-config.js`, `scripts/verify-config.js` | Configure and verify runtime settings |
+| Bytecode checks | `scripts/check-bytecode-size.js`, `scripts/check-contract-sizes.js` | EIP-170 safety checks |
+| Interface docs generator | `scripts/generate-interface-doc.js` | Re-generates interface documentation |
+| Test suites | `test/*.js`, `ui-tests/*.js` | Contract behavior, invariants, ENS hooks, economic/security regressions, UI smoke |
+| CI pipeline | `.github/workflows/ci.yml` | Install, lint, build, size, test, UI smoke |
+
+## 2) package.json scripts (canonical commands)
+
+| Purpose | Script name | Exact command |
+|---|---|---|
+| Build/compile | `build` | `truffle compile` |
+| Runtime size gate | `size` | `node scripts/check-bytecode-size.js` |
+| Interface docs | `docs:interface` | `node scripts/generate-interface-doc.js` |
+| Lint | `lint` | `solhint "contracts/**/*.sol"` |
+| Full tests | `test` | `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js` |
+| UI smoke | `test:ui` | `node scripts/ui/run_ui_smoke_test.js` |
+| UI ABI export | `ui:abi` | `node scripts/ui/export_abi.js` |
+| UI ABI consistency check | `ui:abi:check` | `node scripts/ui/check_ui_abi.js` |
+
+## 3) CI command order
+
+From `.github/workflows/ci.yml`:
+1. `npm install`
+2. `npx playwright install --with-deps chromium`
+3. `npm run lint`
+4. `npm run build`
+5. `npm run size`
+6. `npm run test`
+7. `npm run test:ui`
+
+## 4) Verified local execution
+
+The following canonical commands were executed locally:
+
+- `npm install`
+- `npm run build`
+- `npm run test`
+
+Observed outcomes:
+- Build compiled successfully with solc `0.8.23` via Truffle.
+- Full test command completed successfully with **260 passing** tests.
+- Bytecode size report includes `AGIJobManager deployedBytecode size: 24574 bytes` (under EIP-170 cap of 24576 bytes).
+
+## 5) Contract surface references
+
+For complete callable/API behavior and event/error references, see:
+- `docs/AGIJobManager_Interface.md`
+- `docs/PROTOCOL_FLOW.md`
+- `docs/CONFIGURATION.md`
+- Source of truth: `contracts/AGIJobManager.sol`


### PR DESCRIPTION
### Motivation
- Provide a HEAD-accurate, machine-checkable inventory that grounds operators, integrators, and auditors to the repository surface and canonical commands. 
- Make docs navigation more discoverable by linking the inventory from the index and docs hub while keeping the README quickstart canonical.

### Description
- Added `docs/REPOSITORY_INVENTORY.md` documenting repository map, `package.json` script matrix, CI command order, and verified local command outputs. 
- Linked the new inventory from `docs/00_INDEX.md` and `docs/README.md` and added it to the top-level README docs list. 
- Removed a duplicated quickstart block from `README.md` to keep a single canonical quickstart section and kept all changes additive to docs only. 
- No Solidity/contracts, compiler, Truffle migrations, CI workflows, or runtime code were modified. 

### Testing
- Executed `npm install` locally and observed normal dependency installation. 
- Executed `npm run build` (runs `truffle compile`) and observed successful compilation with `solc 0.8.23`. 
- Executed the full test pipeline via `npm run test` and observed all tests pass (`260 passing`) and the bytecode-size check reported `AGIJobManager deployedBytecode size: 24574 bytes` (under the EIP-170 cap).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698b981fed508333ba0f4da651448026)