### PR TITLE
Fix ENS/Merkle revert regression in hardening test and remove selfdestruct warning

### DIFF
--- a/contracts/test/RescueMocks.sol
+++ b/contracts/test/RescueMocks.sol
@@ -3,10 +3,6 @@ pragma solidity ^0.8.19;
 
 contract ForceSendETH {
     constructor() payable {}
-
-    function boom(address payable target) external {
-        selfdestruct(target);
-    }
 }
 
 contract MockRescueERC20 {


### PR DESCRIPTION
### Motivation
- Ensure the Merkle/ENS revert regression test actually exercises ENS fallback paths instead of being bypassed by zeroed root nodes.
- Remove a deprecated `selfdestruct` usage in test mocks that caused compilation warnings.
- Make the ETH-rescue test robust across different test RPCs without relying on `selfdestruct`-based force-send mechanics.

### Description
- Update `test/mainnetHardening.test.js` to configure non-zero `agentRootNode` and `alphaAgentRootNode`, import `MerkleTree`/`keccak256`, assert an invalid proof is `NotAuthorized`, then validate a correct Merkle proof succeeds.
- Add a `setAccountBalance` RPC helper (tries `hardhat_setBalance` then falls back to `evm_setAccountBalance`) and replace the `ForceSendETH`-based balance funding with an RPC balance set in the ETH rescue test.
- Remove the `selfdestruct` usage from the `ForceSendETH` mock in `contracts/test/RescueMocks.sol` by simplifying the contract to an inert payable constructor, and remove the `ForceSendETH` require from the test.
- Rename the test description to reflect the new approach and wire the updated constructor/init parameters to exercise the ENS fallback paths in the manager config.

### Testing
- Ran `npm run build` which compiled successfully and no longer emits the `selfdestruct` deprecation warning.
- Ran the focused test via `npx truffle test --network test test/mainnetHardening.test.js`, which passed (7 passing).
- Ran the full suite with `npm test`, which completed successfully (275 passing) and the bytecode size guard remains within limits.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cc4cfbfc48333bc6e2d6e1ebe19f9)