### PR TITLE
Harden rescue flows and ENS-safe settlement (rescueERC20, tests, docs)

### DIFF
--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2904,6 +2904,29 @@
           "type": "address"
         },
         {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "rescueERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
           "internalType": "bytes",
           "name": "data",
           "type": "bytes"


### PR DESCRIPTION
### Motivation
- Provide owner recovery tools for assets accidentally sent to the contract while preventing any bypass of escrow/bond backing for the AGI token.
- Ensure ENS/ENS-job-pages hooks and tokenURI decoding cannot revert or otherwise brick settlement flows.
- Keep changes minimal, bytecode-conscious, and fully covered by adversarial/guardian tests and operator runbooks.

### Description
- Added a typed owner recovery entry `rescueERC20(token,to,amount)` that uses `TransferUtils.safeTransfer` for generic tokens and enforces the treasury safety posture for the AGI token by requiring `paused() == true`, `settlementPaused == false`, and `amount <= withdrawableAGI()` before transfer. 
- Kept the existing generic `rescueToken(token,data)` calldata path for arbitrary recoveries (ERC721/1155 transfer payloads) while explicitly blocking AGI via that path to avoid bypassing escrow protections. 
- Left completion NFT mint flow ENS decoding defensive (gas-limited `staticcall` + ABI-shape/length checks and fallback to the jobCompletionURI) so malformed or short ENS payloads cannot revert settlement. 
- Added/updated tests in `test/mainnetHardening.test.js` to cover forced-ETH rescue, `rescueERC20` behavior (non-AGI and AGI safety posture), generic `rescueToken` usage for ERC721/1155, malformed/false-return token behaviors, and ENS-hook liveness scenarios. 
- Updated `docs/MAINNET_OPERATIONS.md` to document `rescueETH`, `rescueERC20`, and the retained `rescueToken` path plus the safety matrix and runbook guidance for operators, and regenerated the UI ABI (`docs/ui/abi/AGIJobManager.json`) to reflect the new surface. 

### Testing
- Ran targeted tests: `npx truffle test test/mainnetHardening.test.js --network test` and the full suite via `npm test`; the full suite completed successfully with all tests passing. 
- Verified UI ABI export with `npm run ui:abi` to keep the repo UI/ABI sync green. 
- Confirmed runtime bytecode size guard: `AGIJobManager deployedBytecode size: 24336 bytes` which is below the EIP-170 cap of `24576` bytes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb4c55df483338ac8ceba567cfaae)