### PR TITLE
docs: add mainnet operator runbook for AGIJobManager

### DIFF
--- a/docs/MAINNET_OPS.md
+++ b/docs/MAINNET_OPS.md
@@ -37,10 +37,11 @@
 
 ### Arbitrary token recovery (ERC721/ERC1155/odd contracts)
 - Use `rescueToken(target, calldata)` as owner with encoded token call data.
-- Guardrails:
-  - target cannot be `agiToken`,
-  - target cannot be `address(this)`,
-  - target cannot be zero address.
+- On-chain guardrail: target cannot be `agiToken` (enforced by `rescueToken`).
+- Operator preflight checks (recommended in runbooks/automation):
+  - reject `address(this)` targets,
+  - reject zero-address targets,
+  - verify calldata selector/args match the intended token standard (ERC721/ERC1155/custom).
 
 ## Emergency controls
 - `pause()` / `unpause()` for broad admin stop/start.


### PR DESCRIPTION
### Motivation
- Provide a concise, operator-focused runbook for Ethereum mainnet that documents production constants (AGIALPHA), post-deploy checks, ENS degradation posture, rescue/recovery procedures, and emergency ops so operators can run and recover the system safely.

### Description
- Add `docs/MAINNET_OPS.md` containing mainnet constants (AGIALPHA address), post-deploy checklist, ENS best-effort/degradation playbook, rescue/ETH/ERC20/arbitrary-token guidance with guardrails, emergency controls, and Mermaid diagrams for lifecycle, funds flow, ENS hook flow, and emergency procedures; no Solidity/runtime code changes were made.

### Testing
- Ran the full automated suite (`npm test`) which passed (274 passing), and re-ran the bytecode checks (`npm run size` and `node scripts/check-contract-sizes.js`) which report `AGIJobManager` runtime bytecode size `24409` bytes, remaining under the EIP-170 safety cap (<24575).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd58c06c88333ab0ec6a2661a9c14)