### PR TITLE
Harden owner rescue paths and ENS decode safety for mainnet ops

### DIFF
--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -73,6 +73,10 @@ library ENSOwnership {
         bytes memory data;
         (ok, data) = target.staticcall(abi.encodeWithSelector(selector, node));
         if (!ok || data.length < 32) return (false, address(0));
-        result = abi.decode(data, (address));
+        uint256 word;
+        assembly {
+            word := mload(add(data, 32))
+        }
+        result = address(uint160(word));
     }
 }

--- a/docs/MAINNET_OPS.md
+++ b/docs/MAINNET_OPS.md
@@ -1,0 +1,101 @@
+# AGIJobManager Mainnet Ops Runbook
+
+## Production constants
+- **Network:** Ethereum mainnet.
+- **Production ERC20:** **AGI ALPHA AGENT (AGIALPHA)** at `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
+- AGIALPHA transfer semantics are standard ERC20 (no fee/rebase), but token-level **pause** can block transfers.
+- Operational requirement: keep AGIALPHA **unpaused** for normal escrow, bond, settlement, and withdrawal flows.
+
+## Deploy + post-deploy checklist
+1. Deploy `AGIJobManager` with mainnet wiring (AGIALPHA + ENS + NameWrapper + roots + Merkle roots).
+2. Verify bytecode size guard before promotion (`AGIJobManager` runtime must remain `< 24575` bytes).
+3. Smoke test lifecycle in production profile:
+   - `createJob`
+   - `applyForJob`
+   - `requestJobCompletion`
+   - `validateJob` / `disapproveJob`
+   - `finalizeJob` or dispute path
+4. Validate treasury controls:
+   - `pause` / `unpause`
+   - `withdrawAGI` (only while paused)
+   - `rescueETH`, `rescueERC20` (non-AGI only), `rescueCall`
+5. Transfer ownership to business operator multisig (recommended). `Ownable.transferOwnership` remains the canonical rotation path.
+
+## ENS operational model (best effort)
+- ENS hooks and ENS tokenURI overrides are **best-effort mirrors**.
+- Settlement/finalization is intentionally tolerant of ENS breakage, malformed responses, or reverts.
+- If ENS is unhealthy/out-of-sync:
+  - keep core escrow workflow running,
+  - continue settlements,
+  - use fallback completion URI behavior,
+  - repair ENS integration out-of-band.
+
+## Emergency and recovery procedures
+- **Forced ETH recovery:**
+  - use `rescueETH(amount)` (owner-only).
+- **Stray ERC20 (non-AGI):**
+  - use `rescueERC20(token, amount)` (owner-only; always sends to `owner()`).
+- **Odd token standards (ERC721/ERC1155/custom):**
+  - use `rescueCall(target, data)` with encoded calldata.
+  - safety guardrails reject `target == agiToken`, `target == address(this)`, and `target == address(0)`.
+- **AGIALPHA reserve safety:**
+  - `rescueERC20` cannot move AGIALPHA.
+  - use `withdrawAGI` for treasury withdrawals under pause + solvency constraints.
+
+## Degradation playbook
+- Symptoms: ENS resolver failures, NameWrapper failures, ENS hook reverts, malformed ENS tokenURI returndata.
+- Actions:
+  1. Keep settlement open (do **not** block finalization solely due to ENS issues).
+  2. Optionally disable ENS tokenURI mode (`setUseEnsJobTokenURI(false)`) until dependency recovers.
+  3. Continue monitoring solvency and job completion throughput.
+  4. Repair ENS infra independently and re-enable optional UX mirrors later.
+
+## Mermaid diagrams
+
+### 1) Job lifecycle
+```mermaid
+flowchart LR
+  A[createJob] --> B[applyForJob]
+  B --> C[requestJobCompletion]
+  C --> D{Validator outcome}
+  D -->|approvals/disapprovals| E[finalizeJob]
+  D -->|dispute| F[resolveDisputeWithCode]
+  E --> G[Escrow release + NFT mint]
+  F --> G
+```
+
+### 2) Funds flow
+```mermaid
+flowchart TD
+  U[Employer AGIALPHA] -->|createJob escrow| M[AGIJobManager]
+  V[Validators AGIALPHA bond] --> M
+  A[Agent AGIALPHA bond] --> M
+  M -->|agent win| AG[Agent payout + bond return]
+  M -->|validator rewards/slash| VAL[Validators]
+  M -->|employer win| EMP[Employer refund path]
+  M -->|surplus only while paused| OWN[Owner withdrawAGI]
+```
+
+### 3) ENS hook flow (best effort)
+```mermaid
+sequenceDiagram
+  participant Core as AGIJobManager
+  participant ENSP as ensJobPages
+  Core->>ENSP: hook call (gas-limited)
+  alt hook succeeds
+    ENSP-->>Core: ok
+  else revert/failure
+    ENSP-->>Core: fail
+    Note over Core: ignore failure, continue settlement
+  end
+```
+
+### 4) Emergency ops
+```mermaid
+flowchart LR
+  X[Unexpected assets in contract] --> Y{Asset type}
+  Y -->|ETH| Z[rescueETH]
+  Y -->|ERC20 non-AGI| R[rescueERC20]
+  Y -->|ERC721/ERC1155/custom| C[rescueCall]
+  Y -->|AGIALPHA| W[withdrawAGI with pause + solvency checks]
+```

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2904,11 +2904,6 @@
           "type": "address"
         },
         {
-          "internalType": "address",
-          "name": "to",
-          "type": "address"
-        },
-        {
           "internalType": "uint256",
           "name": "amount",
           "type": "uint256"
@@ -2923,7 +2918,7 @@
       "inputs": [
         {
           "internalType": "address",
-          "name": "token",
+          "name": "target",
           "type": "address"
         },
         {
@@ -2932,7 +2927,7 @@
           "type": "bytes"
         }
       ],
-      "name": "rescueToken",
+      "name": "rescueCall",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/test/mainnetRescueAndMint.test.js
+++ b/test/mainnetRescueAndMint.test.js
@@ -31,7 +31,7 @@ contract("AGIJobManager rescue hardening", (accounts) => {
     );
   }
 
-  it("rescueERC20 keeps AGI backing safe and follows withdrawAGI pause posture", async () => {
+  it("rescueERC20 blocks AGI token to preserve withdrawAGI safety posture", async () => {
     const agi = await MockERC20.new({ from: owner });
     const manager = await deployManager(agi);
 
@@ -40,34 +40,18 @@ contract("AGIJobManager rescue hardening", (accounts) => {
     await manager.createJob("ipfs://spec", web3.utils.toWei("10"), 1000, "details", { from: employer });
 
     await expectCustomError(
-      manager.rescueERC20.call(agi.address, owner, web3.utils.toWei("1"), { from: owner }),
-      "InvalidState"
-    );
-
-    await manager.pause({ from: owner });
-    await expectCustomError(
-      manager.rescueERC20.call(agi.address, owner, web3.utils.toWei("1"), { from: owner }),
-      "InsufficientWithdrawableBalance"
-    );
-
-    await agi.mint(manager.address, web3.utils.toWei("4"), { from: owner });
-    await manager.rescueERC20(agi.address, owner, web3.utils.toWei("4"), { from: owner });
-    assert.equal((await agi.balanceOf(owner)).toString(), web3.utils.toWei("4"));
-
-    await manager.setSettlementPaused(true, { from: owner });
-    await expectCustomError(
-      manager.rescueERC20.call(agi.address, owner, "1", { from: owner }),
-      "SettlementPaused"
+      manager.rescueERC20.call(agi.address, web3.utils.toWei("1"), { from: owner }),
+      "InvalidParameters"
     );
   });
 
-  it("rescueERC20 transfers arbitrary non-AGI tokens", async () => {
+  it("rescueERC20 transfers arbitrary non-AGI tokens to owner", async () => {
     const agi = await MockERC20.new({ from: owner });
     const manager = await deployManager(agi);
     const stray = await MockRescueERC20.new({ from: owner });
 
     await stray.mint(manager.address, 25, { from: owner });
-    await manager.rescueERC20(stray.address, owner, 25, { from: owner });
+    await manager.rescueERC20(stray.address, 25, { from: owner });
     assert.equal((await stray.balanceOf(owner)).toString(), "25");
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent external integration misconfiguration (ENS or otherwise) from being able to brick settlement/finalization while keeping the contract safe for business operators.
- Provide minimal owner rescue tooling to recover ETH and arbitrary non-AGI tokens without allowing AGI escrow bypass, while preserving transferable ownership semantics.
- Preserve EIP-170 bytecode headroom and keep the change surface minimal to avoid inflating runtime size or introducing new revert strings.

### Description
- Replace the previous ERC20/token rescue surface with a constrained owner-only API by adding `rescueERC20(address token, uint256 amount)` that always sends stray ERC20 tokens to `owner()` and explicitly blocks rescuing the AGI token, while keeping `rescueETH(uint256)` as the low-level owner send path.
- Add `rescueCall(address target, bytes data)` as a generic owner escape hatch for odd tokens (ERC721/ERC1155/custom calldata) with strict guardrails rejecting `target == address(0)`, `target == address(agiToken)`, and `target == address(this)` and reverting on failed calls.
- Harden ENS ownership decode by removing `abi.decode` on untrusted returndata in `ENSOwnership._staticcallAddress` and replacing it with a 32-byte assembly load masked to a 160-bit address so malformed or reverting ENS/NameWrapper/Resolver responses do not bubble up reverts.
- Update tests, UI ABI and docs: migrate tests to call `rescueCall` where appropriate, adjust `mainnetRescueAndMint` and `mainnetHardening` tests to reflect new `rescueERC20` semantics, refresh `docs/ui/abi/AGIJobManager.json`, and add a concise operator runbook at `docs/MAINNET_OPS.md` documenting AGIALPHA mainnet context, ENS best-effort behavior, and rescue procedures.

### Testing
- Ran targeted hardening tests with `npx truffle test --network test test/mainnetHardening.test.js test/mainnetRescueAndMint.test.js test/ui_abi_sync.test.js` and the tests for ENS and rescue semantics passed.
- Ran the full test harness via `npm test` and verified unit/regression suites pass after updates (hardening/rescue tests are included in the suite).
- Verified bytecode size guard with `npm run size` and `node scripts/check-contract-sizes.js`, reporting `AGIJobManager` runtime bytecode `24169` bytes which is under the `24575` limit.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698cd58c06c88333ab0ec6a2661a9c14)