### PR TITLE
Harden settlement liveness, gas bounds, ENS/constructor validation, and add regression tests

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -253,8 +253,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     );
     event AgentBondMinUpdated(uint256 indexed oldMin, uint256 indexed newMin);
     event ValidatorSlashBpsUpdated(uint256 indexed oldBps, uint256 indexed newBps);
-    event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);
-    event ConfigUpdated(uint8 indexed key, uint256 value);
 
     uint8 private constant ENS_HOOK_CREATE = 1;
     uint8 private constant ENS_HOOK_ASSIGN = 2;
@@ -267,6 +265,8 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     uint256 internal constant ENS_URI_MAX_RETURN_BYTES = 2048;
     uint256 internal constant ENS_URI_MAX_STRING_BYTES = 1024;
     uint256 internal constant NFT_BALANCE_OF_GAS_LIMIT = 100_000;
+    uint256 internal constant SAFE_MINT_GAS_LIMIT = 250_000;
+    uint256 internal constant ERC165_GAS_LIMIT = 50_000;
     uint256 internal constant MAX_JOB_SPEC_URI_BYTES = 2048;
     uint256 internal constant MAX_JOB_COMPLETION_URI_BYTES = 1024;
     uint256 internal constant MAX_BASE_IPFS_URL_BYTES = 512;
@@ -278,12 +278,12 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         bytes32[4] memory rootNodes,
         bytes32[2] memory merkleRoots
     ) ERC721("AGIJobs", "Job") {
-        if (agiTokenAddress == address(0)) revert InvalidParameters();
-        if (
-            ensConfig[0] == address(0)
-                && ensConfig[1] == address(0)
-                && (rootNodes[0] | rootNodes[1] | rootNodes[2] | rootNodes[3]) != bytes32(0)
-        ) revert InvalidParameters();
+        if (agiTokenAddress == address(0) || agiTokenAddress.code.length == 0) revert InvalidParameters();
+        if (bytes(baseIpfs).length > MAX_BASE_IPFS_URL_BYTES) revert InvalidParameters();
+        if ((rootNodes[0] | rootNodes[1] | rootNodes[2] | rootNodes[3]) != bytes32(0)) {
+            if (ensConfig[0] == address(0) || ensConfig[0].code.length == 0) revert InvalidParameters();
+        }
+        if (ensConfig[1] != address(0) && ensConfig[1].code.length == 0) revert InvalidParameters();
         _initAddressConfig(agiTokenAddress, baseIpfs, ensConfig[0], ensConfig[1]);
         _initRoots(rootNodes, merkleRoots);
 
@@ -522,7 +522,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         _callEnsJobPagesHook(ENS_HOOK_ASSIGN, _jobId);
     }
 
-    function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external nonReentrant {
+    function requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external whenSettlementNotPaused nonReentrant {
         Job storage job = _job(_jobId);
         uint256 uriLength = bytes(_jobCompletionURI).length;
         if (!(uriLength > 0 && uriLength <= MAX_JOB_COMPLETION_URI_BYTES)) revert InvalidParameters();
@@ -538,11 +538,11 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         _callEnsJobPagesHook(ENS_HOOK_COMPLETION, _jobId);
     }
 
-    function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
+    function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenSettlementNotPaused nonReentrant {
         _recordValidatorVote(_jobId, subdomain, proof, true);
     }
 
-    function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused nonReentrant {
+    function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenSettlementNotPaused nonReentrant {
         _recordValidatorVote(_jobId, subdomain, proof, false);
     }
 
@@ -613,7 +613,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         }
     }
 
-    function disputeJob(uint256 _jobId) external whenNotPaused nonReentrant {
+    function disputeJob(uint256 _jobId) external whenSettlementNotPaused nonReentrant {
         Job storage job = _job(_jobId);
         _requireJobUnsettled(job);
         if (msg.sender != job.assignedAgent && msg.sender != job.employer) revert NotAuthorized();
@@ -704,20 +704,20 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
         _setAddressFlag(moderators, _moderator, false);
     }
     function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable {
-        if (_newTokenAddress == address(0)) revert InvalidParameters();
+        if (_newTokenAddress == address(0) || _newTokenAddress.code.length == 0) revert InvalidParameters();
         _requireEmptyEscrow();
         address oldToken = address(agiToken);
         agiToken = IERC20(_newTokenAddress);
         emit AGITokenAddressUpdated(oldToken, _newTokenAddress);
     }
     function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable {
-        if (_newEnsRegistry == address(0)) revert InvalidParameters();
+        if (_newEnsRegistry == address(0) || _newEnsRegistry.code.length == 0) revert InvalidParameters();
         _requireEmptyEscrow();
         ens = ENS(_newEnsRegistry);
         emit EnsRegistryUpdated(_newEnsRegistry);
     }
     function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable {
-        if (_newNameWrapper == address(0)) revert InvalidParameters();
+        if (_newNameWrapper != address(0) && _newNameWrapper.code.length == 0) revert InvalidParameters();
         _requireEmptyEscrow();
         nameWrapper = NameWrapper(_newNameWrapper);
         emit NameWrapperUpdated(_newNameWrapper);
@@ -778,7 +778,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     }
     function setMaxJobPayout(uint256 _maxPayout) external onlyOwner {
         maxJobPayout = _maxPayout;
-        emit ConfigUpdated(2, _maxPayout);
     }
     function setJobDurationLimit(uint256 _limit) external onlyOwner {
         jobDurationLimit = _limit;
@@ -1145,21 +1144,20 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             }
         }
         tokenUriValue = UriUtils.applyBaseIpfs(tokenUriValue, baseIpfsUrl);
+        _tokenURIs[tokenId] = tokenUriValue;
         if (job.employer.code.length != 0) {
-            try this.safeMintCompletionNFT(job.employer, tokenId) {
+            try this.safeMintCompletionNFT{ gas: SAFE_MINT_GAS_LIMIT }(job.employer, tokenId) {
             } catch {
                 _mint(job.employer, tokenId);
             }
         } else {
             _mint(job.employer, tokenId);
         }
-        _tokenURIs[tokenId] = tokenUriValue;
         emit NFTIssued(tokenId, job.employer, tokenUriValue);
     }
 
     function safeMintCompletionNFT(address to, uint256 tokenId) external {
         if (msg.sender != address(this)) revert NotAuthorized();
-        if (to.code.length == 0) revert InvalidState();
         _safeMint(to, tokenId);
     }
 
@@ -1207,7 +1205,6 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
             mstore(add(ptr, 36), jobId)
             success := call(ENS_HOOK_GAS_LIMIT, target, 0, ptr, 0x44, 0, 0)
         }
-        emit EnsHookAttempted(hook, jobId, target, success != 0);
     }
 
     function _verifyOwnership(
@@ -1350,13 +1347,13 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
                 let ptr := mload(0x40)
                 mstore(ptr, 0x01ffc9a700000000000000000000000000000000000000000000000000000000)
                 mstore(add(ptr, 0x04), shl(224, 0x01ffc9a7))
-                isSupported := staticcall(gas(), nftAddress, ptr, 0x24, ptr, 0x20)
+                isSupported := staticcall(ERC165_GAS_LIMIT, nftAddress, ptr, 0x24, ptr, 0x20)
                 isSupported := and(isSupported, gt(returndatasize(), 0x1f))
                 isSupported := and(isSupported, iszero(iszero(mload(ptr))))
                 if isSupported {
                     mstore(ptr, 0x01ffc9a700000000000000000000000000000000000000000000000000000000)
                     mstore(add(ptr, 0x04), shl(224, 0x80ac58cd))
-                    isSupported := staticcall(gas(), nftAddress, ptr, 0x24, ptr, 0x20)
+                    isSupported := staticcall(ERC165_GAS_LIMIT, nftAddress, ptr, 0x24, ptr, 0x20)
                     isSupported := and(isSupported, gt(returndatasize(), 0x1f))
                     isSupported := and(isSupported, iszero(iszero(mload(ptr))))
                 }

--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -70,6 +70,9 @@ contract ENSJobPages is Ownable {
         bytes32 rootNode,
         string memory rootName
     ) {
+        if (ensAddress == address(0) || ensAddress.code.length == 0) revert InvalidParameters();
+        if (publicResolverAddress == address(0) || publicResolverAddress.code.length == 0) revert InvalidParameters();
+        if (nameWrapperAddress != address(0) && nameWrapperAddress.code.length == 0) revert InvalidParameters();
         ens = IENSRegistry(ensAddress);
         nameWrapper = INameWrapper(nameWrapperAddress);
         publicResolver = IPublicResolver(publicResolverAddress);
@@ -79,20 +82,21 @@ contract ENSJobPages is Ownable {
 
     function setENSRegistry(address ensAddress) external onlyOwner {
         address old = address(ens);
-        if (ensAddress == address(0)) revert InvalidParameters();
+        if (ensAddress == address(0) || ensAddress.code.length == 0) revert InvalidParameters();
         ens = IENSRegistry(ensAddress);
         emit ENSRegistryUpdated(old, ensAddress);
     }
 
     function setNameWrapper(address nameWrapperAddress) external onlyOwner {
         address old = address(nameWrapper);
+        if (nameWrapperAddress != address(0) && nameWrapperAddress.code.length == 0) revert InvalidParameters();
         nameWrapper = INameWrapper(nameWrapperAddress);
         emit NameWrapperUpdated(old, nameWrapperAddress);
     }
 
     function setPublicResolver(address publicResolverAddress) external onlyOwner {
         address old = address(publicResolver);
-        if (publicResolverAddress == address(0)) revert InvalidParameters();
+        if (publicResolverAddress == address(0) || publicResolverAddress.code.length == 0) revert InvalidParameters();
         publicResolver = IPublicResolver(publicResolverAddress);
         emit PublicResolverUpdated(old, publicResolverAddress);
     }
@@ -109,7 +113,7 @@ contract ENSJobPages is Ownable {
 
     function setJobManager(address manager) external onlyOwner {
         address old = jobManager;
-        if (manager == address(0)) revert InvalidParameters();
+        if (manager == address(0) || manager.code.length == 0) revert InvalidParameters();
         jobManager = manager;
         emit JobManagerUpdated(old, manager);
     }

--- a/contracts/test/CompletionNFTHolders.sol
+++ b/contracts/test/CompletionNFTHolders.sol
@@ -6,6 +6,7 @@ import "@openzeppelin/contracts/token/ERC20/IERC20.sol";
 
 interface IAGIJobManagerCreateJob {
     function createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external;
+    function tokenURI(uint256 tokenId) external view returns (string memory);
 }
 
 contract ERC721ReceiverEmployer is IERC721Receiver {
@@ -13,6 +14,7 @@ contract ERC721ReceiverEmployer is IERC721Receiver {
     IERC20 public token;
     uint256 public receivedCount;
     uint256 public lastTokenId;
+    string public callbackTokenUri;
 
     constructor(address managerAddress, address tokenAddress) {
         manager = IAGIJobManagerCreateJob(managerAddress);
@@ -33,7 +35,33 @@ contract ERC721ReceiverEmployer is IERC721Receiver {
             receivedCount++;
         }
         lastTokenId = tokenId;
+        callbackTokenUri = manager.tokenURI(tokenId);
         return IERC721Receiver.onERC721Received.selector;
+    }
+}
+
+contract GasGriefReceiverEmployer is IERC721Receiver {
+    IAGIJobManagerCreateJob public manager;
+    IERC20 public token;
+
+    constructor(address managerAddress, address tokenAddress) {
+        manager = IAGIJobManagerCreateJob(managerAddress);
+        token = IERC20(tokenAddress);
+    }
+
+    function createJob(string memory spec, uint256 payout, uint256 duration, string memory details) external {
+        token.approve(address(manager), payout);
+        manager.createJob(spec, payout, duration, details);
+    }
+
+    function onERC721Received(address, address, uint256, bytes calldata)
+        external
+        pure
+        override
+        returns (bytes4)
+    {
+        while (true) {
+        }
     }
 }
 

--- a/contracts/test/MockGasGriefERC165.sol
+++ b/contracts/test/MockGasGriefERC165.sol
@@ -1,0 +1,9 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract MockGasGriefERC165 {
+    function supportsInterface(bytes4) external pure returns (bool) {
+        while (true) {
+        }
+    }
+}

--- a/test/ensJobPages.validation.test.js
+++ b/test/ensJobPages.validation.test.js
@@ -1,0 +1,58 @@
+const ENSJobPages = artifacts.require('ENSJobPages');
+const MockENSRegistry = artifacts.require('MockENSRegistry');
+const MockPublicResolver = artifacts.require('MockPublicResolver');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC20 = artifacts.require('MockERC20');
+const AGIJobManager = artifacts.require('AGIJobManager');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { expectCustomError } = require('./helpers/errors');
+
+contract('ENSJobPages validation', (accounts) => {
+  const [owner, other] = accounts;
+  const ZERO32 = '0x' + '00'.repeat(32);
+
+  it('enforces contract addresses in constructor and setters', async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+
+    for (const args of [
+      [other, wrapper.address, resolver.address],
+      [ens.address, wrapper.address, other],
+      [ens.address, other, resolver.address]
+    ]) {
+      try {
+        await ENSJobPages.new(args[0], args[1], args[2], ZERO32, 'jobs.agi.eth', { from: owner });
+        assert.fail('expected constructor revert');
+      } catch (error) {
+        assert.include(String(error.message), 'could not decode');
+      }
+    }
+
+
+
+
+
+    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, ZERO32, 'jobs.agi.eth', { from: owner });
+    await expectCustomError(pages.setENSRegistry.call(other, { from: owner }), 'InvalidParameters');
+    await expectCustomError(pages.setPublicResolver.call(other, { from: owner }), 'InvalidParameters');
+    await expectCustomError(pages.setNameWrapper.call(other, { from: owner }), 'InvalidParameters');
+  });
+
+  it('rejects non-contract job manager addresses', async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const token = await MockERC20.new({ from: owner });
+
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(token.address, 'ipfs://base', ens.address, wrapper.address, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32),
+      { from: owner }
+    );
+
+    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, ZERO32, 'jobs.agi.eth', { from: owner });
+    await expectCustomError(pages.setJobManager.call(other, { from: owner }), 'InvalidParameters');
+    await pages.setJobManager(manager.address, { from: owner });
+  });
+});

--- a/test/ensJobPagesHooks.test.js
+++ b/test/ensJobPagesHooks.test.js
@@ -72,13 +72,7 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
 
-    const createReceipt = await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
-    const createHook = createReceipt.logs.find((log) => log.event === "EnsHookAttempted");
-    assert.ok(createHook, "EnsHookAttempted should be emitted on create");
-    assert.equal(createHook.args.hook.toString(), "1");
-    assert.equal(createHook.args.jobId.toString(), "0");
-    assert.equal(createHook.args.target, ensJobPages.address);
-    assert.equal(createHook.args.success, true);
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
     assert.equal((await ensJobPages.createCalls()).toString(), "1");
 
     await token.mint(agent, web3.utils.toWei("2"), { from: owner });
@@ -116,13 +110,7 @@ contract("AGIJobManager ENS job pages hooks", (accounts) => {
     await token.mint(employer, payout, { from: owner });
     await token.approve(manager.address, payout, { from: employer });
 
-    const createReceipt = await manager.createJob("ipfs://spec.json", payout, 50, "details", { from: employer });
-    const createHook = createReceipt.logs.find((log) => log.event === "EnsHookAttempted");
-    assert.ok(createHook, "EnsHookAttempted should be emitted on create");
-    assert.equal(createHook.args.hook.toString(), "1");
-    assert.equal(createHook.args.jobId.toString(), "0");
-    assert.equal(createHook.args.target, ensJobPages.address);
-    assert.equal(createHook.args.success, false);
+    await manager.createJob("ipfs://spec.json", payout, 50, "details", { from: employer });
 
     await token.mint(agent, web3.utils.toWei("2"), { from: owner });
     await token.approve(manager.address, web3.utils.toWei("2"), { from: agent });


### PR DESCRIPTION
### Motivation

- Remove settlement-bricking vectors from external integrations and pause semantics so emergency ops cannot alter adjudication outcomes.
- Make best-effort integrations (ENS hooks, tokenURI, ERC721 receivers, ERC165 probes) gas-bounded and non-reverting so settlement always progresses or falls back safely. 
- Fail fast on bad deployment wiring to avoid genesis misconfiguration incidents.
- Preserve the repository EIP-170 runtime bytecode size guard.

### Description

- Pause / settlement semantics: `requestJobCompletion`, `validateJob`, `disapproveJob`, and `disputeJob` are now gated by `whenSettlementNotPaused` so `pause()` only blocks new intake while `settlementPaused` freezes adjudication. 
- Completion NFT minting hardened: added `SAFE_MINT_GAS_LIMIT`, compute & persist `tokenURI` before safe-mint, perform a bounded-gas self-call `safeMintCompletionNFT{gas: SAFE_MINT_GAS_LIMIT}` and fall back to `_mint` on any failure; `safeMintCompletionNFT` remains callable only by the contract. 
- ERC165/721 probing hardened: added `ERC165_GAS_LIMIT` and replaced `staticcall(gas(), ...)` with `staticcall(ERC165_GAS_LIMIT, ...)`, treating failures/malformed returns as unsupported (no OOG). 
- Constructor and setter validation tightened: constructor enforces non-zero and contract `code.length` for AGI token and validates `baseIpfs` length; ENS/NameWrapper wiring rules enforced (roots vs ENS presence) and setters require contract code where applicable. 
- ENS ownership utility reworked: `ENSOwnership` now uses low-level `staticcall` with explicit gas stipends, validates returndata shapes, and always returns `false` on error rather than reverting. 
- Tests and fixtures: added/updated regression tests and test fixtures to cover pause vs settlement semantics, safe-mint fallback and tokenURI callback-reading, gas-griefing ERC165 and looping balanceOf, ENS hooks non‑bricking behavior, ENSJobPages constructor/setter validation, and solvency invariants; added `MockGasGriefERC165` and gas-griefing receiver test contracts. 
- Code-size headroom changes: removed two low-value diagnostic emits/events (internal ENS hook attempt and a generic `ConfigUpdated` emit) to keep runtime bytecode under the repo guard without affecting settlement correctness.

### Testing

- Ran targeted automated test suites locally via Truffle: `test/mainnetHardening.test.js`, `test/pausing.accessControl.test.js`, `test/ensJobPages.validation.test.js`, `test/ensJobPagesHooks.test.js`, `test/invariants.solvency.test.js`, and `test/escrowAccounting.invariants.test.js`; all updated and new tests passed in the final validation run. 
- Verified compilation and repeated Truffle test runs during development to iterate fixes (intermediate failures were addressed). 
- Bytecode size guard: `npm run size` reports `AGIJobManager runtime bytecode size: 24564 bytes`, which is below the repo guard (24575 bytes) and considered passing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d4441c1e48333a03025a0a6bbe7fa)