### PR TITLE
Fix ENS URI overflow check to prevent settlement bricking

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -64,6 +64,7 @@ interface NameWrapper {
     function ownerOf(uint256 id) external view returns (address);
 }
 
+
 contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     // -----------------------
     // Custom errors (smaller bytecode than revert strings)
@@ -1140,10 +1141,16 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
                     mstore(add(payload, 36), jobId)
                 }
                 (bool ok, bytes memory data) = target.staticcall{ gas: ENS_URI_GAS_LIMIT }(payload);
-                if (ok && data.length != 0) {
-                    string memory ensUri = abi.decode(data, (string));
-                    if (bytes(ensUri).length != 0) {
-                        tokenUriValue = ensUri;
+                if (ok) {
+                    assembly {
+                        let size := mload(data)
+                        let len := mload(add(data, 64))
+                        if and(
+                            gt(len, 0),
+                            and(eq(mload(add(data, 32)), 32), iszero(gt(len, sub(size, 64))))
+                        ) {
+                            tokenUriValue := add(data, 64)
+                        }
                     }
                 }
             }

--- a/contracts/test/MockENSJobPagesMalformed.sol
+++ b/contracts/test/MockENSJobPagesMalformed.sol
@@ -1,0 +1,26 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockENSJobPagesMalformed {
+    bytes private tokenURIBytes;
+    bool public revertOnHook;
+
+    function setTokenURIBytes(bytes calldata data) external {
+        tokenURIBytes = data;
+    }
+
+    function setRevertOnHook(bool shouldRevert) external {
+        revertOnHook = shouldRevert;
+    }
+
+    function handleHook(uint8, uint256) external view {
+        if (revertOnHook) revert();
+    }
+
+    function jobEnsURI(uint256) external view returns (string memory) {
+        bytes memory data = tokenURIBytes;
+        assembly {
+            return(add(data, 32), mload(data))
+        }
+    }
+}

--- a/contracts/test/RevertingENSComponents.sol
+++ b/contracts/test/RevertingENSComponents.sol
@@ -1,0 +1,65 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract RevertingENSRegistry {
+    bool public revertOwner;
+    bool public revertResolver;
+    address public resolverAddress;
+
+    function setRevertOwner(bool value) external {
+        revertOwner = value;
+    }
+
+    function setRevertResolver(bool value) external {
+        revertResolver = value;
+    }
+
+    function setResolverAddress(address value) external {
+        resolverAddress = value;
+    }
+
+    function owner(bytes32) external view returns (address) {
+        if (revertOwner) revert();
+        return address(0);
+    }
+
+    function resolver(bytes32) external view returns (address) {
+        if (revertResolver) revert();
+        return resolverAddress;
+    }
+}
+
+contract RevertingNameWrapper {
+    bool public revertOwnerOf;
+
+    function setRevertOwnerOf(bool value) external {
+        revertOwnerOf = value;
+    }
+
+    function ownerOf(uint256) external view returns (address) {
+        if (revertOwnerOf) revert();
+        return address(0);
+    }
+
+    function isApprovedForAll(address, address) external pure returns (bool) {
+        revert();
+    }
+}
+
+contract RevertingResolver {
+    bool public revertAddr;
+    address public resolved;
+
+    function setRevertAddr(bool value) external {
+        revertAddr = value;
+    }
+
+    function setResolved(address value) external {
+        resolved = value;
+    }
+
+    function addr(bytes32) external view returns (address payable) {
+        if (revertAddr) revert();
+        return payable(resolved);
+    }
+}

--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -35,11 +35,12 @@ library ENSOwnership {
         bytes32 subnode
     ) private view returns (bool) {
         if (nameWrapperAddress == address(0)) return false;
-        try NameWrapperLike(nameWrapperAddress).ownerOf(uint256(subnode)) returns (address actualOwner) {
-            return actualOwner == claimant;
-        } catch {
-            return false;
-        }
+        (bool ok, address actualOwner) = _staticcallAddress(
+            nameWrapperAddress,
+            NameWrapperLike.ownerOf.selector,
+            subnode
+        );
+        return ok && actualOwner == claimant;
     }
 
     function _verifyResolverOwnership(

--- a/test/mainnetHardening.test.js
+++ b/test/mainnetHardening.test.js
@@ -1,0 +1,157 @@
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockENSJobPagesMalformed = artifacts.require("MockENSJobPagesMalformed");
+const RevertingENSRegistry = artifacts.require("RevertingENSRegistry");
+const RevertingNameWrapper = artifacts.require("RevertingNameWrapper");
+const RevertingResolver = artifacts.require("RevertingResolver");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+contract("AGIJobManager mainnet hardening", (accounts) => {
+  const [owner, employer, agent, validator, treasury] = accounts;
+  const ZERO32 = "0x" + "00".repeat(32);
+
+  async function deployManager(token, ensAddress, nameWrapperAddress, baseIpfs = "ipfs://base") {
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        baseIpfs,
+        ensAddress,
+        nameWrapperAddress,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32
+      ),
+      { from: owner }
+    );
+    return manager;
+  }
+
+  async function prepareSimpleSettlement(manager, token, jobCreator = employer, createViaContract) {
+    const nft = await MockERC721.new({ from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(jobCreator, payout, { from: owner });
+
+    if (createViaContract) {
+      await createViaContract(payout);
+    } else {
+      await token.approve(manager.address, payout, { from: jobCreator });
+      await manager.createJob("ipfs://spec", payout, 100, "details", { from: jobCreator });
+    }
+
+    await token.mint(agent, web3.utils.toWei("3"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("3"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, "QmCompletion", { from: agent });
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+  }
+
+  it("does not allow malformed ENS tokenURI payloads to brick settlement", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await deployManager(token, ens.address, wrapper.address);
+    const malformed = await MockENSJobPagesMalformed.new({ from: owner });
+
+    await manager.setEnsJobPages(malformed.address, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
+
+    await prepareSimpleSettlement(manager, token);
+    await malformed.setTokenURIBytes("0x1234", { from: owner });
+    let receipt = await manager.finalizeJob(0, { from: employer });
+    let issued = receipt.logs.find((l) => l.event === "NFTIssued");
+    assert.equal(await manager.tokenURI(issued.args.tokenId), "ipfs://base/QmCompletion");
+
+    const hugeLen = "f".repeat(62) + "e0";
+    const overflowPayload = "0x"
+      + "0".repeat(63) + "20"
+      + hugeLen
+      + "0".repeat(64);
+    const managerOverflow = await deployManager(token, ens.address, wrapper.address);
+    await managerOverflow.setEnsJobPages(malformed.address, { from: owner });
+    await managerOverflow.setUseEnsJobTokenURI(true, { from: owner });
+    await prepareSimpleSettlement(managerOverflow, token);
+    await malformed.setTokenURIBytes(overflowPayload, { from: owner });
+    receipt = await managerOverflow.finalizeJob(0, { from: employer });
+    issued = receipt.logs.find((l) => l.event === "NFTIssued");
+    assert.equal(await managerOverflow.tokenURI(issued.args.tokenId), "ipfs://base/QmCompletion");
+
+    const manager2 = await deployManager(token, ens.address, wrapper.address);
+    await manager2.setEnsJobPages(malformed.address, { from: owner });
+    await manager2.setUseEnsJobTokenURI(true, { from: owner });
+    await prepareSimpleSettlement(manager2, token);
+    await malformed.setTokenURIBytes(web3.eth.abi.encodeParameter("string", "ens://job.valid"), { from: owner });
+    receipt = await manager2.finalizeJob(0, { from: employer });
+    issued = receipt.logs.find((l) => l.event === "NFTIssued");
+    assert.equal(await manager2.tokenURI(issued.args.tokenId), "ens://job.valid");
+  });
+
+  it("keeps apply/validate authorization stable when ENS integrations revert", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await RevertingENSRegistry.new({ from: owner });
+    const wrapper = await RevertingNameWrapper.new({ from: owner });
+    const resolver = await RevertingResolver.new({ from: owner });
+    const manager = await deployManager(token, ens.address, wrapper.address);
+    const nft = await MockERC721.new({ from: owner });
+
+    await ens.setResolverAddress(resolver.address, { from: owner });
+    await ens.setRevertResolver(true, { from: owner });
+    await wrapper.setRevertOwnerOf(true, { from: owner });
+    await resolver.setRevertAddr(true, { from: owner });
+
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent, { from: owner });
+
+    await token.mint(employer, web3.utils.toWei("10"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("10"), { from: employer });
+    await manager.createJob("ipfs://spec", web3.utils.toWei("10"), 1000, "details", { from: employer });
+
+    await expectCustomError(manager.applyForJob.call(0, "agent", [], { from: agent }), "NotAuthorized");
+
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await token.mint(agent, web3.utils.toWei("2"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+
+    await manager.requestJobCompletion(0, "ipfs://completion", { from: agent });
+    await expectCustomError(manager.validateJob.call(0, "validator", [], { from: validator }), "NotAuthorized");
+    await manager.addAdditionalValidator(validator, { from: owner });
+    await token.mint(validator, web3.utils.toWei("20"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("20"), { from: validator });
+    await manager.validateJob(0, "validator", [], { from: validator });
+  });
+
+
+
+  it("settlement remains live when ENS hook target reverts with ENS URI mode enabled", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await deployManager(token, ens.address, wrapper.address);
+    const malformed = await MockENSJobPagesMalformed.new({ from: owner });
+
+    await malformed.setRevertOnHook(true, { from: owner });
+    await manager.setEnsJobPages(malformed.address, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
+
+    await prepareSimpleSettlement(manager, token);
+    await manager.finalizeJob(0, { from: employer });
+    const core = await manager.getJobCore(0);
+    assert.equal(core.completed, true);
+  });
+
+});


### PR DESCRIPTION
### Motivation
- Prevent a P1 vector where a malformed `jobEnsURI` returndata can craft `len` such that `add(64, len)` wraps and the assembly check accepts an enormous string, which can cause `UriUtils.applyBaseIpfs` iteration to run out of gas and brick `finalizeJob` settlement. 
- Harden ENS-related integrations so ENS resolver/name-wrapper failures or malicious payloads remain best-effort and cannot stop settlement liveness. 

### Description
- Make the returndata bounds check overflow-safe in `AGIJobManager._mintCompletionNFT` by loading `size := mload(data)` and validating `len` with `iszero(gt(len, sub(size, 64)))` (under the existing `offset == 32` + `len > 0` constraints) instead of an addition-based comparison that could wrap. 
- Add `MockENSJobPagesMalformed.sol` to simulate arbitrary/malformed `jobEnsURI` returndata (including crafted overflow-length payloads) and `RevertingENSComponents.sol` to simulate ENS/name-wrapper/resolver reverts for regression coverage. 
- Add `test/mainnetHardening.test.js` which includes a regression that crafts an overflow-length ABI payload (`len = 2^256 - 32`) and verifies `finalizeJob` still succeeds and falls back safely to the default completion URI, plus tests that ENS hook reverts do not break authorization or settlement. 
- Refactor `ENSOwnership` helper to use a `_staticcallAddress` pattern that returns `(bool ok, address)` instead of a `try/catch` on external calls, making ownership checks more controlled and resilient to reverting ENS components. 
- Small documentation updates to `docs/MAINNET_OPERATIONS.md` to reflect rescue/bytecode constraints and an emergency operations flowchart. 

### Testing
- Ran the focused test file with `npx truffle test test/mainnetHardening.test.js --network test` and it passed (3 passing). 
- Ran the full test suite with `npm test` (which runs `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`) and observed the suite succeed (`267 passing`) and ABI/size checks pass. 
- Verified bytecode size with `npm run size` which completed successfully (`AGIJobManager runtime bytecode size: 24565 bytes`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bde8274d48333bbb51dae5ccdd844)