### PR TITLE
Restore EIP-170 compliance while preserving ENS hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,18 @@ flowchart LR
 - Deployment sequence: [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
 - Day-2 operations and incident playbooks: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
 - Configuration reference for owner-settable knobs: [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
+- Mainnet institutional runbook (deploy + incident + diagrams): [`docs/MAINNET_OPERATIONS.md`](docs/MAINNET_OPERATIONS.md)
+
+### Mainnet token assumptions (production)
+
+- AGIALPHA token address: `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
+- The system expects exact-transfer ERC20 semantics (no fee-on-transfer/rebase behavior).
+- AGIALPHA token-level pause must remain unpaused for normal operation.
+- ENS integration is intentionally best-effort; core escrow/settlement correctness does not depend on ENS success.
+
+### Dependency pinning note
+
+- `@openzeppelin/contracts` is pinned to `4.9.6` to keep v4 import paths and Ownable constructor behavior stable across deterministic builds.
 
 **Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to keep runtime bytecode under the EIP‑170 cap; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
 

--- a/docs/MAINNET_OPERATIONS.md
+++ b/docs/MAINNET_OPERATIONS.md
@@ -1,0 +1,123 @@
+# Mainnet Operations Runbook (Business-Operated Deployment)
+
+## Explicit mainnet assumptions
+
+- **Production AGI token**: `AGIALPHA` at `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
+- **Token behavior assumption**: OpenZeppelin-standard ERC20 exact transfer semantics (no fee-on-transfer, no rebasing).
+- **Operational dependency**: token-level pause on `AGIALPHA` must be **unpaused** for normal protocol operations.
+- **ENS integration model**: ENS hooks and ENS ownership checks are best-effort mirrors; settlement and escrow correctness must not depend on ENS call success.
+
+## Deploy day sequence
+
+1. Deploy `ENSJobPages`.
+2. Deploy `AGIJobManager` with final constructor config (token + ENS registry + NameWrapper + roots + Merkle roots).
+3. Wire contracts:
+   - `setEnsJobPages(ENSJobPages)`
+   - `setUseEnsJobTokenURI(false)` initially (enable only after hook smoke tests).
+4. Configure governance/ops:
+   - moderators
+   - additional agents/validators (if used)
+   - validator/agent bond parameters
+   - validator threshold parameters
+   - AGI types (ERC721 contracts + payout percentages)
+5. Configure identity gating roots (Merkle and ENS roots).
+6. Smoke test all lifecycle actions with small payout jobs.
+7. Verify contracts on Etherscan + confirm bytecode-size gate.
+8. Transfer ownership to multisig (`transferOwnership`) and archive signer runbook.
+9. Call `lockIdentityConfiguration()` only after ENS / token / root wiring is fully verified.
+10. Unpause rollout:
+    - keep `settlementPaused=false`
+    - `unpause()` execution flows
+    - optionally enable `setUseEnsJobTokenURI(true)` after ENS URI checks.
+
+## Post-deploy verification checklist
+
+- Constructor addresses match signed deployment plan.
+- `withdrawableAGI()` is non-negative and escrow-backed invariants hold.
+- `scripts/check-contract-sizes.js` passes and runtime bytecode is under EIP-170.
+- Ownership is multisig-held and emergency signers tested.
+- ENS hooks produce expected events without blocking settlement.
+
+## Incident response
+
+### Pause / unpause
+
+- `pause()` for emergency entry freeze and admin-safe treasury actions.
+- Keep `settlementPaused=false` when you need participants to settle/finalize during pause windows.
+- Use `setSettlementPaused(true)` only for full settlement freeze incidents.
+- Recovery order: diagnose root cause -> revert unsafe config -> `setSettlementPaused(false)` -> `unpause()`.
+
+### Rescue functions
+
+- AGI surplus recovery is available on `withdrawAGI(amount)` with pause + settlement-not-paused + withdrawable accounting protections.
+- The current production contract does **not** expose generic arbitrary-token/ETH rescue entrypoints; forced ETH or unrelated ERC20 transfers should be prevented operationally.
+
+### Disable AGI types safely
+
+- Use `setAGITypeStatus` / AGI type update controls to disable compromised NFT dependencies.
+- Do not change payout percentages in a way that violates validator reward headroom constraints.
+
+## Admin function safety matrix
+
+| Function | Safe during normal ops | Safe during pause | Notes |
+| --- | --- | --- | --- |
+| `pause` / `unpause` | Yes | Yes | Primary incident toggle. |
+| `setSettlementPaused` | Yes (careful) | Yes | Freezes/unfreezes settlement path. |
+| `withdrawAGI` (AGI only) | No | Yes (only if settlement not paused) | Same safety bounds for AGI surplus. |
+| Generic token/ETH rescue | No | No | Not exposed in current contract surface. |
+| `lockIdentityConfiguration` | One-way | One-way | Finalize only after full config verification. |
+
+## Recommended parameter ranges (mainnet)
+
+| Parameter | Recommended range | Rationale |
+| --- | --- | --- |
+| `requiredValidatorApprovals` | 2-5 | Small enough for liveness, large enough for confidence. |
+| `requiredValidatorDisapprovals` | 2-5 | Match approvals to reduce asymmetry. |
+| `voteQuorum` | >= max(approvals, disapprovals) | Prevent low-participation outcomes. |
+| `validationRewardPercentage` | 5-15% | Keeps validator incentives healthy without starving agent payout. |
+| `completionReviewPeriod` | 1-7 days | Gives validators reaction window. |
+| `disputeReviewPeriod` | 3-21 days | Moderator liveness + evidence window. |
+| Agent/validator bond bps | 100-2000 bps | Enough economic skin-in-game without hurting participation. |
+
+## Job lifecycle state machine
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created
+    Created --> Assigned: applyForJob
+    Assigned --> CompletionRequested: requestJobCompletion
+    CompletionRequested --> Completed: finalizeJob / validator threshold
+    CompletionRequested --> Disputed: disputeJob
+    Disputed --> Completed: resolveDispute(agent win)
+    Disputed --> Expired: resolveDispute(employer win)
+    Assigned --> Expired: expireJob
+    Created --> Deleted: delistJob
+```
+
+## Funds flow
+
+```mermaid
+flowchart TD
+    E[Employer payout deposit] --> C[(AGIJobManager balance)]
+    A[Agent bond] --> C
+    V[Validator bonds] --> C
+    D[Dispute bond] --> C
+    C --> L[Locked backing: escrow + bonds]
+    C --> S[Settlement payouts/refunds]
+    C --> R[Platform retained surplus]
+    R --> W[withdrawAGI under pause safety]
+```
+
+## ENS hook best-effort flow
+
+```mermaid
+flowchart LR
+    J[Job completion settlement] --> U{useEnsJobTokenURI?}
+    U -- no --> D[Use jobCompletionURI]
+    U -- yes --> H[Staticcall ENSJobPages.jobEnsURI with gas cap]
+    H --> K{Call + ABI payload valid?}
+    K -- yes --> E[Use ENS URI if non-empty]
+    K -- no --> D
+    E --> M[Mint NFT + settle]
+    D --> M
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "name": "agijobmanager",
       "version": "0.1.0",
       "dependencies": {
-        "@openzeppelin/contracts": "^4.9.6"
+        "@openzeppelin/contracts": "4.9.6"
       },
       "devDependencies": {
         "@openzeppelin/test-helpers": "^0.5.16",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "ui:abi:check": "node scripts/ui/check_ui_abi.js"
   },
   "dependencies": {
-    "@openzeppelin/contracts": "^4.9.6"
+    "@openzeppelin/contracts": "4.9.6"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "^0.5.16",


### PR DESCRIPTION
### Motivation

- Keep `AGIJobManager` runtime bytecode under the EIP-170 cap while preserving the minimal ENS robustness improvements. 
- Previous additions (generic owner rescue entrypoints and heavy adversarial tests) caused the bytecode size guard to fail and needed to be removed to restore deployability.

### Description

- Removed the generic owner `rescue` entrypoint and deleted the large adversarial test mocks and test file (`test/mainnetReadiness.hardening.test.js`, `contracts/test/ForceEthSender.sol`, `contracts/test/MockENSJobPagesReturnData.sol`, `contracts/test/MockRevertingENSStack.sol`) to reduce runtime size and keep AGI outflow on the existing `withdrawAGI` path. 
- Kept ENS hardening: `_mintCompletionNFT` now performs a best-effort returndata-shape check before `abi.decode` and `ENSOwnership.verifyENSOwnership` uses revert-safe `staticcall` probes via a private `_staticcallAddress` helper. 
- Updated `docs/MAINNET_OPERATIONS.md` to reflect the current contract surface and operational guidance that no generic token/ETH rescue entrypoints are exposed. 
- Pinned `@openzeppelin/contracts` to `4.9.6` in `package.json`/`package-lock.json`, and left `truffle-config.js` / `viaIR` settings unchanged.

### Testing

- Ran `npm run size` and confirmed `AGIJobManager` runtime bytecode is `24574` bytes, satisfying the EIP-170 guard. 
- Ran `npm test` (full Truffle suite) and observed the full test suite pass (`264 passing`) and the bytecode size gate succeed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bcb3bdf688333be080053fda62ddd)