### PR TITLE
docs: add CI-parity testing runbook & baseline inventory (record HEAD results)

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,6 +82,12 @@ npm run lint
 npm run size
 ```
 
+## Testing
+
+- Testing runbook and deterministic guidance: [`docs/TESTING.md`](docs/TESTING.md)
+- Risk-based coverage matrix and regression policy: [`docs/TEST_PLAN.md`](docs/TEST_PLAN.md)
+- Diagram-first architecture of test harness and failure modes: [`docs/ARCHITECTURE_TESTS.md`](docs/ARCHITECTURE_TESTS.md)
+
 ## Architecture + illustrations
 
 ### Job lifecycle (state machine)

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -15,6 +15,23 @@ npm test
 npm run test:ui
 ```
 
+## Baseline at repository HEAD (inventory run)
+
+Executed in this exact order on a clean checkout:
+
+1. `npm install`
+2. `npm run lint`
+3. `npm run build`
+4. `npm run size`
+5. `npm run test`
+
+Observed baseline:
+
+- `npm run size`: `AGIJobManager runtime bytecode size: 24574 bytes` (within EIP-170 cap, near the limit).
+- `npm run test`: `260 passing` on local Ganache `test` network.
+
+> Note: CI also runs `npm run test:ui` after contract tests.
+
 ## Canonical scripts (`package.json`)
 
 | Script | Command | Purpose |
@@ -81,3 +98,7 @@ npx truffle test --network test test/*dispute*.test.js
 | AGIType safety and broken ERC721 isolation | `test/agiTypes.safety.test.js` |
 | ENS hook best-effort integration | `test/ensHooks.integration.test.js` |
 | Identity config locking lifecycle | `test/identityConfig.locking.test.js` |
+
+## Known offline-test limitation
+
+- ENS tokenURI malformed-return handling is constrained by the current production implementation: empty ENS tokenURI responses are covered and correctly fall back, but malformed ABI payload simulation is documented as an operational caveat because the decode path is inside production minting logic and the runtime bytecode budget is already near the EIP-170 ceiling.

--- a/docs/TEST_PLAN.md
+++ b/docs/TEST_PLAN.md
@@ -1,5 +1,43 @@
 # Test Plan (Mainnet-Grade Deterministic Expansion)
 
+## Repository inventory (tooling and CI parity)
+
+### Toolchain and scripts
+
+- Test stack: **Truffle + Mocha** on Ganache in-memory provider (`network: test`, chainId `1337`).
+- Compiler profile: Solidity `0.8.23`, optimizer enabled (`runs=50`), `viaIR=false`, `evmVersion=london`.
+- Canonical scripts from `package.json`:
+  - `build`: `truffle compile`
+  - `lint`: `solhint "contracts/**/*.sol"`
+  - `size`: `node scripts/check-bytecode-size.js`
+  - `test`: `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`
+  - `test:ui`: `node scripts/ui/run_ui_smoke_test.js`
+
+### CI execution order mirrored locally
+
+1. `npm install`
+2. `npm run lint`
+3. `npm run build`
+4. `npm run size`
+5. `npm run test`
+6. `npm run test:ui`
+
+### Current suite inventory highlights
+
+Existing suites already cover the requested mainnet-critical areas:
+
+- Lifecycle and settlement: `test/jobLifecycle.core.test.js`, `test/livenessTimeouts.test.js`, `test/escrowAccounting.test.js`, `test/completionSettlementInvariant.test.js`.
+- Permissioning and controls: `test/adminOps.test.js`, `test/pausing.accessControl.test.js`, `test/identityConfig.locking.test.js`.
+- Disputes and moderator flows: `test/disputeHardening.test.js`, `test/disputes.moderator.test.js`.
+- Invariants and economics: `test/invariants.solvency.test.js`, `test/escrowAccounting.invariants.test.js`, `test/validatorVoting.bonds.test.js`, `test/economicSafety.test.js`.
+- ENS integration and ENSJobPages: `test/ensHooks.integration.test.js`, `test/ensJobPagesHooks.test.js`, `test/ensJobPagesHelper.test.js`, `test/namespaceAlpha.test.js`.
+- Utilities: `test/utils.uri-transfer.test.js`, `test/invariants.libs.test.js`.
+
+### Baseline results at HEAD
+
+- Full contract suite: **260 passing** (`npm run test`).
+- Runtime size gate: `AGIJobManager runtime bytecode size: 24574 bytes`.
+
 ## Deterministic execution model
 
 - Local-only execution on Truffle `test` network (in-memory Ganache).


### PR DESCRIPTION
### Motivation

- Provide an operator- and auditor-friendly, CI-parity testing runbook and a precise repository inventory to make the repository easier to validate for mainnet readiness.
- Capture an authoritative baseline of the toolchain, scripts, and HEAD test results so reviewers can reproduce CI locally and reason about bytecode budget risks.
- Preserve the minimal-change policy by delivering documentation updates only and avoiding production Solidity edits. 

### Description

- Added a `Testing` section to `README.md` linking to the canonical runbook (`docs/TESTING.md`), risk-based plan (`docs/TEST_PLAN.md`), and architecture/diagrams (`docs/ARCHITECTURE_TESTS.md`).
- Extended `docs/TESTING.md` with a `Baseline at repository HEAD (inventory run)` subsection that records the exact CI-parity command order and the observed HEAD outcomes. 
- Extended `docs/TEST_PLAN.md` with a `Repository inventory` section that enumerates the toolchain, compiler profile, canonical `package.json` scripts, mirrored CI step order, current test-suite inventory by risk area, and the baseline results snapshot. 
- No production contracts or runtime configuration were changed; changes are documentation-only and intentionally avoid runtime bytecode growth. 

### Testing

- Ran the CI-parity sequence: `npm install`, `npm run lint`, `npm run build`, `npm run size`, `npm run test`, and `npm run test:ui`, and observed all steps succeed locally. 
- `npm run size` reported: `AGIJobManager runtime bytecode size: 24574 bytes`, which is under the EIP-170 runtime cap but close to the limit. 
- `npm run test` completed with `260 passing` tests (full Truffle + Mocha suite on local Ganache `test` network). 
- `npm run test:ui` passed the UI smoke checks (2/2). 
- Note: a documented offline-test limitation remains for malformed ENS tokenURI ABI-payload simulation and is recorded in the docs as an operational caveat (this was intentionally documented rather than altering production minting logic due to the near‑EIP‑170 bytecode budget).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698ba8f850408333b96e808b0c22ee10)