### PR TITLE
Owner ERC20 rescue + ENS/settlement hardening, tests & docs (size‑safe)

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1253,6 +1253,16 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         }
     }
 
+    function rescueERC20(address token, address to, uint256 amount) external onlyOwner whenSettlementNotPaused nonReentrant {
+        if (token == address(0) || to == address(0) || amount == 0) revert InvalidParameters();
+        if (token == address(agiToken)) {
+            if (!paused()) revert InvalidState();
+            uint256 available = withdrawableAGI();
+            if (amount > available) revert InsufficientWithdrawableBalance();
+        }
+        TransferUtils.safeTransfer(token, to, amount);
+    }
+
     function canAccessPremiumFeature(address user) external view returns (bool) {
         return reputation[user] >= premiumReputationThreshold;
     }

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2918,6 +2918,29 @@
       "inputs": [
         {
           "internalType": "address",
+          "name": "token",
+          "type": "address"
+        },
+        {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "amount",
+          "type": "uint256"
+        }
+      ],
+      "name": "rescueERC20",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "address",
           "name": "user",
           "type": "address"
         }


### PR DESCRIPTION
### Motivation
- Provide owner rescue tooling for assets accidentally sent to the contract while preserving escrow safety and never allowing AGI backing funds to be drained by a rescue path.
- Ensure ENS/tokenURI integrations cannot brick settlement flows when external components return malformed data or revert.
- Keep runtime bytecode under EIP‑170 limits and avoid adding features (ERC721/1155 rescue or overly heavy safe-mint fallbacks) that would push the contract over the size guard.

### Description
- Added an owner-only `rescueERC20(address token, address to, uint256 amount)` function that uses `TransferUtils.safeTransfer` and enforces AGI-specific constraints requiring the contract to be `paused()`, `settlementPaused==false`, and `amount <= withdrawableAGI()` when `token == agiToken`.
- Preserved existing `rescueETH` and `rescueToken` semantics and updated the operator docs to accurately reflect the available rescue surface and the deliberate omission of ERC721/1155 rescue entrypoints for bytecode reasons.
- Extended the mainnet hardening tests in `test/mainnetHardening.test.js` to cover malformed ENS tokenURI payloads, ENS/NameWrapper/Resolver reverts, ENS hook revert resilience, forced ETH rescue, calldata-based generic rescue behavior, and the new AGI-aware `rescueERC20` posture checks.
- Regenerated the UI ABI export so the UI ABI includes the new `rescueERC20` entry and updated `docs/MAINNET_OPERATIONS.md` to document rescue procedures and operational constraints.

### Testing
- Ran `npm install`, `npm run ui:abi`, and the full test suite via `npm test` which executes the Truffle/Mocha tests; the full suite completed with `272 passing` and no failing tests.
- Ran the repository bytecode size checks and the `AGIJobManager` deployed bytecode is `24262` bytes which is below the EIP‑170 cap (`< 24575`), so the size guard passed.
- Verified the UI ABI sync by running `npm run ui:abi` and the ABI sync test passed after exporting `docs/ui/abi/AGIJobManager.json` to include `rescueERC20`.
- All added/updated tests (mainnet hardening scenarios) passed in CI-local runs and confirm that ENS/tokenURI issues and rescue flows do not break settlement liveness.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cb4c55df483338ac8ceba567cfaae)