### PR TITLE
Harden owner rescue paths, add deterministic invariants, and update mainnet runbook

### DIFF
--- a/contracts/test/CompletionNFTHolders.sol
+++ b/contracts/test/CompletionNFTHolders.sol
@@ -1,0 +1,53 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+import "@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol";
+import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
+
+interface IAGIJobManagerCreateJob {
+    function createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external;
+}
+
+contract ERC721ReceiverEmployer is IERC721Receiver {
+    IAGIJobManagerCreateJob public manager;
+    IERC20 public token;
+    uint256 public receivedCount;
+    uint256 public lastTokenId;
+
+    constructor(address managerAddress, address tokenAddress) {
+        manager = IAGIJobManagerCreateJob(managerAddress);
+        token = IERC20(tokenAddress);
+    }
+
+    function createJob(string memory spec, uint256 payout, uint256 duration, string memory details) external {
+        token.approve(address(manager), payout);
+        manager.createJob(spec, payout, duration, details);
+    }
+
+    function onERC721Received(address, address, uint256 tokenId, bytes calldata)
+        external
+        override
+        returns (bytes4)
+    {
+        unchecked {
+            receivedCount++;
+        }
+        lastTokenId = tokenId;
+        return IERC721Receiver.onERC721Received.selector;
+    }
+}
+
+contract NonReceiverEmployer {
+    IAGIJobManagerCreateJob public manager;
+    IERC20 public token;
+
+    constructor(address managerAddress, address tokenAddress) {
+        manager = IAGIJobManagerCreateJob(managerAddress);
+        token = IERC20(tokenAddress);
+    }
+
+    function createJob(string memory spec, uint256 payout, uint256 duration, string memory details) external {
+        token.approve(address(manager), payout);
+        manager.createJob(spec, payout, duration, details);
+    }
+}

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2904,6 +2904,29 @@
           "type": "address"
         },
         {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "rescueERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
           "internalType": "bytes",
           "name": "data",
           "type": "bytes"
@@ -2912,6 +2935,25 @@
       "name": "rescueToken",
       "outputs": [],
       "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "agent",
+          "type": "address"
+        }
+      ],
+      "name": "getActiveJobsByAgent",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/test/invariantSeededSequence.test.js
+++ b/test/invariantSeededSequence.test.js
@@ -1,0 +1,139 @@
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+
+const { buildInitConfig } = require("./helpers/deploy");
+
+contract("AGIJobManager seeded invariant sequences", (accounts) => {
+  const [owner, employerA, employerB, agentA, agentB, validatorA, validatorB] = accounts;
+  const ZERO32 = "0x" + "00".repeat(32);
+
+  function makeRng(seed) {
+    let state = BigInt(seed);
+    return () => {
+      state = (1103515245n * state + 12345n) % (1n << 31n);
+      return Number(state);
+    };
+  }
+
+  async function assertInvariants(manager, token, harnessActive) {
+    const balance = BigInt((await token.balanceOf(manager.address)).toString());
+    const lockedEscrow = BigInt((await manager.lockedEscrow()).toString());
+    const lockedAgent = BigInt((await manager.lockedAgentBonds()).toString());
+    const lockedValidator = BigInt((await manager.lockedValidatorBonds()).toString());
+    const lockedDispute = BigInt((await manager.lockedDisputeBonds()).toString());
+    const lockedTotal = lockedEscrow + lockedAgent + lockedValidator + lockedDispute;
+
+    assert.ok(balance >= lockedTotal, "solvency invariant violated");
+
+    const withdrawable = BigInt((await manager.withdrawableAGI()).toString());
+    assert.equal(withdrawable.toString(), (balance - lockedTotal).toString(), "withdrawable mismatch");
+
+    for (const [agent, expected] of Object.entries(harnessActive)) {
+      const onchain = await manager.getActiveJobsByAgent(agent);
+      assert.equal(onchain.toString(), String(expected), "activeJobsByAgent mismatch");
+    }
+  }
+
+  it("runs deterministic bounded action sequences while preserving accounting invariants", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        wrapper.address,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32
+      ),
+      { from: owner }
+    );
+
+    const nft = await MockERC721.new({ from: owner });
+    await nft.mint(agentA, { from: owner });
+    await nft.mint(agentB, { from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await manager.addAdditionalAgent(agentA, { from: owner });
+    await manager.addAdditionalAgent(agentB, { from: owner });
+    await manager.addAdditionalValidator(validatorA, { from: owner });
+    await manager.addAdditionalValidator(validatorB, { from: owner });
+    await manager.setRequiredValidatorApprovals(2, { from: owner });
+
+    const funded = web3.utils.toWei("200");
+    for (const acct of [employerA, employerB, agentA, agentB, validatorA, validatorB]) {
+      await token.mint(acct, funded, { from: owner });
+      await token.approve(manager.address, funded, { from: acct });
+    }
+
+    const employers = [employerA, employerB];
+    const agents = [agentA, agentB];
+    const validators = [validatorA, validatorB];
+    const harnessActive = { [agentA]: 0, [agentB]: 0 };
+    const activeJobs = [];
+    const rng = makeRng(1337);
+
+    for (let i = 0; i < 30; i++) {
+      const action = rng() % 7;
+      try {
+        if (action === 0) {
+          const employer = employers[rng() % employers.length];
+          const payout = web3.utils.toWei(String((rng() % 5) + 1));
+          await manager.createJob("ipfs://spec", payout, 300, "seeded", { from: employer });
+          const jobId = Number((await manager.nextJobId()).toString()) - 1;
+          activeJobs.push(jobId);
+        } else if (action === 1 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          const agent = agents[rng() % agents.length];
+          await manager.applyForJob(jobId, "agent", [], { from: agent });
+          harnessActive[agent] += 1;
+        } else if (action === 2 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          const core = await manager.getJobCore(jobId);
+          if (core.assignedAgent !== "0x0000000000000000000000000000000000000000") {
+            await manager.requestJobCompletion(jobId, "ipfs://done", { from: core.assignedAgent });
+          }
+        } else if (action === 3 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          const val = validators[rng() % validators.length];
+          await manager.validateJob(jobId, "validator", [], { from: val });
+        } else if (action === 4 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          await time.increase(2);
+          const core = await manager.getJobCore(jobId);
+          await manager.finalizeJob(jobId, { from: core.employer });
+          if (core.assignedAgent !== "0x0000000000000000000000000000000000000000") {
+            harnessActive[core.assignedAgent] = Math.max(harnessActive[core.assignedAgent] - 1, 0);
+          }
+        } else if (action === 5 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          const core = await manager.getJobCore(jobId);
+          if (core.assignedAgent === "0x0000000000000000000000000000000000000000") {
+            await manager.cancelJob(jobId, { from: core.employer });
+          }
+        } else if (action === 6 && activeJobs.length) {
+          const jobId = activeJobs[rng() % activeJobs.length];
+          const core = await manager.getJobCore(jobId);
+          if (core.assignedAgent !== "0x0000000000000000000000000000000000000000") {
+            await time.increase(301);
+            await manager.expireJob(jobId, { from: owner });
+            harnessActive[core.assignedAgent] = Math.max(harnessActive[core.assignedAgent] - 1, 0);
+          }
+        }
+      } catch (_) {
+        // Expected: deterministic adversarial runner intentionally probes invalid transitions.
+      }
+
+      await assertInvariants(manager, token, harnessActive);
+    }
+  });
+});

--- a/test/mainnetRescueAndMint.test.js
+++ b/test/mainnetRescueAndMint.test.js
@@ -1,0 +1,73 @@
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockRescueERC20 = artifacts.require("MockRescueERC20");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+contract("AGIJobManager rescue hardening", (accounts) => {
+  const [owner, employer] = accounts;
+  const ZERO32 = "0x" + "00".repeat(32);
+
+  async function deployManager(token) {
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    return AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        "ipfs://base",
+        ens.address,
+        wrapper.address,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32
+      ),
+      { from: owner }
+    );
+  }
+
+  it("rescueERC20 keeps AGI backing safe and follows withdrawAGI pause posture", async () => {
+    const agi = await MockERC20.new({ from: owner });
+    const manager = await deployManager(agi);
+
+    await agi.mint(employer, web3.utils.toWei("10"), { from: owner });
+    await agi.approve(manager.address, web3.utils.toWei("10"), { from: employer });
+    await manager.createJob("ipfs://spec", web3.utils.toWei("10"), 1000, "details", { from: employer });
+
+    await expectCustomError(
+      manager.rescueERC20.call(agi.address, owner, web3.utils.toWei("1"), { from: owner }),
+      "InvalidState"
+    );
+
+    await manager.pause({ from: owner });
+    await expectCustomError(
+      manager.rescueERC20.call(agi.address, owner, web3.utils.toWei("1"), { from: owner }),
+      "InsufficientWithdrawableBalance"
+    );
+
+    await agi.mint(manager.address, web3.utils.toWei("4"), { from: owner });
+    await manager.rescueERC20(agi.address, owner, web3.utils.toWei("4"), { from: owner });
+    assert.equal((await agi.balanceOf(owner)).toString(), web3.utils.toWei("4"));
+
+    await manager.setSettlementPaused(true, { from: owner });
+    await expectCustomError(
+      manager.rescueERC20.call(agi.address, owner, "1", { from: owner }),
+      "SettlementPaused"
+    );
+  });
+
+  it("rescueERC20 transfers arbitrary non-AGI tokens", async () => {
+    const agi = await MockERC20.new({ from: owner });
+    const manager = await deployManager(agi);
+    const stray = await MockRescueERC20.new({ from: owner });
+
+    await stray.mint(manager.address, 25, { from: owner });
+    await manager.rescueERC20(stray.address, owner, 25, { from: owner });
+    assert.equal((await stray.balanceOf(owner)).toString(), "25");
+  });
+});


### PR DESCRIPTION
### Motivation
- Provide owner recovery (rescue) tooling for ETH and ERC‑20 while preventing withdrawal of escrowed AGI backing. 
- Add stronger, CI‑friendly regression coverage (adversarial/invariant sequences) to ensure settlement liveness and solvency invariants under misconfiguration and hostile sequences. 
- Keep runtime bytecode under the EIP‑170 cap and avoid bulky imports that would risk deployability. 

### Description
- Added an owner-only `rescueERC20(address token, address to, uint256 amount)` function with guarded AGI behavior that enforces paused/timing posture and `amount <= withdrawableAGI()` and is `nonReentrant`, and preserved the generic calldata `rescueToken(address, bytes)` for arbitrary NFT/multi-token recoveries; `rescueETH` remains present using a low-level call and `TransferFailed()` on failure. 
- Exposed `getActiveJobsByAgent(address)` as a small view accessor to support on-chain invariant assertions from tests without changing runtime accounting. 
- Added a deterministic seeded scenario runner test (`test/invariantSeededSequence.test.js`) that executes bounded adversarial action sequences and checks solvency invariants, `withdrawableAGI()` consistency, and `activeJobsByAgent` correctness after each action. 
- Added focused rescue tests (`test/mainnetRescueAndMint.test.js`) that prove AGI rescue is blocked unless the contract is paused and the amount is withdrawable, and that arbitrary non‑AGI ERC‑20 rescue works; added a small test helper contract for ERC‑721 receiver/non‑receiver scenarios (kept bytecode headroom by using direct `_mint` behavior). 
- Updated the institutional operator documentation `docs/MAINNET_OPERATIONS.md` (deploy runbook, admin safety matrix, ENS degradation and rescue procedures, Mermaid diagrams) and regenerated `docs/ui/abi/AGIJobManager.json` so UI sync checks pass. 
- Took a conservative size-first approach: avoided adding heavy OZ helpers or introducing an external-only safe mint path that would increase runtime bytecode; documentation notes the chosen NFT mint posture to preserve EIP‑170 headroom. 

### Testing
- Compiled and size-checked with `npx truffle compile --all && node scripts/check-contract-sizes.js` and observed `AGIJobManager deployedBytecode size: 24409 bytes` (under the 24,575 byte EIP‑170 cap). 
- Ran targeted Truffle tests covering ABI sync, mainnet hardening, rescue hardening, and the new invariant runner with `npx truffle test --network test test/ui_abi_sync.test.js test/mainnetRescueAndMint.test.js test/invariantSeededSequence.test.js test/mainnetHardening.test.js test/bytecodeSize.test.js`, and these targeted suites passed. 
- Notes on full `npm test`: an initial full-suite run surfaced a UI ABI sync mismatch which was resolved by regenerating `docs/ui/abi/AGIJobManager.json`; after that the targeted test suites above completed successfully and the bytecode guard passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb4c55df483338ac8ceba567cfaae)