### PR TITLE
Restore EIP-170 compliance by trimming AGIJobManager runtime surface and slimming tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -64,6 +64,7 @@ interface NameWrapper {
     function ownerOf(uint256 id) external view returns (address);
 }
 
+
 contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     // -----------------------
     // Custom errors (smaller bytecode than revert strings)

--- a/contracts/test/RevertingENSComponents.sol
+++ b/contracts/test/RevertingENSComponents.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract RevertingENSRegistry {
+    bool public revertOwner;
+    bool public revertResolver;
+    address public resolverAddress;
+
+    function setRevertOwner(bool value) external {
+        revertOwner = value;
+    }
+
+    function setRevertResolver(bool value) external {
+        revertResolver = value;
+    }
+
+    function setResolverAddress(address value) external {
+        resolverAddress = value;
+    }
+
+    function owner(bytes32) external view returns (address) {
+        if (revertOwner) revert();
+        return address(0);
+    }
+
+    function resolver(bytes32) external view returns (address) {
+        if (revertResolver) revert();
+        return resolverAddress;
+    }
+}
+
+contract RevertingNameWrapper {
+    bool public revertOwnerOf;
+
+    function setRevertOwnerOf(bool value) external {
+        revertOwnerOf = value;
+    }
+
+    function ownerOf(uint256) external view returns (address) {
+        if (revertOwnerOf) revert();
+        return address(0);
+    }
+
+    function isApprovedForAll(address, address) external pure returns (bool) {
+        revert();
+    }
+}
+
+contract RevertingResolver {
+    bool public revertAddr;
+    address public resolved;
+
+    function setRevertAddr(bool value) external {
+        revertAddr = value;
+    }
+
+    function setResolved(address value) external {
+        resolved = value;
+    }
+
+    function addr(bytes32) external view returns (address payable) {
+        if (revertAddr) revert();
+        return payable(resolved);
+    }
+}

--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -35,11 +35,12 @@ library ENSOwnership {
         bytes32 subnode
     ) private view returns (bool) {
         if (nameWrapperAddress == address(0)) return false;
-        try NameWrapperLike(nameWrapperAddress).ownerOf(uint256(subnode)) returns (address actualOwner) {
-            return actualOwner == claimant;
-        } catch {
-            return false;
-        }
+        (bool ok, address actualOwner) = _staticcallAddress(
+            nameWrapperAddress,
+            NameWrapperLike.ownerOf.selector,
+            subnode
+        );
+        return ok && actualOwner == claimant;
     }
 
     function _verifyResolverOwnership(

--- a/test/mainnetHardening.test.js
+++ b/test/mainnetHardening.test.js
@@ -1,0 +1,100 @@
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const RevertingENSRegistry = artifacts.require("RevertingENSRegistry");
+const RevertingNameWrapper = artifacts.require("RevertingNameWrapper");
+const RevertingResolver = artifacts.require("RevertingResolver");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+contract("AGIJobManager mainnet hardening", (accounts) => {
+  const [owner, employer, agent, validator, treasury] = accounts;
+  const ZERO32 = "0x" + "00".repeat(32);
+
+  async function deployManager(token, ensAddress, nameWrapperAddress, baseIpfs = "ipfs://base") {
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        baseIpfs,
+        ensAddress,
+        nameWrapperAddress,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32
+      ),
+      { from: owner }
+    );
+    return manager;
+  }
+
+  async function prepareSimpleSettlement(manager, token, jobCreator = employer, createViaContract) {
+    const nft = await MockERC721.new({ from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(jobCreator, payout, { from: owner });
+
+    if (createViaContract) {
+      await createViaContract(payout);
+    } else {
+      await token.approve(manager.address, payout, { from: jobCreator });
+      await manager.createJob("ipfs://spec", payout, 100, "details", { from: jobCreator });
+    }
+
+    await token.mint(agent, web3.utils.toWei("3"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("3"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, "QmCompletion", { from: agent });
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+  }
+
+  it("keeps apply/validate authorization stable when ENS integrations revert", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await RevertingENSRegistry.new({ from: owner });
+    const wrapper = await RevertingNameWrapper.new({ from: owner });
+    const resolver = await RevertingResolver.new({ from: owner });
+    const manager = await deployManager(token, ens.address, wrapper.address);
+    const nft = await MockERC721.new({ from: owner });
+
+    await ens.setResolverAddress(resolver.address, { from: owner });
+    await ens.setRevertResolver(true, { from: owner });
+    await wrapper.setRevertOwnerOf(true, { from: owner });
+    await resolver.setRevertAddr(true, { from: owner });
+
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent, { from: owner });
+
+    await token.mint(employer, web3.utils.toWei("10"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("10"), { from: employer });
+    await manager.createJob("ipfs://spec", web3.utils.toWei("10"), 1000, "details", { from: employer });
+
+    await expectCustomError(manager.applyForJob.call(0, "agent", [], { from: agent }), "NotAuthorized");
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+
+    await manager.requestJobCompletion(0, "ipfs://completion", { from: agent });
+    await expectCustomError(manager.validateJob.call(0, "validator", [], { from: validator }), "NotAuthorized");
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await token.mint(validator, web3.utils.toWei("20"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("20"), { from: validator });
+    await manager.validateJob(0, "validator", [], { from: validator });
+  });
+
+
+
+
+});


### PR DESCRIPTION
### Motivation
- Restore the non‑negotiable EIP‑170 runtime bytecode guard by removing newly introduced runtime surface that pushed `AGIJobManager` over the 24,575 byte limit. 
- Preserve ENS ownership hardening and authorization liveness checks while removing heavier rescue and decoding helpers that increased bytecode size. 
- Keep tests aligned with the reduced runtime surface by removing mocks and test cases that depended on the removed features. 

### Description
- Removed the extra internal helper/rescue surface and consolidated owner AGI withdrawals into `withdrawAGI(uint256)` with the existing `withdrawableAGI()` bounds check and protections, eliminating the internal `_withdrawAGITo` and the `rescueETH` / `rescueERC20` runtime entrypoints. 
- Simplified ENS tokenURI handling by removing the separate `_isValidSingleStringEncoding` runtime helper and restoring a leaner ENS staticcall + decode path in `_mintCompletionNFT`. 
- Kept and strengthened ENS ownership hardening by switching to low‑level `staticcall` helpers in `contracts/utils/ENSOwnership.sol` so external failures return `false` rather than bubbling reverts. 
- Cleaned tests and fixtures: removed now-unused adversarial mocks (`contracts/test/ForceETHSender.sol` and `contracts/test/MockENSJobPagesMalformed.sol`), trimmed `test/mainnetHardening.test.js` to focus on ENS‑revert authorization coverage, and added `contracts/test/RevertingENSComponents.sol` to simulate ENS/namewrapper/resolver revert scenarios. 
- Updated `docs/MAINNET_OPERATIONS.md` to reflect the current rescue/withdrawal posture and operational guidance for the trimmed runtime surface. 

### Testing
- Ran `npm run size` and confirmed `AGIJobManager runtime bytecode size: 24574 bytes`, which is under the EIP‑170 limit. (passed) 
- Ran the full test flow with `npm test` (Truffle compile + full test suites + ABI smoke + contract size checks) and observed the full suite passing (`265 passing`). (passed)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bde8274d48333bbb51dae5ccdd844)