### PR TITLE
Sync UI ABI and remove legacy dispute API; add ENS/rescue robustness and script fixes

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -83,13 +83,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     error InsolventEscrowBalance();
     error ConfigLocked();
     error SettlementPaused();
-    error DeprecatedParameter();
-
-    /// @notice Canonical dispute resolution codes (numeric ordering is stable; do not reorder).
-    /// @dev 0 = NO_ACTION (log only; dispute remains active)
-    // Pre-hashed resolution strings (smaller + cheaper than hashing literals each call)
-    bytes32 private constant RES_AGENT_WIN = 0x6594a8dd3f558fd2dd11fa44c7925f5b9e19868e6d0b4b97d2132fe5e25b5071;
-    bytes32 private constant RES_EMPLOYER_WIN = 0xee31e9f396a85b8517c6d07b02f904858ad9f3456521bedcff02cc14e75ca8ce;
 
     IERC20 public agiToken;
     string private baseIpfsUrl;
@@ -106,8 +99,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint256 public completionReviewPeriod = 7 days;
     uint256 public disputeReviewPeriod = 14 days;
     uint256 internal constant MAX_REVIEW_PERIOD = 365 days;
-    /// @notice Deprecated and unused payout knob.
-    uint256 public additionalAgentPayoutPercentage = 50;
     bool public settlementPaused;
     uint256 internal constant DISPUTE_BOND_BPS = 50;
     uint256 internal constant DISPUTE_BOND_MIN = 1e18;
@@ -139,12 +130,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     /// @notice Total AGI locked as dispute bonds for unsettled disputes.
     uint256 public lockedDisputeBonds;
     uint256 internal constant maxActiveJobsPerAgent = 3;
-
-    string public termsAndConditionsIpfsHash;
-    string public contactEmail;
-    string public additionalText1;
-    string public additionalText2;
-    string public additionalText3;
 
     bytes32 public clubRootNode;
     bytes32 public alphaClubRootNode;
@@ -220,7 +205,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     event JobCompleted(uint256 indexed jobId, address indexed agent, uint256 indexed reputationPoints);
     event ReputationUpdated(address user, uint256 newReputation);
     event JobCancelled(uint256 indexed jobId);
-    event DisputeResolved(uint256 indexed jobId, address indexed resolver, string resolution);
     event DisputeResolvedWithCode(
         uint256 indexed jobId,
         address indexed resolver,
@@ -243,7 +227,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     event RewardPoolContribution(address indexed contributor, uint256 indexed amount);
     event CompletionReviewPeriodUpdated(uint256 indexed oldPeriod, uint256 indexed newPeriod);
     event DisputeReviewPeriodUpdated(uint256 indexed oldPeriod, uint256 indexed newPeriod);
-    event AdditionalAgentPayoutPercentageUpdated(uint256 newPercentage);
     event AGIWithdrawn(address indexed to, uint256 indexed amount, uint256 indexed remainingWithdrawable);
     event PlatformRevenueAccrued(uint256 indexed jobId, uint256 indexed amount);
     event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);
@@ -280,6 +263,8 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint8 private constant ENS_HOOK_LOCK_BURN = 6;
     uint256 internal constant ENS_HOOK_GAS_LIMIT = 500_000;
     uint256 internal constant ENS_URI_GAS_LIMIT = 200_000;
+    uint256 internal constant ENS_URI_MAX_RETURN_BYTES = 2048;
+    uint256 internal constant ENS_URI_MAX_STRING_BYTES = 1024;
 
     constructor(
         address agiTokenAddress,
@@ -639,19 +624,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         emit JobDisputed(_jobId, msg.sender);
     }
 
-    /// @notice Deprecated: use resolveDisputeWithCode for typed settlement.
-    /// @dev Non-canonical strings map to NO_ACTION (dispute remains active).
-    function resolveDispute(uint256 _jobId, string calldata resolution) external onlyModerator whenSettlementNotPaused nonReentrant {
-        bytes32 r = keccak256(bytes(resolution));
-        uint8 resolutionCode;
-        if (r == RES_AGENT_WIN) {
-            resolutionCode = 1;
-        } else if (r == RES_EMPLOYER_WIN) {
-            resolutionCode = 2;
-        }
-        _resolveDispute(_jobId, resolutionCode, resolution);
-    }
-
     /// @notice Resolve a dispute with a typed action code and freeform reason.
     function resolveDisputeWithCode(
         uint256 _jobId,
@@ -679,11 +651,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         } else {
             revert InvalidParameters();
         }
-        emit DisputeResolved(
-            _jobId,
-            msg.sender,
-            resolutionCode == 1 ? "agent win" : "employer win"
-        );
         emit DisputeResolvedWithCode(_jobId, msg.sender, resolutionCode, reason);
     }
 
@@ -861,16 +828,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         challengePeriodAfterApproval = period;
         emit ChallengePeriodAfterApprovalUpdated(oldPeriod, period);
     }
-    /// @notice Deprecated and unused in payout logic.
-    function setAdditionalAgentPayoutPercentage(uint256) external view onlyOwner {
-        revert DeprecatedParameter();
-    }
-    function updateTermsAndConditionsIpfsHash(string calldata _hash) external onlyOwner { termsAndConditionsIpfsHash = _hash; }
-    function updateContactEmail(string calldata _email) external onlyOwner { contactEmail = _email; }
-    function updateAdditionalText1(string calldata _text) external onlyOwner { additionalText1 = _text; }
-    function updateAdditionalText2(string calldata _text) external onlyOwner { additionalText2 = _text; }
-    function updateAdditionalText3(string calldata _text) external onlyOwner { additionalText3 = _text; }
-
     function getJobCore(uint256 jobId)
         external
         view
@@ -1135,28 +1092,42 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (useEnsJobTokenURI) {
             address target = ensJobPages;
             if (target != address(0) && target.code.length != 0) {
-                bytes memory payload = new bytes(36);
+                bytes memory data;
                 assembly {
-                    mstore(add(payload, 32), 0x751809b400000000000000000000000000000000000000000000000000000000)
-                    mstore(add(payload, 36), jobId)
+                    let ptr := mload(0x40)
+                    mstore(ptr, shl(224, 0x751809b4))
+                    mstore(add(ptr, 4), jobId)
+
+                    if staticcall(ENS_URI_GAS_LIMIT, target, ptr, 0x24, 0, 0) {
+                        let rdsize := returndatasize()
+                        if gt(rdsize, ENS_URI_MAX_RETURN_BYTES) {
+                            rdsize := ENS_URI_MAX_RETURN_BYTES
+                        }
+
+                        data := mload(0x40)
+                        mstore(data, rdsize)
+                        returndatacopy(add(data, 32), 0, rdsize)
+                        mstore(0x40, add(add(data, 32), and(add(rdsize, 31), not(31))))
+                    }
                 }
-                (bool ok, bytes memory data) = target.staticcall{ gas: ENS_URI_GAS_LIMIT }(payload);
-                if (ok) {
+                if (data.length >= 64) {
+                    uint256 offset;
+                    uint256 strLen;
                     assembly {
-                        let size := mload(data)
-                        let len := mload(add(data, 64))
-                        let end := add(64, len)
-                        if and(
-                            gt(len, 0),
-                            and(
-                                eq(mload(add(data, 32)), 32),
-                                and(
-                                    iszero(lt(end, len)),
-                                    iszero(gt(end, size))
-                                )
-                            )
-                        ) {
-                            tokenUriValue := add(data, 64)
+                        offset := mload(add(data, 32))
+                        strLen := mload(add(data, 64))
+                    }
+                    if (offset == 32 && strLen > 0 && strLen <= ENS_URI_MAX_STRING_BYTES) {
+                        uint256 paddedLen;
+                        unchecked {
+                            paddedLen = (strLen + 31) & ~uint256(31);
+                        }
+                        if (64 + paddedLen <= data.length) {
+                            string memory ensUri;
+                            assembly {
+                                ensUri := add(data, 64)
+                            }
+                            tokenUriValue = ensUri;
                         }
                     }
                 }
@@ -1261,6 +1232,25 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         if (amount > available) revert InsufficientWithdrawableBalance();
         _t(msg.sender, amount);
         emit AGIWithdrawn(msg.sender, amount, available - amount);
+    }
+
+    function rescueETH(uint256 amount) external onlyOwner nonReentrant {
+        (bool ok, ) = owner().call{ value: amount }("");
+        if (!ok) revert TransferFailed();
+    }
+
+    function rescueToken(address token, bytes calldata data) external onlyOwner nonReentrant {
+        if (token == address(agiToken)) revert InvalidParameters();
+        (bool ok, bytes memory ret) = token.call(data);
+        if (!ok) revert TransferFailed();
+        if (ret.length > 0) {
+            if (ret.length != 32) revert TransferFailed();
+            uint256 returned;
+            assembly {
+                returned := mload(add(ret, 32))
+            }
+            if (returned != 1) revert TransferFailed();
+        }
     }
 
     function canAccessPremiumFeature(address user) external view returns (bool) {

--- a/contracts/test/RescueMocks.sol
+++ b/contracts/test/RescueMocks.sol
@@ -1,0 +1,71 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract ForceSendETH {
+    constructor() payable {}
+
+    function boom(address payable target) external {
+        selfdestruct(target);
+    }
+}
+
+contract MockRescueERC20 {
+    mapping(address => uint256) public balanceOf;
+
+    function mint(address to, uint256 amount) external {
+        balanceOf[to] += amount;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        uint256 fromBalance = balanceOf[msg.sender];
+        require(fromBalance >= amount, "bal");
+        unchecked {
+            balanceOf[msg.sender] = fromBalance - amount;
+            balanceOf[to] += amount;
+        }
+        return true;
+    }
+}
+
+contract MockRescueERC721 {
+    mapping(uint256 => address) public ownerOf;
+
+    function mint(address to, uint256 tokenId) external {
+        ownerOf[tokenId] = to;
+    }
+
+    function transferFrom(address from, address to, uint256 tokenId) external {
+        require(ownerOf[tokenId] == from, "owner");
+        ownerOf[tokenId] = to;
+    }
+}
+
+contract MockRescueERC1155 {
+    mapping(address => mapping(uint256 => uint256)) public balanceOf;
+
+    function mint(address to, uint256 id, uint256 amount) external {
+        balanceOf[to][id] += amount;
+    }
+
+    function safeTransferFrom(address from, address to, uint256 id, uint256 amount, bytes calldata) external {
+        uint256 fromBalance = balanceOf[from][id];
+        require(fromBalance >= amount, "bal");
+        unchecked {
+            balanceOf[from][id] = fromBalance - amount;
+            balanceOf[to][id] += amount;
+        }
+    }
+}
+
+
+contract MockRescueERC20False {
+    function transfer(address, uint256) external pure returns (bool) {
+        return false;
+    }
+}
+
+contract MockRescueMalformedReturn {
+    function transfer(address, uint256) external pure returns (bytes4) {
+        return 0x12345678;
+    }
+}

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -48,11 +48,6 @@
     },
     {
       "inputs": [],
-      "name": "DeprecatedParameter",
-      "type": "error"
-    },
-    {
-      "inputs": [],
       "name": "IneligibleAgentPayout",
       "type": "error"
     },
@@ -172,19 +167,6 @@
         }
       ],
       "name": "AGIWithdrawn",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": false,
-          "internalType": "uint256",
-          "name": "newPercentage",
-          "type": "uint256"
-        }
-      ],
-      "name": "AdditionalAgentPayoutPercentageUpdated",
       "type": "event"
     },
     {
@@ -373,31 +355,6 @@
         }
       ],
       "name": "ConfigUpdated",
-      "type": "event"
-    },
-    {
-      "anonymous": false,
-      "inputs": [
-        {
-          "indexed": true,
-          "internalType": "uint256",
-          "name": "jobId",
-          "type": "uint256"
-        },
-        {
-          "indexed": true,
-          "internalType": "address",
-          "name": "resolver",
-          "type": "address"
-        },
-        {
-          "indexed": false,
-          "internalType": "string",
-          "name": "resolution",
-          "type": "string"
-        }
-      ],
-      "name": "DisputeResolved",
       "type": "event"
     },
     {
@@ -1158,19 +1115,6 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "additionalAgentPayoutPercentage",
-      "outputs": [
-        {
-          "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
       "inputs": [
         {
           "internalType": "address",
@@ -1184,45 +1128,6 @@
           "internalType": "bool",
           "name": "",
           "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText1",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText2",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "additionalText3",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
         }
       ],
       "stateMutability": "view",
@@ -1484,19 +1389,6 @@
           "internalType": "uint256",
           "name": "",
           "type": "uint256"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [],
-      "name": "contactEmail",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
         }
       ],
       "stateMutability": "view",
@@ -1971,19 +1863,6 @@
       "type": "function"
     },
     {
-      "inputs": [],
-      "name": "termsAndConditionsIpfsHash",
-      "outputs": [
-        {
-          "internalType": "string",
-          "name": "",
-          "type": "string"
-        }
-      ],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
       "inputs": [
         {
           "internalType": "address",
@@ -2268,24 +2147,6 @@
         }
       ],
       "name": "disputeJob",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
-          "name": "_jobId",
-          "type": "uint256"
-        },
-        {
-          "internalType": "string",
-          "name": "resolution",
-          "type": "string"
-        }
-      ],
-      "name": "resolveDispute",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"
@@ -2723,84 +2584,6 @@
       "inputs": [
         {
           "internalType": "uint256",
-          "name": "",
-          "type": "uint256"
-        }
-      ],
-      "name": "setAdditionalAgentPayoutPercentage",
-      "outputs": [],
-      "stateMutability": "view",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_hash",
-          "type": "string"
-        }
-      ],
-      "name": "updateTermsAndConditionsIpfsHash",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_email",
-          "type": "string"
-        }
-      ],
-      "name": "updateContactEmail",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText1",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText2",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "string",
-          "name": "_text",
-          "type": "string"
-        }
-      ],
-      "name": "updateAdditionalText3",
-      "outputs": [],
-      "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "uint256",
           "name": "jobId",
           "type": "uint256"
         }
@@ -3096,6 +2879,37 @@
         }
       ],
       "name": "withdrawAGI",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "rescueETH",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "bytes",
+          "name": "data",
+          "type": "bytes"
+        }
+      ],
+      "name": "rescueToken",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/docs/ui/abi/ui_required_interface.json
+++ b/docs/ui/abi/ui_required_interface.json
@@ -51,7 +51,6 @@
     "validateJob": 3,
     "disapproveJob": 3,
     "disputeJob": 1,
-    "resolveDispute": 2,
     "resolveDisputeWithCode": 3
   },
   "events": [
@@ -63,7 +62,6 @@
     "JobCompleted",
     "JobCancelled",
     "JobDisputed",
-    "DisputeResolved",
     "DisputeResolvedWithCode",
     "NFTIssued"
   ],

--- a/scripts/erc8004/export_metrics.js
+++ b/scripts/erc8004/export_metrics.js
@@ -119,6 +119,51 @@ function sortObjectByKeys(entries) {
   return Object.fromEntries(entries.sort(([a], [b]) => a.localeCompare(b)));
 }
 
+
+function hasEvent(contract, eventName) {
+  const json = contract.constructor?._json?.abi || contract.abi || [];
+  return json.some((item) => item && item.type === 'event' && item.name === eventName);
+}
+
+async function fetchEventsIfPresent(contract, eventName, fromBlock, toBlock, batchSize) {
+  if (!hasEvent(contract, eventName)) return [];
+  return fetchEvents(contract, eventName, fromBlock, toBlock, batchSize);
+}
+
+
+function decodeDisputeResolution(ev) {
+  const resolutionCodeRaw = ev.returnValues.resolutionCode || ev.returnValues[2];
+  if (resolutionCodeRaw !== undefined) {
+    const code = Number(resolutionCodeRaw);
+    if (code === 1) return 'agent win';
+    if (code === 2) return 'employer win';
+  }
+  const resolutionRaw = ev.returnValues.resolution || ev.returnValues.reason || ev.returnValues[2] || '';
+  return String(resolutionRaw).toLowerCase();
+}
+
+function isTypedDisputeResolutionEvent(ev) {
+  if ((ev.event || '') === 'DisputeResolvedWithCode') return true;
+  return ev.returnValues && ev.returnValues.resolutionCode !== undefined;
+}
+
+function mergeDisputeResolutionEvents(legacyEvents, typedEvents) {
+  const byKey = new Map();
+  for (const ev of legacyEvents.concat(typedEvents)) {
+    const jobId = String(ev.returnValues.jobId || ev.returnValues[0] || '');
+    const resolution = decodeDisputeResolution(ev);
+    const key = `${ev.transactionHash || ''}:${jobId}:${resolution}`;
+    const existing = byKey.get(key);
+    if (!existing || (isTypedDisputeResolutionEvent(ev) && !isTypedDisputeResolutionEvent(existing))) {
+      byKey.set(key, ev);
+    }
+  }
+  return Array.from(byKey.values()).sort((a, b) => {
+    if (a.blockNumber !== b.blockNumber) return a.blockNumber - b.blockNumber;
+    return (a.logIndex || 0) - (b.logIndex || 0);
+  });
+}
+
 function getAGIJobManagerContract() {
   const web3Instance = ensureWeb3();
   if (typeof artifacts !== 'undefined') {
@@ -176,14 +221,16 @@ async function runExportMetrics(overrides = {}) {
     jobCompletionRequested,
     jobCompleted,
     jobDisputed,
-    disputeResolved,
+    disputeResolvedLegacy,
+    disputeResolvedWithCode,
   ] = await Promise.all([
     fetchEvents(contract, 'JobCreated', fromBlock, toBlock, batchSize),
     fetchEvents(contract, 'JobApplied', fromBlock, toBlock, batchSize),
     fetchEvents(contract, 'JobCompletionRequested', fromBlock, toBlock, batchSize),
     fetchEvents(contract, 'JobCompleted', fromBlock, toBlock, batchSize),
     fetchEvents(contract, 'JobDisputed', fromBlock, toBlock, batchSize),
-    fetchEvents(contract, 'DisputeResolved', fromBlock, toBlock, batchSize),
+    fetchEventsIfPresent(contract, 'DisputeResolved', fromBlock, toBlock, batchSize),
+    fetchEventsIfPresent(contract, 'DisputeResolvedWithCode', fromBlock, toBlock, batchSize),
   ]);
 
   let jobValidated = [];
@@ -196,6 +243,8 @@ async function runExportMetrics(overrides = {}) {
       fetchEvents(contract, 'ReputationUpdated', fromBlock, toBlock, batchSize),
     ]);
   }
+
+  const disputeResolved = mergeDisputeResolutionEvents(disputeResolvedLegacy, disputeResolvedWithCode);
 
   const chainId = await web3.eth.getChainId();
   const contractAddress = contract.address;
@@ -363,8 +412,7 @@ async function runExportMetrics(overrides = {}) {
 
   for (const ev of disputeResolved) {
     const jobId = ev.returnValues.jobId || ev.returnValues[0];
-    const resolutionRaw = ev.returnValues.resolution || ev.returnValues[2] || '';
-    const resolution = String(resolutionRaw).toLowerCase();
+    const resolution = decodeDisputeResolution(ev);
     const job = await getJob(jobId);
     if (!job.assignedAgent) continue;
     const metrics = getAgent(job.assignedAgent);
@@ -515,3 +563,5 @@ module.exports = function (callback) {
 };
 
 module.exports.runExportMetrics = runExportMetrics;
+
+module.exports.mergeDisputeResolutionEvents = mergeDisputeResolutionEvents;

--- a/scripts/postdeploy-config.js
+++ b/scripts/postdeploy-config.js
@@ -38,6 +38,11 @@ function toStringValue(value) {
   return String(value);
 }
 
+
+function hasMethod(instance, name) {
+  return typeof instance[name] === "function";
+}
+
 function parseEnvList(value) {
   if (!value) return [];
   return value
@@ -444,79 +449,92 @@ module.exports = async function postdeployConfig(callback) {
       console.warn("additionalAgentPayoutPercentage is deprecated and ignored.");
     }
 
-    await addParamOp({
-      key: "termsAndConditionsIpfsHash",
-      label: "Set termsAndConditionsIpfsHash",
-      currentValue: await instance.termsAndConditionsIpfsHash(),
-      desiredValue: config.termsAndConditionsIpfsHash,
-      send: () =>
-        instance.updateTermsAndConditionsIpfsHash(
-          config.termsAndConditionsIpfsHash,
-          txFrom ? { from: txFrom } : {}
-        ),
-      verify: async () => {
-        const updated = await instance.termsAndConditionsIpfsHash();
-        if (updated !== config.termsAndConditionsIpfsHash) {
-          throw new Error("termsAndConditionsIpfsHash did not update");
-        }
-      },
-    });
+    if (
+      hasMethod(instance, "termsAndConditionsIpfsHash")
+      && hasMethod(instance, "updateTermsAndConditionsIpfsHash")
+    ) {
+      await addParamOp({
+        key: "termsAndConditionsIpfsHash",
+        label: "Set termsAndConditionsIpfsHash",
+        currentValue: await instance.termsAndConditionsIpfsHash(),
+        desiredValue: config.termsAndConditionsIpfsHash,
+        send: () =>
+          instance.updateTermsAndConditionsIpfsHash(
+            config.termsAndConditionsIpfsHash,
+            txFrom ? { from: txFrom } : {}
+          ),
+        verify: async () => {
+          const updated = await instance.termsAndConditionsIpfsHash();
+          if (updated !== config.termsAndConditionsIpfsHash) {
+            throw new Error("termsAndConditionsIpfsHash did not update");
+          }
+        },
+      });
+    }
 
-    await addParamOp({
-      key: "contactEmail",
-      label: "Set contactEmail",
-      currentValue: await instance.contactEmail(),
-      desiredValue: config.contactEmail,
-      send: () => instance.updateContactEmail(config.contactEmail, txFrom ? { from: txFrom } : {}),
-      verify: async () => {
-        const updated = await instance.contactEmail();
-        if (updated !== config.contactEmail) {
-          throw new Error("contactEmail did not update");
-        }
-      },
-    });
+    if (hasMethod(instance, "contactEmail") && hasMethod(instance, "updateContactEmail")) {
+      await addParamOp({
+        key: "contactEmail",
+        label: "Set contactEmail",
+        currentValue: await instance.contactEmail(),
+        desiredValue: config.contactEmail,
+        send: () => instance.updateContactEmail(config.contactEmail, txFrom ? { from: txFrom } : {}),
+        verify: async () => {
+          const updated = await instance.contactEmail();
+          if (updated !== config.contactEmail) {
+            throw new Error("contactEmail did not update");
+          }
+        },
+      });
+    }
 
-    await addParamOp({
-      key: "additionalText1",
-      label: "Set additionalText1",
-      currentValue: await instance.additionalText1(),
-      desiredValue: config.additionalText1,
-      send: () => instance.updateAdditionalText1(config.additionalText1, txFrom ? { from: txFrom } : {}),
-      verify: async () => {
-        const updated = await instance.additionalText1();
-        if (updated !== config.additionalText1) {
-          throw new Error("additionalText1 did not update");
-        }
-      },
-    });
+    if (hasMethod(instance, "additionalText1") && hasMethod(instance, "updateAdditionalText1")) {
+      await addParamOp({
+        key: "additionalText1",
+        label: "Set additionalText1",
+        currentValue: await instance.additionalText1(),
+        desiredValue: config.additionalText1,
+        send: () => instance.updateAdditionalText1(config.additionalText1, txFrom ? { from: txFrom } : {}),
+        verify: async () => {
+          const updated = await instance.additionalText1();
+          if (updated !== config.additionalText1) {
+            throw new Error("additionalText1 did not update");
+          }
+        },
+      });
+    }
 
-    await addParamOp({
-      key: "additionalText2",
-      label: "Set additionalText2",
-      currentValue: await instance.additionalText2(),
-      desiredValue: config.additionalText2,
-      send: () => instance.updateAdditionalText2(config.additionalText2, txFrom ? { from: txFrom } : {}),
-      verify: async () => {
-        const updated = await instance.additionalText2();
-        if (updated !== config.additionalText2) {
-          throw new Error("additionalText2 did not update");
-        }
-      },
-    });
+    if (hasMethod(instance, "additionalText2") && hasMethod(instance, "updateAdditionalText2")) {
+      await addParamOp({
+        key: "additionalText2",
+        label: "Set additionalText2",
+        currentValue: await instance.additionalText2(),
+        desiredValue: config.additionalText2,
+        send: () => instance.updateAdditionalText2(config.additionalText2, txFrom ? { from: txFrom } : {}),
+        verify: async () => {
+          const updated = await instance.additionalText2();
+          if (updated !== config.additionalText2) {
+            throw new Error("additionalText2 did not update");
+          }
+        },
+      });
+    }
 
-    await addParamOp({
-      key: "additionalText3",
-      label: "Set additionalText3",
-      currentValue: await instance.additionalText3(),
-      desiredValue: config.additionalText3,
-      send: () => instance.updateAdditionalText3(config.additionalText3, txFrom ? { from: txFrom } : {}),
-      verify: async () => {
-        const updated = await instance.additionalText3();
-        if (updated !== config.additionalText3) {
-          throw new Error("additionalText3 did not update");
-        }
-      },
-    });
+    if (hasMethod(instance, "additionalText3") && hasMethod(instance, "updateAdditionalText3")) {
+      await addParamOp({
+        key: "additionalText3",
+        label: "Set additionalText3",
+        currentValue: await instance.additionalText3(),
+        desiredValue: config.additionalText3,
+        send: () => instance.updateAdditionalText3(config.additionalText3, txFrom ? { from: txFrom } : {}),
+        verify: async () => {
+          const updated = await instance.additionalText3();
+          if (updated !== config.additionalText3) {
+            throw new Error("additionalText3 did not update");
+          }
+        },
+      });
+    }
 
     const currentValidatorMerkleRoot = await instance.validatorMerkleRoot();
     const currentAgentMerkleRoot = await instance.agentMerkleRoot();

--- a/scripts/verify-config.js
+++ b/scripts/verify-config.js
@@ -168,6 +168,10 @@ function report(status, key, message) {
   return status === "FAIL";
 }
 
+function hasMethod(instance, name) {
+  return typeof instance[name] === "function";
+}
+
 module.exports = async function verifyConfig(callback) {
   try {
     const args = parseArgs(process.argv);
@@ -183,99 +187,39 @@ module.exports = async function verifyConfig(callback) {
 
     let failed = false;
 
-    const checks = [
-      {
-        key: "requiredValidatorApprovals",
-        expected: config.requiredValidatorApprovals,
-        actual: await instance.requiredValidatorApprovals(),
-      },
-      {
-        key: "requiredValidatorDisapprovals",
-        expected: config.requiredValidatorDisapprovals,
-        actual: await instance.requiredValidatorDisapprovals(),
-      },
-      {
-        key: "premiumReputationThreshold",
-        expected: config.premiumReputationThreshold,
-        actual: await instance.premiumReputationThreshold(),
-      },
-      {
-        key: "validationRewardPercentage",
-        expected: config.validationRewardPercentage,
-        actual: await instance.validationRewardPercentage(),
-      },
-      {
-        key: "maxJobPayout",
-        expected: config.maxJobPayout,
-        actual: await instance.maxJobPayout(),
-      },
-      {
-        key: "jobDurationLimit",
-        expected: config.jobDurationLimit,
-        actual: await instance.jobDurationLimit(),
-      },
-      {
-        key: "completionReviewPeriod",
-        expected: config.completionReviewPeriod,
-        actual: await instance.completionReviewPeriod(),
-      },
-      {
-        key: "disputeReviewPeriod",
-        expected: config.disputeReviewPeriod,
-        actual: await instance.disputeReviewPeriod(),
-      },
-      {
-        key: "additionalAgentPayoutPercentage",
-        expected: config.additionalAgentPayoutPercentage,
-        actual: await instance.additionalAgentPayoutPercentage(),
-      },
-      {
-        key: "termsAndConditionsIpfsHash",
-        expected: config.termsAndConditionsIpfsHash,
-        actual: await instance.termsAndConditionsIpfsHash(),
-      },
-      {
-        key: "contactEmail",
-        expected: config.contactEmail,
-        actual: await instance.contactEmail(),
-      },
-      {
-        key: "additionalText1",
-        expected: config.additionalText1,
-        actual: await instance.additionalText1(),
-      },
-      {
-        key: "additionalText2",
-        expected: config.additionalText2,
-        actual: await instance.additionalText2(),
-      },
-      {
-        key: "additionalText3",
-        expected: config.additionalText3,
-        actual: await instance.additionalText3(),
-      },
-      {
-        key: "validatorMerkleRoot",
-        expected: config.validatorMerkleRoot,
-        actual: await instance.validatorMerkleRoot(),
-      },
-      {
-        key: "agentMerkleRoot",
-        expected: config.agentMerkleRoot,
-        actual: await instance.agentMerkleRoot(),
-      },
+    const checkSpecs = [
+      ["requiredValidatorApprovals", "requiredValidatorApprovals"],
+      ["requiredValidatorDisapprovals", "requiredValidatorDisapprovals"],
+      ["premiumReputationThreshold", "premiumReputationThreshold"],
+      ["validationRewardPercentage", "validationRewardPercentage"],
+      ["maxJobPayout", "maxJobPayout"],
+      ["jobDurationLimit", "jobDurationLimit"],
+      ["completionReviewPeriod", "completionReviewPeriod"],
+      ["disputeReviewPeriod", "disputeReviewPeriod"],
+      ["additionalAgentPayoutPercentage", "additionalAgentPayoutPercentage"],
+      ["termsAndConditionsIpfsHash", "termsAndConditionsIpfsHash"],
+      ["contactEmail", "contactEmail"],
+      ["additionalText1", "additionalText1"],
+      ["additionalText2", "additionalText2"],
+      ["additionalText3", "additionalText3"],
+      ["validatorMerkleRoot", "validatorMerkleRoot"],
+      ["agentMerkleRoot", "agentMerkleRoot"],
     ];
 
-    for (const check of checks) {
-      if (check.expected === undefined) {
+    for (const [key, methodName] of checkSpecs) {
+      const expectedValue = config[key];
+      if (expectedValue === undefined) continue;
+      if (!hasMethod(instance, methodName)) {
+        report("SKIP", key, `method ${methodName}() not in ABI; skipping`);
         continue;
       }
-      const expected = toStringValue(check.expected);
-      const actual = toStringValue(check.actual);
+      const actualValue = await instance[methodName]();
+      const expected = toStringValue(expectedValue);
+      const actual = toStringValue(actualValue);
       if (expected === actual) {
-        report("PASS", check.key, `${actual}`);
+        report("PASS", key, `${actual}`);
       } else {
-        failed = report("FAIL", check.key, `expected ${expected}, got ${actual}`) || failed;
+        failed = report("FAIL", key, `expected ${expected}, got ${actual}`) || failed;
       }
     }
 

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -324,7 +324,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
       const tokenIdAfterCompletion = await manager.nextTokenId();
       await expectCustomError(
-        manager.resolveDispute.call(0, "agent win", { from: moderator }),
+        manager.resolveDisputeWithCode.call(0, 1, "agent win", { from: moderator }),
         "InvalidState"
       );
       await expectCustomError(manager.disputeJob.call(0, { from: employer }), "InvalidState");
@@ -343,7 +343,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.disputeJob(0, { from: employer });
 
       const employerBalanceBefore = await token.balanceOf(employer);
-      await manager.resolveDispute(0, "employer win", { from: moderator });
+      await manager.resolveDisputeWithCode(0, 2, "employer win", { from: moderator });
       const employerBalanceAfter = await token.balanceOf(employer);
 
       const agentBond = await computeAgentBond(manager, payout, duration);
@@ -359,7 +359,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
         "InvalidState"
       );
       await expectCustomError(
-        manager.resolveDispute.call(0, "agent win", { from: moderator }),
+        manager.resolveDisputeWithCode.call(0, 1, "agent win", { from: moderator }),
         "InvalidState"
       );
     });
@@ -376,7 +376,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await manager.disputeJob(0, { from: agent });
 
       const agentBalanceBefore = await token.balanceOf(agent);
-      await manager.resolveDispute(0, "agent win", { from: moderator });
+      await manager.resolveDisputeWithCode(0, 1, "agent win", { from: moderator });
       const agentBalanceAfter = await token.balanceOf(agent);
 
       const agentBond = await computeAgentBond(manager, payout, duration);
@@ -620,7 +620,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
       await altManager.requestJobCompletion(0, updatedIpfs, { from: agent });
       await altManager.disputeJob(0, { from: agent });
       await expectCustomError(
-        altManager.resolveDispute.call(0, "agent win", { from: moderator }),
+        altManager.resolveDisputeWithCode.call(0, 1, "agent win", { from: moderator }),
         "TransferFailed"
       );
     });

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -254,7 +254,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
       await manager.disputeJob(jobId, { from: employer });
       await manager.addModerator(moderator, { from: owner });
 
-      await manager.resolveDispute(jobId, "agent win", { from: moderator });
+      await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
       const tokenId = (await manager.nextTokenId()).toNumber() - 1;
       assert.equal(await manager.ownerOf(tokenId), employer);
     });

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -466,7 +466,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
         manager.disapproveJob(jobId, "validator", buildProof(validatorTree, validator2), { from: validator2 }),
         "InvalidState"
       );
-      await expectCustomError(manager.resolveDispute(jobId, "agent win", { from: moderator }), "InvalidState");
+      await expectCustomError(manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator }), "InvalidState");
     });
 
     it("blocks disputes after completion", async () => {
@@ -499,7 +499,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await manager.disputeJob(jobId, { from: employer });
 
       const agentBalanceBefore = new BN(await token.balanceOf(agent));
-      await manager.resolveDispute(jobId, "agent win", { from: moderator });
+      await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
       const agentBalanceAfter = new BN(await token.balanceOf(agent));
 
       const agentBond = await computeAgentBond(manager, payout, new BN(1000));
@@ -590,7 +590,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await expectCustomError(manager.disputeJob(jobId, { from: agent }), "InvalidState");
 
       await manager.addModerator(moderator, { from: owner });
-      await manager.resolveDispute(jobId, "employer win", { from: moderator });
+      await manager.resolveDisputeWithCode(jobId, 2, "employer win", { from: moderator });
       await expectCustomError(manager.disputeJob(jobId, { from: employer }), "InvalidState");
     });
 
@@ -607,14 +607,14 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await manager.disputeJob(jobId, { from: employer });
 
       const agentBalanceBefore = new BN(await token.balanceOf(agent));
-      const resolveReceipt = await manager.resolveDispute(jobId, "agent win", { from: moderator });
-      expectEvent(resolveReceipt, "DisputeResolved", { jobId: new BN(jobId), resolver: moderator });
+      const resolveReceipt = await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
+      expectEvent(resolveReceipt, "DisputeResolvedWithCode", { jobId: new BN(jobId), resolver: moderator, resolutionCode: new BN(1) });
       const agentBalanceAfter = new BN(await token.balanceOf(agent));
       const agentBond = await computeAgentBond(manager, payout, new BN(1000));
       const agentPayout = payout.muln(92).divn(100).add(agentBond).add(disputeBond);
       assert(agentBalanceAfter.sub(agentBalanceBefore).eq(agentPayout));
 
-      await expectCustomError(manager.resolveDispute(jobId, "agent win", { from: moderator }), "InvalidState");
+      await expectCustomError(manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator }), "InvalidState");
 
       const payout2 = new BN(web3.utils.toWei("40"));
       const { jobId: jobId2 } = await createJob(manager, token, employer, payout2, 1000, "ipfs-2");
@@ -624,7 +624,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await manager.disputeJob(jobId2, { from: employer });
 
       const employerBalanceBefore = new BN(await token.balanceOf(employer));
-      await manager.resolveDispute(jobId2, "employer win", { from: moderator });
+      await manager.resolveDisputeWithCode(jobId2, 2, "employer win", { from: moderator });
       const employerBalanceAfter = new BN(await token.balanceOf(employer));
       const agentBond2 = await computeAgentBond(manager, payout2, new BN(1000));
       assert(employerBalanceAfter.sub(employerBalanceBefore).eq(payout2.add(agentBond2).add(disputeBond2)));
@@ -644,7 +644,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await fundDisputeBond(token, manager, agent, payout, owner);
       await manager.disputeJob(jobId, { from: agent });
 
-      const receipt = await manager.resolveDispute(jobId, "needs-more-info", { from: moderator });
+      const receipt = await manager.resolveDisputeWithCode(jobId, 0, "needs-more-info", { from: moderator });
       expectEvent(receipt, "DisputeResolvedWithCode", {
         jobId: new BN(jobId),
         resolver: moderator,
@@ -668,7 +668,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
       await fundDisputeBond(token, manager, employer, payout, owner);
       await manager.disputeJob(jobId, { from: employer });
 
-      await expectCustomError(manager.resolveDispute(jobId, "agent win", { from: other }), "NotModerator");
+      await expectCustomError(manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: other }), "NotModerator");
     });
   });
 
@@ -832,22 +832,11 @@ contract("AGIJobManager comprehensive", (accounts) => {
         manager.contributeToRewardPool(web3.utils.toWei("1"), { from: employer }));
     });
 
-    it("updates metadata fields and premium threshold", async () => {
-      await expectRevert.unspecified(manager.updateTermsAndConditionsIpfsHash("hash", { from: other }));
-      await manager.updateTermsAndConditionsIpfsHash("terms", { from: owner });
-      await manager.updateContactEmail("contact@example.com", { from: owner });
-      await manager.updateAdditionalText1("text1", { from: owner });
-      await manager.updateAdditionalText2("text2", { from: owner });
-      await manager.updateAdditionalText3("text3", { from: owner });
+    it("updates premium threshold", async () => {
       await manager.setPremiumReputationThreshold(42, { from: owner });
-
-      assert.equal(await manager.termsAndConditionsIpfsHash(), "terms");
-      assert.equal(await manager.contactEmail(), "contact@example.com");
-      assert.equal(await manager.additionalText1(), "text1");
-      assert.equal(await manager.additionalText2(), "text2");
-      assert.equal(await manager.additionalText3(), "text3");
       assert.equal(await manager.premiumReputationThreshold(), "42");
     });
+
 
     it("updates baseIpfsUrl for future mints", async () => {
       await expectRevert.unspecified(manager.setBaseIpfsUrl("ipfs://new", { from: other }));

--- a/test/AGIJobManager.test.js
+++ b/test/AGIJobManager.test.js
@@ -18,7 +18,7 @@ const functionNames = new Set(
   artifact.abi.filter((item) => item.type === "function").map((item) => item.name)
 );
 
-["createJob", "applyForJob", "resolveDispute", "resolveDisputeWithCode"].forEach((name) => {
+["createJob", "applyForJob", "resolveDisputeWithCode"].forEach((name) => {
   assert.ok(functionNames.has(name), `Missing expected function: ${name}`);
 });
 
@@ -26,7 +26,7 @@ const eventNames = new Set(
   artifact.abi.filter((item) => item.type === "event").map((item) => item.name)
 );
 
-["JobCreated", "JobCompleted", "DisputeResolved", "DisputeResolvedWithCode"].forEach((name) => {
+["JobCreated", "JobCompleted", "DisputeResolvedWithCode"].forEach((name) => {
   assert.ok(eventNames.has(name), `Missing expected event: ${name}`);
 });
 

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -278,7 +278,6 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.removeModerator(other, { from: owner });
     assert.equal(await manager.moderators(other), false, "moderator should be removable after lock");
     await manager.addAdditionalAgent(other, { from: owner });
-    await manager.updateContactEmail("ops@example.com", { from: owner });
     await manager.blacklistAgent(agent, true, { from: owner });
 
     await manager.pause({ from: owner });

--- a/test/caseStudies.job12.replay.test.js
+++ b/test/caseStudies.job12.replay.test.js
@@ -346,7 +346,7 @@ contract("Case study replay: legacy AGI Job 12", (accounts) => {
     await manager.disputeJob(jobId, { from: employer });
 
     const beforeTokenId = await manager.nextTokenId();
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
     const afterTokenId = await manager.nextTokenId();
 
     assert.equal(afterTokenId.toString(), new BN(beforeTokenId).addn(1).toString());

--- a/test/disputeHardening.test.js
+++ b/test/disputeHardening.test.js
@@ -244,7 +244,7 @@ contract("AGIJobManager dispute hardening", (accounts) => {
 
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
     const agentBalanceBefore = await token.balanceOf(agent);
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
     const agentBalanceAfter = await token.balanceOf(agent);
     const expectedAgentPayout = payout.muln(90).divn(100).add(agentBond).add(disputeBond);
     assert(agentBalanceAfter.sub(agentBalanceBefore).eq(expectedAgentPayout));
@@ -260,7 +260,7 @@ contract("AGIJobManager dispute hardening", (accounts) => {
     assert(agentBeforeDispute.sub(agentAfterDispute).eq(disputeBondTwo));
 
     const employerBeforeResolve = await token.balanceOf(employer);
-    await manager.resolveDispute(jobIdTwo, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobIdTwo, 2, "employer win", { from: moderator });
     const employerAfterResolve = await token.balanceOf(employer);
     assert(employerAfterResolve.sub(employerBeforeResolve).eq(payoutTwo.add(agentBondTwo).add(disputeBondTwo)));
   });

--- a/test/economicSafety.test.js
+++ b/test/economicSafety.test.js
@@ -79,27 +79,7 @@ contract("AGIJobManager economic safety", (accounts) => {
     await expectCustomError(manager.setValidationRewardPercentage.call(30, { from: owner }), "InvalidParameters");
   });
 
-  it("reverts deprecated additional agent payout settings", async () => {
-    const manager = await AGIJobManager.new(...buildInitConfig(
-        token.address,
-        "ipfs://base",
-        ens.address,
-        nameWrapper.address,
-        clubRoot,
-        agentRoot,
-        clubRoot,
-        agentRoot,
-        ZERO_ROOT,
-        ZERO_ROOT,
-      ),
-      { from: owner }
-    );
 
-    await expectCustomError(
-      manager.setAdditionalAgentPayoutPercentage.call(90, { from: owner }),
-      "DeprecatedParameter"
-    );
-  });
 
   it("settles successfully with safe payout configuration", async () => {
     const manager = await AGIJobManager.new(...buildInitConfig(

--- a/test/erc8004.adapter.test.js
+++ b/test/erc8004.adapter.test.js
@@ -12,7 +12,7 @@ const MockResolver = artifacts.require('MockResolver');
 const MockERC721 = artifacts.require('MockERC721');
 const MockNameWrapper = artifacts.require('MockNameWrapper');
 
-const { runExportMetrics } = require('../scripts/erc8004/export_metrics');
+const { runExportMetrics, mergeDisputeResolutionEvents } = require('../scripts/erc8004/export_metrics');
 const { buildInitConfig } = require('./helpers/deploy');
 const { fundValidators, fundAgents } = require('./helpers/bonds');
 
@@ -72,6 +72,27 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
     await fundAgents(token, manager, [agent], owner);
   });
 
+
+  it('deduplicates legacy and typed dispute events for the same settlement', async () => {
+    const legacy = {
+      event: 'DisputeResolved',
+      transactionHash: '0xabc',
+      blockNumber: 10,
+      logIndex: 1,
+      returnValues: { jobId: '7', resolution: 'employer win' },
+    };
+    const typed = {
+      event: 'DisputeResolvedWithCode',
+      transactionHash: '0xabc',
+      blockNumber: 10,
+      logIndex: 2,
+      returnValues: { jobId: '7', resolutionCode: '2', reason: 'employer win' },
+    };
+    const merged = mergeDisputeResolutionEvents([legacy], [typed]);
+    assert.strictEqual(merged.length, 1, 'same settlement should not be double-counted');
+    assert.strictEqual(merged[0].event, 'DisputeResolvedWithCode', 'typed event should be preferred');
+  });
+
   it('exports deterministic metrics and expected aggregates', async () => {
     const jobId1 = await createJob();
     await manager.applyForJob(jobId1, 'agent', EMPTY_PROOF, { from: agent });
@@ -85,7 +106,7 @@ contract('ERC-8004 adapter export (smoke test)', (accounts) => {
     await manager.applyForJob(jobId2, 'agent', EMPTY_PROOF, { from: agent });
     await manager.requestJobCompletion(jobId2, 'ipfs-disputed', { from: agent });
     await manager.disapproveJob(jobId2, 'club', EMPTY_PROOF, { from: validator });
-    await manager.resolveDispute(jobId2, 'employer win', { from: moderator });
+    await manager.resolveDisputeWithCode(jobId2, 2, 'employer win', { from: moderator });
 
     const toBlock = await web3.eth.getBlockNumber();
     const outDir = fs.mkdtempSync(path.join(os.tmpdir(), 'erc8004-'));

--- a/test/escrowAccounting.test.js
+++ b/test/escrowAccounting.test.js
@@ -335,7 +335,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const jobAfterDisapproval = await manager.getJobCore(jobId);
     assert.equal(jobAfterDisapproval.disputed, true, "job should enter dispute at disapproval threshold");
 
-    await manager.resolveDispute(jobId, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 2, "employer win", { from: moderator });
 
     const validatorAfter = await token.balanceOf(validator);
     const validatorTwoAfter = await token.balanceOf(validatorTwo);
@@ -410,7 +410,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     const disputeBond = await fundDisputeBond(token, manager, employer, payout, owner);
     await manager.disputeJob(jobId, { from: employer });
     const employerBefore = await token.balanceOf(employer);
-    await manager.resolveDispute(jobId, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 2, "employer win", { from: moderator });
     const employerAfter = await token.balanceOf(employer);
     assert.equal(employerAfter.sub(employerBefore).toString(), payout.add(agentBond).add(disputeBond).toString());
 
@@ -451,7 +451,7 @@ contract("AGIJobManager escrow accounting", (accounts) => {
     await manager.requestJobCompletion(disputeJobId, "ipfs-dispute", { from: agent });
     await fundDisputeBond(token, manager, employer, payout, owner);
     await manager.disputeJob(disputeJobId, { from: employer });
-    await manager.resolveDispute(disputeJobId, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(disputeJobId, 2, "employer win", { from: moderator });
     assert.equal((await manager.lockedEscrow()).toString(), "0");
 
     const expireJobId = await createJob(payout, 1);

--- a/test/jobStatus.test.js
+++ b/test/jobStatus.test.js
@@ -77,7 +77,7 @@ contract("AGIJobManager jobStatus", (accounts) => {
     job = await manager.getJobCore(jobId);
     assert.strictEqual(job.disputed, true, "disputed job should be flagged");
 
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
     job = await manager.getJobCore(jobId);
     assert.strictEqual(job.completed, true, "resolved job should be completed");
   });

--- a/test/mainnetHardening.test.js
+++ b/test/mainnetHardening.test.js
@@ -9,6 +9,12 @@ const MockENSJobPagesMalformed = artifacts.require("MockENSJobPagesMalformed");
 const RevertingENSRegistry = artifacts.require("RevertingENSRegistry");
 const RevertingNameWrapper = artifacts.require("RevertingNameWrapper");
 const RevertingResolver = artifacts.require("RevertingResolver");
+const ForceSendETH = artifacts.require("ForceSendETH");
+const MockRescueERC20 = artifacts.require("MockRescueERC20");
+const MockRescueERC721 = artifacts.require("MockRescueERC721");
+const MockRescueERC1155 = artifacts.require("MockRescueERC1155");
+const MockRescueERC20False = artifacts.require("MockRescueERC20False");
+const MockRescueMalformedReturn = artifacts.require("MockRescueMalformedReturn");
 
 const { buildInitConfig } = require("./helpers/deploy");
 const { expectCustomError } = require("./helpers/errors");
@@ -154,5 +160,100 @@ contract("AGIJobManager mainnet hardening", (accounts) => {
     const core = await manager.getJobCore(0);
     assert.equal(core.completed, true);
   });
+
+  it("rescues forced ETH to owner", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await deployManager(token, ens.address, wrapper.address);
+    const sender = await ForceSendETH.new({ from: owner, value: web3.utils.toWei("1") });
+
+    await sender.boom(manager.address, { from: owner });
+    const ownerBefore = BigInt(await web3.eth.getBalance(owner));
+    const tx = await manager.rescueETH(web3.utils.toWei("1"), { from: owner });
+    const gasSpent = BigInt(tx.receipt.gasUsed) * BigInt((await web3.eth.getTransaction(tx.tx)).gasPrice);
+    const ownerAfter = BigInt(await web3.eth.getBalance(owner));
+    assert.equal(ownerAfter - ownerBefore + gasSpent, BigInt(web3.utils.toWei("1")));
+  });
+
+  it("rescues non-AGI tokens via calldata and blocks AGI token rescue", async () => {
+    const agi = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await deployManager(agi, ens.address, wrapper.address);
+
+    const erc20 = await MockRescueERC20.new({ from: owner });
+    const erc721 = await MockRescueERC721.new({ from: owner });
+    const erc1155 = await MockRescueERC1155.new({ from: owner });
+
+    await erc20.mint(manager.address, 7, { from: owner });
+    await erc721.mint(manager.address, 9, { from: owner });
+    await erc1155.mint(manager.address, 11, 13, { from: owner });
+
+    const erc20Data = web3.eth.abi.encodeFunctionCall(
+      { name: "transfer", type: "function", inputs: [
+        { type: "address", name: "to" },
+        { type: "uint256", name: "amount" }
+      ] },
+      [owner, "7"]
+    );
+    await manager.rescueToken(erc20.address, erc20Data, { from: owner });
+    assert.equal((await erc20.balanceOf(owner)).toString(), "7");
+
+    const erc721Data = web3.eth.abi.encodeFunctionCall(
+      { name: "transferFrom", type: "function", inputs: [
+        { type: "address", name: "from" },
+        { type: "address", name: "to" },
+        { type: "uint256", name: "tokenId" }
+      ] },
+      [manager.address, owner, "9"]
+    );
+    await manager.rescueToken(erc721.address, erc721Data, { from: owner });
+    assert.equal(await erc721.ownerOf(9), owner);
+
+    const erc1155Data = web3.eth.abi.encodeFunctionCall(
+      { name: "safeTransferFrom", type: "function", inputs: [
+        { type: "address", name: "from" },
+        { type: "address", name: "to" },
+        { type: "uint256", name: "id" },
+        { type: "uint256", name: "amount" },
+        { type: "bytes", name: "data" }
+      ] },
+      [manager.address, owner, "11", "13", "0x"]
+    );
+    await manager.rescueToken(erc1155.address, erc1155Data, { from: owner });
+    assert.equal((await erc1155.balanceOf(owner, 11)).toString(), "13");
+
+    const agiData = web3.eth.abi.encodeFunctionCall(
+      { name: "transfer", type: "function", inputs: [
+        { type: "address", name: "to" },
+        { type: "uint256", name: "amount" }
+      ] },
+      [owner, "1"]
+    );
+    await expectCustomError(manager.rescueToken.call(agi.address, agiData, { from: owner }), "InvalidParameters");
+  });
+
+
+  it("reverts rescueToken when token returns false or malformed returndata", async () => {
+    const agi = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await deployManager(agi, ens.address, wrapper.address);
+    const falseToken = await MockRescueERC20False.new({ from: owner });
+    const malformedToken = await MockRescueMalformedReturn.new({ from: owner });
+
+    const transferData = web3.eth.abi.encodeFunctionCall(
+      { name: "transfer", type: "function", inputs: [
+        { type: "address", name: "to" },
+        { type: "uint256", name: "amount" }
+      ] },
+      [owner, "1"]
+    );
+
+    await expectCustomError(manager.rescueToken.call(falseToken.address, transferData, { from: owner }), "TransferFailed");
+    await expectCustomError(manager.rescueToken.call(malformedToken.address, transferData, { from: owner }), "TransferFailed");
+  });
+
 
 });

--- a/test/regressions.better-only.js
+++ b/test/regressions.better-only.js
@@ -145,7 +145,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     await token.mint(current.address, payout, { from: owner });
     await expectRevert(current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator }));
     assert.equal((await current.nextTokenId()).toNumber(), 0, "current should not mint while disputed");
-    await current.resolveDispute(currentJobId, "agent win", { from: moderator });
+    await current.resolveDisputeWithCode(currentJobId, 1, "agent win", { from: moderator });
     assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint once via dispute resolution");
   });
 
@@ -175,7 +175,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     await fundDisputeBond(token, current, employer, payout, owner);
     await current.disputeJob(currentJobId, { from: employer });
     await current.addModerator(moderator, { from: owner });
-    await current.resolveDispute(currentJobId, "agent win", { from: moderator });
+    await current.resolveDisputeWithCode(currentJobId, 1, "agent win", { from: moderator });
     assert.equal((await current.nextTokenId()).toNumber(), 1, "current should mint despite zero validators");
   });
 
@@ -251,7 +251,7 @@ contract("AGIJobManager better-only regressions", (accounts) => {
     await current.addModerator(moderator, { from: owner });
     await current.setRequiredValidatorApprovals(1, { from: owner });
     await token.mint(current.address, payout, { from: owner });
-    await current.resolveDispute(currentJobId, "employer win", { from: moderator });
+    await current.resolveDisputeWithCode(currentJobId, 2, "employer win", { from: moderator });
     await expectRevert(current.validateJob(currentJobId, "validator", EMPTY_PROOF, { from: validator }));
   });
 

--- a/test/scenarioEconomicStateMachine.test.js
+++ b/test/scenarioEconomicStateMachine.test.js
@@ -225,7 +225,7 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
       contract: await token.balanceOf(manager.address),
     };
 
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
     const jobAfterAgentWin = await manager.getJobCore(jobId);
     assert.strictEqual(jobAfterAgentWin.completed, true, "agent-win dispute should complete job");
     assert.strictEqual(jobAfterAgentWin.disputed, false, "dispute flag should clear after resolution");
@@ -265,10 +265,10 @@ contract("AGIJobManager economic state-machine scenarios", (accounts) => {
     await manager.disapproveJob(jobIdTwo, "validator-b", EMPTY_PROOF, { from: validatorB });
     const disputedJob = await manager.getJobCore(jobIdTwo);
     assert.strictEqual(disputedJob.disputed, true, "job should be disputed after disapprovals");
-    await expectCustomError(manager.resolveDispute.call(jobIdTwo, "agent win", { from: other }), "NotModerator");
+    await expectCustomError(manager.resolveDisputeWithCode.call(jobIdTwo, 1, "agent win", { from: other }), "NotModerator");
 
     const employerBefore = await token.balanceOf(employer);
-    await manager.resolveDispute(jobIdTwo, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobIdTwo, 2, "employer win", { from: moderator });
     const employerAfter = await token.balanceOf(employer);
     const validatorRewardTotal = payoutTwo.mul(await manager.validationRewardPercentage()).divn(100);
     const agentBondTwo = await computeAgentBond(manager, payoutTwo, toBN(3600));

--- a/test/securityRegression.test.js
+++ b/test/securityRegression.test.js
@@ -85,7 +85,7 @@ contract("AGIJobManager security regressions", (accounts) => {
       "JobNotFound"
     );
     await expectCustomError(manager.disputeJob.call(999, { from: employer }), "JobNotFound");
-    await expectCustomError(manager.resolveDispute.call(999, "agent win", { from: moderator }), "JobNotFound");
+    await expectCustomError(manager.resolveDisputeWithCode.call(999, 1, "agent win", { from: moderator }), "JobNotFound");
   });
 
   it("blocks double completion and employer-win follow-up", async () => {
@@ -114,7 +114,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await manager.requestJobCompletion(jobIdTwo, "ipfs-done-two", { from: agent });
     await fundDisputeBond(token, manager, employer, payoutTwo, owner);
     await manager.disputeJob(jobIdTwo, { from: employer });
-    await manager.resolveDispute(jobIdTwo, "employer win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobIdTwo, 2, "employer win", { from: moderator });
     await expectCustomError(
       manager.validateJob.call(jobIdTwo, "validator", EMPTY_PROOF, { from: validator }),
       "InvalidState"
@@ -138,7 +138,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     const disputeBond = await fundDisputeBond(token, manager, employer, payout, owner);
     await manager.disputeJob(jobId, { from: employer });
     const agentBefore = await token.balanceOf(agent);
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
 
     const agentBalance = await token.balanceOf(agent);
     const agentBond = await computeAgentBond(manager, payout, toBN(1000));
@@ -192,7 +192,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await fundDisputeBond(token, manager, employer, payout, owner);
     await manager.disputeJob(jobId, { from: employer });
 
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
 
     const job = await manager.getJobCore(jobId);
     const jobValidation = await manager.getJobValidation(jobId);
@@ -213,7 +213,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await time.increase(2);
     await fundDisputeBond(token, manager, employer, payout, owner);
     await manager.disputeJob(jobId, { from: employer });
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
 
     const job = await manager.getJobCore(jobId);
     const jobValidation = await manager.getJobValidation(jobId);
@@ -234,7 +234,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await manager.disputeJob(jobId, { from: employer });
 
     await manager.pause({ from: owner });
-    await manager.resolveDispute(jobId, "agent win", { from: moderator });
+    await manager.resolveDisputeWithCode(jobId, 1, "agent win", { from: moderator });
 
     const job = await manager.getJobCore(jobId);
     const jobValidation = await manager.getJobValidation(jobId);
@@ -289,7 +289,7 @@ contract("AGIJobManager security regressions", (accounts) => {
     await manager.disputeJob(jobId, { from: employer });
     await expectCustomError(manager.disputeJob.call(jobId, { from: employer }), "InvalidState");
     await expectCustomError(
-      manager.resolveDispute.call(jobId, "agent win", { from: other }),
+      manager.resolveDisputeWithCode.call(jobId, 1, "agent win", { from: other }),
       "NotModerator"
     );
   });


### PR DESCRIPTION
### Motivation
- Resolve CI failure from ABI drift after removing the legacy string-based dispute API and keep UI artifacts in sync with the on-chain ABI.
- Harden ENS token URI retrieval to avoid unbounded returndata and avoid settlement failures when ENS hooks revert or return malformed data.
- Add safe rescue functions and test mocks so operators can recover accidentally-sent assets while preventing AGI token rescue.
- Make export/verification scripts robust against ABI differences (optional methods/events) and merge legacy/typed dispute events for analytics.

### Description
- Regenerated and committed the UI ABI export at `docs/ui/abi/AGIJobManager.json` and updated `docs/ui/abi/ui_required_interface.json` to remove legacy requirements (`resolveDispute(uint256,string)` and `DisputeResolved`).
- Removed the deprecated string-based `resolveDispute` path and legacy `DisputeResolved` emission from `contracts/AGIJobManager.sol`, strengthened typed dispute flow via `resolveDisputeWithCode`, and updated contract ABI accordingly.
- Added ENS safety limits and robust staticcall handling in `AGIJobManager` for ENS job-token URI reads (`ENS_URI_MAX_RETURN_BYTES`, `ENS_URI_MAX_STRING_BYTES`, safer assembly path) to avoid unbounded returndatasize parsing.
- Added administrative rescue helpers `rescueETH` and `rescueToken` to `AGIJobManager.sol` and corresponding test mocks in `contracts/test/RescueMocks.sol` plus mainnet-hardening tests that exercise rescue flows.
- Updated tests across the suite to use the typed dispute API and to reflect removed metadata accessors (many `*.test.js` modified to call `resolveDisputeWithCode` and drop deprecated assertions).
- Improved scripts/tools: `scripts/erc8004/export_metrics.js` now tolerates presence/absence of legacy events, decodes both legacy and typed dispute events and deduplicates them; `scripts/postdeploy-config.js` and `scripts/verify-config.js` now check for method existence before calling optional metadata setters.

### Testing
- Ran the full test suite with `npm run test` (which ran `truffle compile`, full mocha test matrix, and bytecode size checks) and observed `270 passing`, `0 failing`.
- Rebuilt artifacts and regenerated UI ABI via `npm run build && npm run ui:abi` which produced `docs/ui/abi/AGIJobManager.json` and allowed the `UI ABI sync` tests to pass.
- Executed the ERC-8004 export smoke test and related unit tests that validate dispute event merging and metrics export; the export wrote metrics to a temp path during the run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698bf5cde1388333ab36226cdd72dd0c)