### PR TITLE
Harden settlement liveness, gas-bounded integrations, and bytecode headroom

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,9 +157,10 @@ flowchart LR
 ### Mainnet token assumptions (production)
 
 - AGIALPHA token address: `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
-- The system expects exact-transfer ERC20 semantics (no fee-on-transfer/rebase behavior).
+- AGIALPHA is assumed to use 18 decimals for payout/bond/reputation tuning.
+- The system expects exact-transfer ERC20 semantics (no fee-on-transfer behavior and no rebasing supply mechanics).
 - AGIALPHA token-level pause must remain unpaused for normal operation.
-- ENS integration is intentionally best-effort; core escrow/settlement correctness does not depend on ENS success.
+- ENS integration is intentionally best-effort; state can diverge from ENS mirrors and core escrow/settlement correctness must not depend on ENS success.
 
 ### Dependency pinning note
 

--- a/contracts/test/MockLoopingERC721.sol
+++ b/contracts/test/MockLoopingERC721.sol
@@ -1,0 +1,13 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockLoopingERC721 {
+    function supportsInterface(bytes4) external pure returns (bool) {
+        return true;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        while (true) {}
+        return 0;
+    }
+}

--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -15,6 +15,8 @@ interface NameWrapperLike {
 }
 
 library ENSOwnership {
+    uint256 private constant EXTERNAL_CALL_GAS_LIMIT = 500_000;
+
     function verifyENSOwnership(
         address ensAddress,
         address nameWrapperAddress,
@@ -70,9 +72,14 @@ library ENSOwnership {
         bytes4 selector,
         bytes32 node
     ) private view returns (bool ok, address result) {
-        bytes memory data;
-        (ok, data) = target.staticcall(abi.encodeWithSelector(selector, node));
-        if (!ok || data.length < 32) return (false, address(0));
-        result = abi.decode(data, (address));
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, shl(224, selector))
+            mstore(add(ptr, 0x04), node)
+            ok := staticcall(EXTERNAL_CALL_GAS_LIMIT, target, ptr, 0x24, ptr, 0x20)
+            if and(ok, gt(returndatasize(), 0x1f)) {
+                result := shr(96, mload(ptr))
+            }
+        }
     }
 }

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -2789,6 +2789,24 @@
     {
       "inputs": [
         {
+          "internalType": "address",
+          "name": "to",
+          "type": "address"
+        },
+        {
+          "internalType": "uint256",
+          "name": "tokenId",
+          "type": "uint256"
+        }
+      ],
+      "name": "safeMintCompletionTo",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
           "internalType": "uint256",
           "name": "tokenId",
           "type": "uint256"
@@ -2935,25 +2953,6 @@
       "name": "rescueToken",
       "outputs": [],
       "stateMutability": "nonpayable",
-      "type": "function"
-    },
-    {
-      "inputs": [
-        {
-          "internalType": "address",
-          "name": "user",
-          "type": "address"
-        }
-      ],
-      "name": "canAccessPremiumFeature",
-      "outputs": [
-        {
-          "internalType": "bool",
-          "name": "",
-          "type": "bool"
-        }
-      ],
-      "stateMutability": "view",
       "type": "function"
     },
     {

--- a/docs/ui/abi/ui_required_interface.json
+++ b/docs/ui/abi/ui_required_interface.json
@@ -20,7 +20,6 @@
     "nextJobId": 0,
     "nextTokenId": 0,
     "reputation": 1,
-    "canAccessPremiumFeature": 1,
     "moderators": 1,
     "additionalAgents": 1,
     "additionalValidators": 1,

--- a/test/AGIJobManager.comprehensive.test.js
+++ b/test/AGIJobManager.comprehensive.test.js
@@ -766,8 +766,7 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
     it("handles reward pool contributions and pause protections", async () => {
       await token.mint(employer, payout);
       await token.approve(manager.address, payout, { from: employer });
-      const receipt = await manager.contributeToRewardPool(payout, { from: employer });
-      expectEvent(receipt, "RewardPoolContribution", { contributor: employer, amount: payout });
+      await manager.contributeToRewardPool(payout, { from: employer });
 
       await expectCustomError(manager.contributeToRewardPool.call(0, { from: employer }), "InvalidParameters");
 
@@ -914,6 +913,8 @@ contract("AGIJobManager comprehensive suite", (accounts) => {
 
     it("accepts NameWrapper ownership and resolver address matches", async () => {
       await createJob();
+      await manager.addAdditionalAgent(agent, { from: owner });
+      await manager.addAdditionalValidator(validatorOne, { from: owner });
       const subdomain = "agent";
       await setNameWrapperOwnership(nameWrapper, agentRoot, subdomain, agent);
       await manager.applyForJob(0, subdomain, [], { from: agent });

--- a/test/AGIJobManager.exhaustive.test.js
+++ b/test/AGIJobManager.exhaustive.test.js
@@ -418,7 +418,7 @@ contract("AGIJobManager exhaustive suite", (accounts) => {
     it("enforces owner-only modifiers and updates config", async () => {
       await expectRevert.unspecified(manager.pause({ from: other }));
       await manager.setBaseIpfsUrl("ipfs://new", { from: owner });
-      assert.equal(await manager.canAccessPremiumFeature(agent), false);
+      assert.equal((await manager.reputation(agent)).lt(await manager.premiumReputationThreshold()), true);
 
       await manager.setPremiumReputationThreshold(1, { from: owner });
       assert.equal(await manager.premiumReputationThreshold(), "1");

--- a/test/AGIJobManager.full.test.js
+++ b/test/AGIJobManager.full.test.js
@@ -860,7 +860,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
 
     it("tracks premium access based on reputation", async () => {
       await manager.setPremiumReputationThreshold(100000, { from: owner });
-      assert.equal(await manager.canAccessPremiumFeature(agent), false);
+      assert.equal((await manager.reputation(agent)).lt(await manager.premiumReputationThreshold()), true);
 
       const payout = new BN(web3.utils.toWei("5"));
       const { jobId } = await createJob(manager, token, employer, payout, 1000, "ipfs-7");
@@ -875,7 +875,7 @@ contract("AGIJobManager comprehensive", (accounts) => {
 
       const rep = await manager.reputation(agent);
       await manager.setPremiumReputationThreshold(rep, { from: owner });
-      assert.equal(await manager.canAccessPremiumFeature(agent), true);
+      assert.equal((await manager.reputation(agent)).gte(await manager.premiumReputationThreshold()), true);
     });
   });
 

--- a/test/agentPayoutSnapshot.truffle.test.js
+++ b/test/agentPayoutSnapshot.truffle.test.js
@@ -60,6 +60,8 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
 
     await setNameWrapperOwnership(nameWrapper, agentRoot, "agent", agent);
     await setNameWrapperOwnership(nameWrapper, clubRoot, "validator", validator);
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await manager.addAdditionalValidator(validator, { from: owner });
     await manager.setRequiredValidatorApprovals(1, { from: owner });
     await manager.setChallengePeriodAfterApproval(1, { from: owner });
 
@@ -139,8 +141,6 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     const payout = toBN(toWei("100"));
     const jobId = await createJob(payout);
 
-    await manager.addAdditionalAgent(agent, { from: owner });
-
     await expectCustomError(
       manager.applyForJob.call(jobId, "agent", EMPTY_PROOF, { from: agent }),
       "IneligibleAgentPayout"
@@ -155,8 +155,6 @@ contract("AGIJobManager agent payout snapshots", (accounts) => {
     const tokenId = await agiType.mint.call(agent, { from: owner });
     await agiType.mint(agent, { from: owner });
     await manager.addAGIType(agiType.address, 60, { from: owner });
-    await manager.addAdditionalAgent(agent, { from: owner });
-
     await manager.applyForJob(jobId, "", EMPTY_PROOF, { from: agent });
     const job = await manager.getJobCore(jobId);
     const snapshotPct = job[8];

--- a/test/mainnetRescueAndMint.test.js
+++ b/test/mainnetRescueAndMint.test.js
@@ -1,14 +1,19 @@
+const { time } = require("@openzeppelin/test-helpers");
+
 const AGIJobManager = artifacts.require("AGIJobManager");
 const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
 const MockENS = artifacts.require("MockENS");
 const MockNameWrapper = artifacts.require("MockNameWrapper");
 const MockRescueERC20 = artifacts.require("MockRescueERC20");
+const ERC721ReceiverEmployer = artifacts.require("ERC721ReceiverEmployer");
+const NonReceiverEmployer = artifacts.require("NonReceiverEmployer");
 
 const { buildInitConfig } = require("./helpers/deploy");
 const { expectCustomError } = require("./helpers/errors");
 
 contract("AGIJobManager rescue hardening", (accounts) => {
-  const [owner, employer] = accounts;
+  const [owner, employer, agent] = accounts;
   const ZERO32 = "0x" + "00".repeat(32);
 
   async function deployManager(token) {
@@ -29,6 +34,26 @@ contract("AGIJobManager rescue hardening", (accounts) => {
       ),
       { from: owner }
     );
+  }
+
+  async function settleContractEmployerJob(manager, token, contractEmployer) {
+    const nft = await MockERC721.new({ from: owner });
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+
+    const payout = web3.utils.toWei("2");
+    await token.mint(contractEmployer.address, payout, { from: owner });
+    await contractEmployer.createJob("ipfs://spec", payout, 100, "details", { from: owner });
+
+    await token.mint(agent, web3.utils.toWei("3"), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei("3"), { from: agent });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, "ipfs://completion", { from: agent });
+
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    await manager.finalizeJob(0, { from: owner });
   }
 
   it("rescueERC20 keeps AGI backing safe and follows withdrawAGI pause posture", async () => {
@@ -69,5 +94,37 @@ contract("AGIJobManager rescue hardening", (accounts) => {
     await stray.mint(manager.address, 25, { from: owner });
     await manager.rescueERC20(stray.address, owner, 25, { from: owner });
     assert.equal((await stray.balanceOf(owner)).toString(), "25");
+  });
+
+  it("safe-mints completion NFTs to ERC721Receiver employers", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const manager = await deployManager(token);
+    const receiverEmployer = await ERC721ReceiverEmployer.new(manager.address, token.address, { from: owner });
+
+    await settleContractEmployerJob(manager, token, receiverEmployer);
+
+    assert.equal((await receiverEmployer.receivedCount()).toString(), "1");
+    const tokenId = await receiverEmployer.lastTokenId();
+    assert.equal(await manager.ownerOf(tokenId), receiverEmployer.address);
+  });
+
+  it("falls back to _mint for contract employers without IERC721Receiver", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const manager = await deployManager(token);
+    const nonReceiverEmployer = await NonReceiverEmployer.new(manager.address, token.address, { from: owner });
+
+    await settleContractEmployerJob(manager, token, nonReceiverEmployer);
+
+    assert.equal(await manager.ownerOf(0), nonReceiverEmployer.address);
+  });
+
+  it("blocks external callers from the internal safe-mint wrapper", async () => {
+    const token = await MockERC20.new({ from: owner });
+    const manager = await deployManager(token);
+
+    await expectCustomError(
+      manager.safeMintCompletionTo.call(employer, 999, { from: owner }),
+      "NotAuthorized"
+    );
   });
 });


### PR DESCRIPTION
### Motivation
- Prevent settlement from being bricked by later owner configuration changes, ENS/network misbehavior, or hostile external contracts while keeping runtime bytecode under the EIP-170 safety gate.
- Make completion NFT delivery non-blocking for settlement and bound external call gas to reduce OOG attack surface.
- Limit user-provided URI sizes to avoid state/gas bloat and add fail-fast constructor checks for miswiring.

### Description
- Snapshot validator reward percentage per job by adding `validatorRewardPctSnapshot` to `Job` and storing it in `applyForJob`, and enforce `agentPayoutPct + validatorRewardPctSnapshot <= 100` at apply-time. All settlement/refund/reputation math now uses the snapshot instead of the mutable global `validationRewardPercentage`.
- Change disapproval auto-dispute semantics to treat `requiredValidatorDisapprovals == 0` as disabled (`if (requiredValidatorDisapprovals > 0 && job.validatorDisapprovals >= requiredValidatorDisapprovals)`).
- Implement non-bricking NFT delivery: add external, self-only `safeMintCompletionTo(address,uint256)` and make `_mintCompletionNFT` `try` the safe-mint and fall back to `_mint` on failure so contracts that don't implement `IERC721Receiver` do not block settlement.
- Add strict byte-length caps and checks: `MAX_JOB_SPEC_URI_BYTES`, `MAX_JOB_COMPLETION_URI_BYTES`, and `MAX_BASE_IPFS_URL_BYTES`, and enforce them in `createJob`, `requestJobCompletion`, and `setBaseIpfsUrl` (revert `InvalidParameters()` on overflow).
- Harden external calls: bound gas for NFT `balanceOf` calls in `getHighestPayoutPercentage` (safe stipend) and replace risky `staticcall` usage in `ENSOwnership` with a bounded-gas assembly `staticcall` that returns `(ok, address)` via safe assembly decoding.
- Fail-fast constructor checks: require non-zero `agiTokenAddress` and coherent ENS/root wiring during initialization.
- Preserve escrow-safe owner recovery: `rescueETH`, `rescueERC20`, and `rescueToken` remain but `rescueERC20` enforces the same paused/settlement/withdrawable semantics for AGI; `rescueToken` blocks AGI token rescue.
- Tests & harness: added `MockLoopingERC721` and tests verifying bounded gas behavior, ENS best-effort resilience, safe-mint fallback and wrapper access control, URI-length guards, and treasury/rescue invariants.
- Bytecode headroom: removed a small convenience view `canAccessPremiumFeature()` and a low-value event emission for reward-pool contributions and trimmed a few minor emits to bring runtime size below the repo guard.

### Testing
- Ran full test subsets during development and final verification: `npx truffle test` targeted suites including `test/mainnetHardening.test.js`, `test/mainnetRescueAndMint.test.js`, `test/adminOps.test.js`, `test/agentPayoutSnapshot.truffle.test.js`, and `test/AGIJobManager.comprehensive.test.js`; all modified and relevant tests passed locally (see CI-like runs in transcript).
- Bytecode size check: ran `truffle compile --all` and `node scripts/check-contract-sizes.js` and confirmed `AGIJobManager deployedBytecode size: 24555 bytes`, which passes the repository EIP-170 safety gate.
- Regression checks included ENS malformed/short-return handling, looping `balanceOf` gas-griefing mock, NFT safe-mint fallback, disapproval-threshold=0 semantics, URI length reverts, and rescue function behaviors; all automated tests in these suites passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d0922c1f48333b02272adc47cb3f4)