### PR TITLE
Harden ENS ownership staticcalls and add ENS/URI/ENSJobPages safety regressions

### DIFF
--- a/contracts/test/GasGriefENSComponents.sol
+++ b/contracts/test/GasGriefENSComponents.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract GasGriefENSRegistry {
+    function resolver(bytes32) external pure returns (address) {
+        while (true) {}
+        return address(0);
+    }
+}
+
+contract GasGriefNameWrapper {
+    function ownerOf(uint256) external pure returns (address) {
+        while (true) {}
+        return address(0);
+    }
+}
+
+contract GasGriefResolver {
+    function addr(bytes32) external pure returns (address payable) {
+        while (true) {}
+        return payable(address(0));
+    }
+}

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -146,9 +146,12 @@ contract("ENSJobPages helper", (accounts) => {
     );
 
     await expectRevert.unspecified(helper.setENSRegistry(owner, { from: owner }));
+    await expectRevert.unspecified(helper.setENSRegistry("0x0000000000000000000000000000000000000000", { from: owner }));
     await expectRevert.unspecified(helper.setPublicResolver(owner, { from: owner }));
+    await expectRevert.unspecified(helper.setPublicResolver("0x0000000000000000000000000000000000000000", { from: owner }));
     await expectRevert.unspecified(helper.setNameWrapper(owner, { from: owner }));
     await expectRevert.unspecified(helper.setJobManager(owner, { from: owner }));
+    await expectRevert.unspecified(helper.setJobManager("0x0000000000000000000000000000000000000000", { from: owner }));
   });
 
 });

--- a/test/utils.uri-transfer.test.js
+++ b/test/utils.uri-transfer.test.js
@@ -62,6 +62,13 @@ contract("Utility libraries: UriUtils + TransferUtils", (accounts) => {
       const out = await harness.applyBaseIpfs("bafy/job.json", "");
       assert.equal(out, "bafy/job.json");
     });
+
+    it("handles edge-case baseIpfsUrl values without reverting", async () => {
+      assert.equal(await harness.applyBaseIpfs("QmData", "/"), "//QmData");
+      assert.equal(await harness.applyBaseIpfs("QmData", "ipfs://"), "ipfs:///QmData");
+      assert.equal(await harness.applyBaseIpfs("QmData", "weird://gateway//path/"), "weird://gateway//path//QmData");
+      assert.equal(await harness.applyBaseIpfs("ens://job-1.alpha.jobs.agi.eth", "ipfs://base"), "ens://job-1.alpha.jobs.agi.eth");
+    });
   });
 
   describe("TransferUtils exact-transfer semantics", () => {


### PR DESCRIPTION
### Motivation
- ENS ownership/ resolver/ namewrapper calls must never revert or forward unbounded gas into settlement flows, and malformed returndata must be treated as “not-owned” rather than causing a revert. 
- Prevent ENS/URI/ENSJobPages integrations from providing realistic bricking or liveness attack vectors on mainnet-operated deployment.

### Description
- Replace decode-based helpers in `ENSOwnership.verifyENSOwnership` with a gas-bounded `_staticcallWord` assembly helper that enforces a 32-byte returndata length, converts raw words into addresses, and normalizes boolean return values to only accept `0`/`1`, causing all problematic paths to safely return `false` instead of reverting. 
- Add `contracts/test/GasGriefENSComponents.sol` mocks that simulate infinite-loop/gas-grief ENS/resolver/wrapper behavior and extend `test/invariants.libs.test.js` to assert `verifyENSOwnership` fails-closed for reverting, malformed, and gas-griefing external components. 
- Extend URI tests in `test/utils.uri-transfer.test.js` to cover edge-case `baseIpfsUrl` values so `UriUtils.applyBaseIpfs` cannot brick settlement, and tighten `test/ensJobPagesHelper.test.js` to reject zero-address updates for ENS registry, public resolver, and job manager setters. 
- No new runtime dependencies or feature removals were introduced and `@openzeppelin/contracts` remains pinned to `4.9.6` as in the repo. 

### Testing
- Ran `npx truffle test test/invariants.libs.test.js test/utils.uri-transfer.test.js test/ensJobPagesHelper.test.js --network test` and the updated/added tests passed. 
- Ran the full automated suite with `npm test` and it completed successfully (test suite passed). 
- Ran `npm run size` and confirmed `AGIJobManager` runtime bytecode size is `24553` bytes, which passes the repository EIP‑170 size guard.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698e0369680483339e44da27011f5319)