### PR TITLE
Harden settlement liveness and fit AGIJobManager under EIP-170 size cap

### DIFF
--- a/contracts/test/ForceSendETH.sol
+++ b/contracts/test/ForceSendETH.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract ForceSendETH {
+    constructor() payable {}
+
+    function destroy(address payable target) external {
+        selfdestruct(target);
+    }
+}

--- a/contracts/test/MockERC1155Lite.sol
+++ b/contracts/test/MockERC1155Lite.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockERC1155Lite {
+    mapping(address => mapping(uint256 => uint256)) public balances;
+
+    function mint(address to, uint256 id, uint256 amount) external {
+        balances[to][id] += amount;
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata) external {
+        uint256 bal = balances[from][id];
+        require(bal >= amount, "insufficient");
+        unchecked {
+            balances[from][id] = bal - amount;
+        }
+        balances[to][id] += amount;
+    }
+
+    function balanceOf(address account, uint256 id) external view returns (uint256) {
+        return balances[account][id];
+    }
+}

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -48,11 +48,6 @@
     },
     {
       "inputs": [],
-      "name": "DeprecatedParameter",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "IneligibleAgentPayout",
       "type": "error"
     },
@@ -172,19 +167,6 @@
         }
       ],
       "name": "AGIWithdrawn",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "newPercentage",
-          "type": "uint256"
-        }
-      ],
-      "name": "AdditionalAgentPayoutPercentageUpdated",
       "type": "event"
     },
     {
@@ -1158,19 +1140,6 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "additionalAgentPayoutPercentage",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
       "inputs": [
         {
           "internalType": "address",
@@ -1184,45 +1153,6 @@
           "internalType": "bool",
           "name": "",
           "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText1",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText2",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText3",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
         }
       ],
       "stateMutability": "view",
@@ -1484,19 +1414,6 @@
           "internalType": "uint256",
           "name": "",
           "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "contactEmail",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
         }
       ],
       "stateMutability": "view",
@@ -1960,19 +1877,6 @@
     {
       "inputs": [],
       "name": "symbol",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "termsAndConditionsIpfsHash",
       "outputs": [
         {
           "internalType": "string",
@@ -2723,84 +2627,6 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "setAdditionalAgentPayoutPercentage",
-      "outputs": [],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_hash",
-          "type": "string"
-        }
-      ],
-      "name": "updateTermsAndConditionsIpfsHash",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_email",
-          "type": "string"
-        }
-      ],
-      "name": "updateContactEmail",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText1",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText2",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText3",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
           "name": "jobId",
           "type": "uint256"
         }
@@ -3096,6 +2922,37 @@
         }
       ],
       "name": "withdrawAGI",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "rescueETH",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "rescueToken",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -832,20 +832,9 @@ contract("AGIJobManager comprehensive", (accounts) => {
         manager.contributeToRewardPool(web3.utils.toWei("1"), { from: employer }));
     });
 
-    it("updates metadata fields and premium threshold", async () => {
-      await expectRevert.unspecified(manager.updateTermsAndConditionsIpfsHash("hash", { from: other }));
-      await manager.updateTermsAndConditionsIpfsHash("terms", { from: owner });
-      await manager.updateContactEmail("contact@example.com", { from: owner });
-      await manager.updateAdditionalText1("text1", { from: owner });
-      await manager.updateAdditionalText2("text2", { from: owner });
-      await manager.updateAdditionalText3("text3", { from: owner });
+    it("updates premium threshold", async () => {
+      await expectRevert.unspecified(manager.setPremiumReputationThreshold(42, { from: other }));
       await manager.setPremiumReputationThreshold(42, { from: owner });
-
-      assert.equal(await manager.termsAndConditionsIpfsHash(), "terms");
-      assert.equal(await manager.contactEmail(), "contact@example.com");
-      assert.equal(await manager.additionalText1(), "text1");
-      assert.equal(await manager.additionalText2(), "text2");
-      assert.equal(await manager.additionalText3(), "text3");
       assert.equal(await manager.premiumReputationThreshold(), "42");
     });
 

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -278,7 +278,6 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.removeModerator(other, { from: owner });
     assert.equal(await manager.moderators(other), false, "moderator should be removable after lock");
     await manager.addAdditionalAgent(other, { from: owner });
-    await manager.updateContactEmail("ops@example.com", { from: owner });
     await manager.blacklistAgent(agent, true, { from: owner });
 
     await manager.pause({ from: owner });

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,28 +79,6 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("reverts deprecated additional agent payout settings", async () => {
-    const manager = await AGIJobManager.new(...buildInitConfig(
-        token.address,
-        "ipfs://base",
-        ens.address,
-        nameWrapper.address,
-        clubRoot,
-        agentRoot,
-        clubRoot,
-        agentRoot,
-        ZERO_ROOT,
-        ZERO_ROOT,
-      ),
-      { from: owner }
-    );
-
-    await expectCustomError(
-      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
-      "DeprecatedParameter"
-    );
-  });
-
   it("settles successfully with safe payout configuration", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(
         token.address,


### PR DESCRIPTION
### Motivation
- Ensure AGIJobManager can be deployed to mainnet under the EIP-170 runtime bytecode limit and keep settlement flows live even when optional ENS integrations misbehave.
- Add small owner rescue paths to recover accidental ETH/tokens while preserving AGI escrow integrity.
- Remove deprecated on-chain metadata and unused payout surface to reclaim bytecode headroom.

### Description
- Implemented a bounded, non-bricking ENS tokenURI fetch: added `MAX_ENS_URI_RETURN_BYTES` and `_tryFetchEnsJobURI()` which uses assembly `staticcall` with `ENS_URI_GAS_LIMIT`, caps returndatasize, validates ABI layout (`offset == 32`, bounded `strLen`, padded-length check), and falls back silently to jobCompletionURI on any failure.
- Added owner rescue functions: `rescueETH(uint256 amount)` and `rescueToken(address token, bytes calldata data)` both `onlyOwner` + `nonReentrant`, with `rescueToken` explicitly rejecting `token == address(agiToken)` so AGI escrow cannot be bypassed and both revert with `TransferFailed()` on failure.
- Removed deprecated/unused metadata and payout fields/setters/events to reduce runtime footprint: `termsAndConditionsIpfsHash`, `contactEmail`, `additionalText1/2/3`, `updateTermsAndConditionsIpfsHash`, `updateContactEmail`, `updateAdditionalText1/2/3`, `additionalAgentPayoutPercentage` and associated setter/event surfaces were deleted from runtime contract.
- Added small test helpers and tests: `ForceSendETH.sol` and `MockERC1155Lite.sol`, and updated `test/mainnetHardening.test.js` to cover ENS malformed-return regressions and the `rescueETH`/`rescueToken` behaviors.
- Updated exported UI ABI to reflect the new contract interface after removals and additions.

### Testing
- Ran targeted hardening tests: `npx truffle test --network test test/mainnetHardening.test.js test/adminOps.test.js test/economicSafety.test.js test/AGIJobManager.full.test.js` and all tests in those files passed after adjustments.
- Ran the full test suite via `npm test` (Truffle + JS tests + contract size checks) and observed a passing run (267 passing) after regenerating UI ABI.
- Verified UI ABI sync by running `npm run ui:abi && npx truffle test --network test test/ui_abi_sync.test.js` which passed after the ABI export update.
- Verified runtime bytecode size with the repo guard: `node scripts/check-contract-sizes.js` / `node scripts/check-bytecode-size.js` reported `AGIJobManager runtime bytecode size: 24470 bytes` which is strictly < `0x6000` (24576), so the size guard passes.
- ENS bricking regression: tests confirmed malformed/short/garbage ENS returns do not revert or OOG settlement flows and valid ABI-encoded string responses still override the tokenURI when enabled.
- Rescue tests: force-sent ETH can be forwarded to `owner()` via `rescueETH`, `rescueToken` succeeds for ERC20/ERC721/ERC1155-like calls and reverts when attempting to target the configured AGI token address; all automated checks passed.

Acceptance checklist (automated verification):
- All automated tests pass; bytecode-size guard passes; AGIJobManager runtime bytecode is < `0x6000`; settlement liveness preserved under malformed ENS returns; deprecated metadata/payout surfaces removed to reclaim bytecode.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf5cde1388333ab36226cdd72dd0c)