### PR TITLE
docs: add deterministic, CI-enforced institutional documentation system

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,30 @@
+name: Docs Integrity
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  docs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: No binaries policy
+        run: npm run check:no-binaries
+
+      - name: Docs checks
+        run: npm run docs:check

--- a/README.md
+++ b/README.md
@@ -52,20 +52,16 @@ AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other ma
 
 ## Documentation
 
-Start with the documentation index: [`docs/00_INDEX.md`](docs/00_INDEX.md).
+Start with the institutional docs landing page: [`docs/README.md`](docs/README.md).
 
-Documentation hub: [`docs/README.md`](docs/README.md).
+Key pages:
+- [Overview](docs/OVERVIEW.md)
+- [Quickstart](docs/QUICKSTART.md)
+- [Quintessential Use Case](docs/QUINTESSENTIAL_USE_CASE.md)
+- [Architecture](docs/ARCHITECTURE.md)
+- [Security Model](docs/SECURITY_MODEL.md)
 
-Core operator/integrator/auditor docs:
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- [`docs/PROTOCOL_FLOW.md`](docs/PROTOCOL_FLOW.md)
-- [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
-- [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
-- [`docs/ENS_INTEGRATION.md`](docs/ENS_INTEGRATION.md)
-- [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
-- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
-- [`docs/GLOSSARY.md`](docs/GLOSSARY.md)
-- [`docs/REPOSITORY_INVENTORY.md`](docs/REPOSITORY_INVENTORY.md)
+Documentation visuals are text-only Mermaid/SVG assets (no binary screenshots). Docs freshness is enforced with `npm run docs:check`; generated reference pages are refreshed via `npm run docs:gen`. Binary file policy enforcement runs via `npm run check:no-binaries`.
 
 ## Quickstart
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,107 +1,31 @@
-# AGIJobManager Architecture
+# Architecture
 
-## System overview
-
-### Components and responsibilities
-- **AGIJobManager (`contracts/AGIJobManager.sol`)**: core escrow, job lifecycle, bond accounting, validator voting, dispute handling, NFT issuance, reputation updates, pause controls, and owner configuration.
-- **ENSJobPages (`contracts/ens/ENSJobPages.sol`)**: optional ENS mirror for job pages and metadata; invoked via best-effort lifecycle hooks.
-- **Utility libraries (`contracts/utils/*.sol`)**:
-  - `BondMath`: computes validator and agent bond sizes.
-  - `ReputationMath`: computes bounded reputation growth points.
-  - `ENSOwnership`: helper checks for ENS/NameWrapper/resolver ownership.
-  - `TransferUtils`: strict ERC20 transfer wrappers.
-  - `UriUtils`: URI validation and base IPFS prefix application.
-- **External systems**:
-  - ERC20 AGI token (`agiToken`) for escrow and bonds.
-  - ENS registry + NameWrapper + PublicResolver used for identity gating and ENS pages.
-
-## Component interaction diagram
+## System component flow
 
 ```mermaid
+%%{init: {"theme":"base","themeVariables":{"fontFamily":"ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial","background":"#14001F","primaryColor":"#4B1D86","primaryTextColor":"#E9DAFF","lineColor":"#7A3FF2","tertiaryColor":"#1B0B2A","noteBkgColor":"#1B0B2A","noteTextColor":"#E9DAFF"}}}%%
 flowchart LR
-    EMP[Employer] -->|createJob + escrow AGI| AJM[AGIJobManager]
-    AGT[Agent] -->|applyForJob + agent bond| AJM
-    VAL[Validator] -->|validate/disapprove + validator bond| AJM
-    MOD[Moderator] -->|resolveDispute*| AJM
-    OWN[Owner] -->|config/pause/lock identity| AJM
-
-    AJM -->|safeTransfer/safeTransferFrom| ERC20[(AGI ERC20)]
-    AJM -->|best-effort hook 1..6| ENSJP[ENSJobPages]
-    ENSJP --> ENS[(ENS Registry)]
-    ENSJP --> WRAP[(NameWrapper)]
-    ENSJP --> RES[(PublicResolver)]
-    AJM --> NFT[(ERC721 job NFT mint)]
+    Owner[Owner/Operator] --> AGI[AGIJobManager]
+    Employer --> AGI
+    Agent --> AGI
+    Validator --> AGI
+    Moderator --> AGI
+    AGI --> Token[(AGI ERC20)]
+    AGI -. best-effort .-> ENS[(ENS Registry + NameWrapper)]
+    AGI -. best-effort .-> Pages[(ENSJobPages)]
+    Offchain[Monitoring/Indexer] --> AGI
 ```
 
-## Happy-path job lifecycle (sequence)
+## Repository architecture flow
 
 ```mermaid
-sequenceDiagram
-    participant Employer
-    participant Agent
-    participant Validators
-    participant AGIJobManager
-    participant ENSJobPages
-
-    Employer->>AGIJobManager: createJob(specURI, payout, duration, details)
-    AGIJobManager-->>ENSJobPages: hook 1 (create) best-effort
-
-    Agent->>AGIJobManager: applyForJob(jobId, subdomain, proof)
-    AGIJobManager-->>ENSJobPages: hook 2 (assign) best-effort
-
-    Agent->>AGIJobManager: requestJobCompletion(jobId, completionURI)
-    AGIJobManager-->>ENSJobPages: hook 3 (completion) best-effort
-
-    Validators->>AGIJobManager: validateJob(...) votes
-    AGIJobManager->>AGIJobManager: challenge period / review checks
-
-    alt approvals lead and windows satisfied
-      anyone->>AGIJobManager: finalizeJob(jobId)
-      AGIJobManager->>AGIJobManager: settle agent + validators + reputation
-      AGIJobManager->>AGIJobManager: mint completion NFT
-      AGIJobManager-->>ENSJobPages: hook 4 (revoke) best-effort
-    else dispute path
-      Validator/Employer/Agent->>AGIJobManager: disapprove/disputeJob
-      Moderator->>AGIJobManager: resolveDisputeWithCode(...)
-      AGIJobManager->>AGIJobManager: settle win/loss path
-      AGIJobManager->>AGIJobManager: mint NFT only on agent-win
-      AGIJobManager-->>ENSJobPages: hook 4 (revoke) best-effort
-    end
+flowchart TB
+    C[contracts/] --> A[AGIJobManager.sol]
+    T[test/] --> A
+    M[migrations/] --> A
+    S[scripts/] --> D[docs generators/checks]
+    D --> Docs[docs/]
+    CI[.github/workflows/docs.yml] --> S
 ```
 
-## Job state machine
-
-```mermaid
-stateDiagram-v2
-    [*] --> Created: createJob
-    Created --> Assigned: applyForJob
-    Created --> Cancelled: cancelJob / delistJob
-
-    Assigned --> CompletionRequested: requestJobCompletion
-    Assigned --> Expired: expireJob
-
-    CompletionRequested --> Completed: finalizeJob (agent-win)
-    CompletionRequested --> Refunded: finalizeJob (employer-win)
-    CompletionRequested --> Disputed: disputeJob or disapproval threshold
-
-    Disputed --> Completed: resolveDispute* agent-win
-    Disputed --> Refunded: resolveDispute* employer-win
-    Disputed --> Completed: resolveStaleDispute(false)
-    Disputed --> Refunded: resolveStaleDispute(true)
-
-    Completed --> ENSRevoked: hook 4
-    Refunded --> ENSRevoked: hook 4
-    Expired --> ENSRevoked: hook 4
-```
-
-## Trust boundaries
-
-### External calls
-- **ERC20 transfers** are performed through `TransferUtils` wrappers and can revert settlement/withdraw flows if token transfers fail.
-- **ENS hooks** are called with fixed gas (`ENS_HOOK_GAS_LIMIT`) and are deliberately best-effort (`call` return value emitted as `EnsHookAttempted`), so lifecycle operations continue if ENS integration fails.
-- **ENS URI fetch for NFT minting** is optional and best-effort (`staticcall` + fallback to completion URI).
-
-### Best-effort implications
-- A job can settle correctly even if ENS hooks fail.
-- ENS page state may lag or be incomplete; on-chain escrow/accounting remains canonical.
-- Operators must monitor `EnsHookAttempted` and reconcile ENS issues operationally rather than expecting automatic rollback.
+- Text-only visual assets: [palette.svg](./assets/palette.svg), [architecture-wireframe.svg](./assets/architecture-wireframe.svg)

--- a/docs/CONTRACTS/AGIJobManager.md
+++ b/docs/CONTRACTS/AGIJobManager.md
@@ -1,0 +1,62 @@
+# AGIJobManager Contract Guide
+
+## Permissions matrix
+
+| Action | Owner | Moderator | Employer | Agent | Validator | Anyone |
+| --- | --- | --- | --- | --- | --- | --- |
+| Create/cancel own job |  |  | ✅ |  |  |  |
+| Apply/request completion |  |  |  | ✅ |  |  |
+| Validate/disapprove |  |  |  |  | ✅ (eligible) |  |
+| Resolve dispute |  | ✅ |  |  |  |  |
+| Emergency controls / param updates | ✅ |  |  |  |  |  |
+| Expire eligible jobs |  |  |  |  |  | ✅ |
+
+## Lifecycle
+
+```mermaid
+stateDiagram-v2
+    [*] --> Created
+    Created --> Assigned: applyForJob
+    Assigned --> CompletionRequested: requestJobCompletion
+    CompletionRequested --> Approved: validator threshold met
+    CompletionRequested --> Disapproved: disapproval threshold met
+    CompletionRequested --> Disputed: disputeJob
+    Approved --> Completed: finalizeJob after challenge window
+    Disapproved --> Refunded: finalizeJob
+    Disputed --> Completed: resolveDispute (agent wins)
+    Disputed --> Refunded: resolveDispute (employer wins)
+    Created --> Cancelled: cancelJob
+    Assigned --> Expired: expireJob
+```
+
+## Dispute + finalize sequence
+
+```mermaid
+sequenceDiagram
+    participant E as Employer
+    participant A as Agent
+    participant V as Validators
+    participant M as Moderator
+    participant C as AGIJobManager
+    A->>C: requestJobCompletion(jobId, completionURI)
+    V->>C: validateJob/disapproveJob
+    alt disputed
+      E->>C: disputeJob(jobId)
+      M->>C: resolveDisputeWithCode(jobId, code, reason)
+    else no dispute
+      E->>C: finalizeJob(jobId)
+    end
+    C-->>E: refund or settlement
+    C-->>A: payout + bond outcome
+```
+
+## Bonds, accounting, and timing
+
+- Escrow: employer payout locked at job creation.
+- Agent bond: posted on apply; returned/slashed at settlement.
+- Validator bond: posted per vote and settled by final outcome.
+- Dispute bond: posted by disputant and settled by resolution.
+- Timing windows: job duration, completion review period, dispute review period, post-approval challenge window.
+
+> **Safety warning**
+> Operators should monitor `withdrawableAGI()` and lock variables before treasury operations.

--- a/docs/CONTRACTS/INTEGRATIONS.md
+++ b/docs/CONTRACTS/INTEGRATIONS.md
@@ -1,0 +1,20 @@
+# Integrations
+
+## ENS / NameWrapper gating
+
+- Eligibility checks may rely on ENS root nodes and NameWrapper ownership checks.
+- Additional allowlists and Merkle proofs provide fallback/operator override paths.
+- ENS failures should not compromise escrow safety, only identity-gated participation.
+
+## ENSJobPages hooks and tokenURI
+
+- Hook calls are best-effort and emitted via `EnsHookAttempted`.
+- `tokenURI` enrichment through ENSJobPages is optional and must not be treated as consensus-critical.
+
+## Merkle allowlists
+
+- Validator and agent Merkle roots are owner-managed via `updateMerkleRoots`.
+- Proof tooling: `scripts/merkle/generate_merkle_proof.js` and `scripts/merkle/smoke_test.js`.
+
+> **Operator note**
+> Maintain an audit trail whenever root nodes, Merkle roots, or additional allowlist entries change.

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -1,21 +1,9 @@
 # Glossary
 
-- **AGIJobManager**: Core ERC721 + escrow contract implementing job lifecycle and settlement.
-- **ENSJobPages**: Optional ENS helper contract for job page records and permissions.
-- **Escrow (`lockedEscrow`)**: AGI token amount reserved for unsettled job payouts.
-- **Withdrawable AGI**: Treasury balance not reserved by escrow/bond locks.
-- **Agent bond**: Stake posted by assigned agent to align completion incentives.
-- **Validator bond**: Stake posted by each validator vote, slashable on incorrect side.
-- **Dispute bond**: Stake posted by disputant in manual disputes.
-- **Completion review period**: Window for validator voting/disputing after completion request.
-- **Challenge period after approval**: Delay after approval threshold before fast finalize.
-- **Dispute review period**: Timeout before owner can resolve stale disputes.
-- **Vote quorum**: Minimum total votes considered sufficient for deterministic slow-path outcome.
-- **AGI type**: ERC721 collection configured with payout percentage used for agent payout tiering.
-- **Best-effort hook**: External ENS call that emits success/failure but does not revert core flow on failure.
-- **Identity configuration lock**: Irreversible freeze of token/ENS/root/ENSJobPages wiring setters that use `whenIdentityConfigurable`; Merkle roots remain owner-updatable.
-- **Settlement pause**: Dedicated toggle blocking settlement-sensitive methods independently of global pause.
-- **Namespace root node**: ENS node (bytes32) root used for ownership gating (`club`, `agent`, alpha variants).
-- **Merkle root**: Root hash used to verify allowlisted agents/validators via proofs.
-- **NameWrapper**: ENS wrapped-name contract used for wrapped root management and fuse operations.
-- **Fuses**: NameWrapper permission bits; in this repo lock path burns resolver/TTL mutability bits for child names.
+- **Employer**: funds and owns job escrow lifecycle initiation.
+- **Agent**: participant assigned to execute job and request completion.
+- **Validator**: bonded reviewer voting approve/disapprove.
+- **Moderator**: dispute resolver role with authority over contested jobs.
+- **Escrow lock**: accounting reserve of payout funds for active jobs.
+- **Settlement pause**: control to stop settlement-sensitive actions.
+- **Best-effort integration**: optional hook/integration whose failure must not affect core safety.

--- a/docs/OPERATIONS/INCIDENT_RESPONSE.md
+++ b/docs/OPERATIONS/INCIDENT_RESPONSE.md
@@ -1,0 +1,24 @@
+# Incident Response
+
+```mermaid
+flowchart TD
+    A[Alert detected] --> B{Active exploit in progress?}
+    B -- Yes --> C[Call pause()]
+    B -- No --> D{Need to stop new settlements but allow resolution prep?}
+    D -- Yes --> E[setSettlementPaused(true)]
+    D -- No --> F{Single bad actor?}
+    F -- Yes --> G[blacklistAgent / blacklistValidator]
+    F -- No --> H{Identity wiring risk?}
+    H -- Yes --> I[lockIdentityConfiguration()]
+    H -- No --> J[Continue monitoring + comms]
+```
+
+## Playbook
+
+- Contain: choose `pause` vs `settlementPaused` based on blast radius.
+- Preserve evidence: capture tx hashes, block ranges, affected job IDs.
+- Communicate: post operator status update with next checkpoint.
+- Recover: unpause only after root cause and compensating controls are in place.
+
+> **Safety warning**
+> `lockIdentityConfiguration()` is permanent; execute only with change-control signoff.

--- a/docs/OPERATIONS/MONITORING.md
+++ b/docs/OPERATIONS/MONITORING.md
@@ -1,0 +1,19 @@
+# Monitoring
+
+## Events catalog
+
+| Event | When emitted | How to monitor | Suggested alert |
+| --- | --- | --- | --- |
+| `JobCreated` | New funded escrow | job counter and payout aggregate | sudden spike detection |
+| `JobApplied` | Agent assigned | per-job assignment lag | stale jobs without completion requests |
+| `JobCompletionRequested` | Agent submits completion | SLA timers for validator window | missing validator participation |
+| `JobValidated` / `JobDisapproved` | Validator vote | quorum progression tracking | conflicting vote wave |
+| `JobDisputed` / `DisputeResolvedWithCode` | Dispute lifecycle | moderator queue age | unresolved disputes > review period |
+| `JobCompleted` / `JobCancelled` / `JobExpired` | terminal settlement | financial reconciliation | settlement anomalies |
+| `AGIWithdrawn` | treasury movement | treasury policy checks | withdrawal outside maintenance window |
+
+## State sanity checks
+
+- `withdrawableAGI()` remains non-negative and aligned with treasury policy.
+- Locked accounting totals trend with active jobs and bonds.
+- Pause/settlement pause flags match incident state.

--- a/docs/OPERATIONS/RUNBOOK.md
+++ b/docs/OPERATIONS/RUNBOOK.md
@@ -1,0 +1,19 @@
+# Operations Runbook
+
+## Configuration catalog
+
+| Parameter | Purpose | Safe range guidance | Operational notes | Where set |
+| --- | --- | --- | --- | --- |
+| `requiredValidatorApprovals` | Approval threshold | >=1 and <= validator quorum | Raise gradually with validator capacity | owner setter |
+| `requiredValidatorDisapprovals` | Disapproval threshold | >=1 and <= validator quorum | Keep symmetric with approval policy unless policy exception is deliberate | owner setter |
+| `completionReviewPeriod` | Validator voting window | Long enough for global validator coverage | Too short harms liveness | owner setter |
+| `disputeReviewPeriod` | Moderator resolution window | Sized for human response | Coordinate moderation on-call | owner setter |
+| `challengePeriodAfterApproval` | Delay before finalize | Prevent instant settlement races | Keep stable once in production | owner setter |
+
+## Parameter-change checklist
+
+1. Record current values and reason for change.
+2. Simulate impact in staging.
+3. Execute owner transaction.
+4. Verify events emitted and getters updated.
+5. Publish operator note and rollback criteria.

--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -1,0 +1,21 @@
+# Overview
+
+AGIJobManager is an owner-operated escrow and settlement protocol for employer-agent jobs with validator voting and moderator dispute resolution.
+
+## Repository guarantees
+
+1. Escrow solvency accounting is explicit (`lockedEscrow`, bond locks, `withdrawableAGI`).
+2. Operator controls are explicit and role-scoped (`pause`, `settlementPaused`, blacklist controls).
+3. ENS and ENSJobPages are best-effort integrations; they are not safety dependencies.
+
+## Components
+
+| Component | Responsibility | Source of truth |
+| --- | --- | --- |
+| AGIJobManager contract | Job lifecycle, escrow, bonds, governance controls | `contracts/AGIJobManager.sol` |
+| ENS helpers | Ownership checks and optional metadata/hook routing | `contracts/utils/ENSOwnership.sol`, `contracts/ens/ENSJobPages.sol` |
+| Deployment wiring | Deterministic deployment and configuration | `migrations/2_deploy_contracts.js`, `scripts/postdeploy-config.js` |
+| Test harness | Regression, hardening, invariants | `test/*.test.js` |
+
+> **Non-goal / limitation**
+> This system is not a decentralized court; owner and moderators are privileged actors by design.

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -1,74 +1,27 @@
-# Quickstart
+# Quickstart (15-30 minutes)
 
-## Purpose
-Get a contributor from clean checkout to compile/test/size-guard with repository-supported commands.
+## Prerequisites
 
-## Audience
-Developers and auditors doing local verification.
+- Node.js 20+
+- npm
 
-## Preconditions / assumptions
-- Node.js + npm installed.
-- No secrets committed; use local environment variables only.
-- Run commands from repo root.
+## Commands
 
-## Install dependencies
 ```bash
 npm ci
-```
-
-## Build / compile
-```bash
 npm run build
+npm run test
+npm run docs:gen
+npm run docs:check
 ```
 
-## Run complete test pipeline
-```bash
-npm test
-```
+## Workflow command matrix
 
-`npm test` runs:
-- `truffle compile --all`
-- `truffle test --network test`
-- `node test/AGIJobManager.test.js`
-- `node scripts/check-contract-sizes.js`
-
-## Run explicit runtime-size guard
-```bash
-npm run size
-```
-
-## Optional checks
-```bash
-npm run lint
-npm run docs:interface
-```
-
-## Local deployment (dev/test chain)
-```bash
-truffle migrate --network test --reset
-```
-
-## Live-network deployment skeleton
-```bash
-truffle migrate --network <mainnet|sepolia> --reset
-node scripts/postdeploy-config.js --network <mainnet|sepolia> --address <AGIJOBMANAGER_ADDRESS>
-node scripts/verify-config.js --network <mainnet|sepolia> --address <AGIJOBMANAGER_ADDRESS>
-```
-
-## Troubleshooting
-- **`truffle: command not found`**: run `npm ci` and use local binaries via npm scripts.
-- **Provider errors (`Missing RPC URL`, `Missing PRIVATE_KEYS`)**: configure env vars consumed by `truffle-config.js` (`<NETWORK>_RPC_URL` or Alchemy/Infura keys, and `PRIVATE_KEYS`).
-- **`ConfigLocked` reverts**: `lockIdentityConfiguration()` permanently blocks identity wiring setters.
-- **Withdrawal revert while unpaused**: `withdrawAGI()` requires both `whenPaused` and `whenSettlementNotPaused`.
-- **Bytecode size failures**: run `npm run size` and inspect contract growth before deployment.
-
-## Gotchas / failure modes
-- `npm install` can drift lockfile resolution; prefer `npm ci` for reproducibility.
-- `truffle test` on non-`test` network may produce misleading failures due to permissions/funding.
-
-## References
-- [`../package.json`](../package.json)
-- [`../truffle-config.js`](../truffle-config.js)
-- [`../scripts/check-bytecode-size.js`](../scripts/check-bytecode-size.js)
-- [`../scripts/postdeploy-config.js`](../scripts/postdeploy-config.js)
-- [`../scripts/verify-config.js`](../scripts/verify-config.js)
+| Command | Outcome | When to use | Common failures |
+| --- | --- | --- | --- |
+| `npm ci` | Deterministic install from lockfile | Fresh clone, CI parity | Node version mismatch |
+| `npm run build` | Compiles contracts with pinned Truffle/solc config | Before deploy/tests | Missing env variables in custom network setup |
+| `npm run test` | Full contract and JS test run | Regression validation | Ganache process state or dependency corruption |
+| `truffle migrate --network test` | Local deploy via migrations | Dry-run deployment wiring | Migration env mismatch |
+| `npm run docs:gen` | Regenerates reference docs | Before commit | Missing source files |
+| `npm run docs:check` | Verifies docs completeness/freshness/links | CI and pre-PR gate | Stale generated docs or broken links |

--- a/docs/QUINTESSENTIAL_USE_CASE.md
+++ b/docs/QUINTESSENTIAL_USE_CASE.md
@@ -1,0 +1,73 @@
+# Quintessential Use Case
+
+A deterministic operator-to-settlement scenario covering happy path, disputes, and expiry.
+
+## Step table
+
+| Step | Actor | Function/Command | Preconditions | Expected on-chain outcome | Events emitted |
+| --- | --- | --- | --- | --- | --- |
+| 1 | Operator | `truffle migrate --network test` | Config present | Contract deployed and wired | deployment tx logs |
+| 2 | Owner | `addModerator`, allowlist setters, `updateMerkleRoots` | ownership | governance and eligibility configured | config update events |
+| 3 | Employer | `createJob(jobSpecURI, payout, duration, details)` | approved token balance | funded job created | `JobCreated` |
+| 4 | Agent | `applyForJob(jobId, subdomain, proof)` | eligibility + bond | job assigned | `JobApplied` |
+| 5 | Agent | `requestJobCompletion(jobId, jobCompletionURI)` | assigned and active | review phase starts | `JobCompletionRequested` |
+| 6a | Validators | `validateJob` | eligibility + bond | approval count increases | `JobValidated` |
+| 6b | Validators | `disapproveJob` | eligibility + bond | disapproval count increases | `JobDisapproved` |
+| 7 | Employer | `finalizeJob(jobId)` | challenge/review conditions met | payout or refund path settles | `JobCompleted` or refund-side events |
+| 8 | Moderator | `resolveDisputeWithCode(jobId, code, reason)` | active dispute | forced settlement by policy code | `DisputeResolvedWithCode` |
+| 9 | Anyone | `expireJob(jobId)` | duration elapsed with no completion | expiry settlement | `JobExpired` |
+| 10 | Operator | monitor events/getters | indexer active | solvency and lifecycle sanity | event stream + getter reads |
+
+## Happy path sequence
+
+```mermaid
+%%{init: {"theme":"base","themeVariables":{"fontFamily":"ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Arial","background":"#14001F","primaryColor":"#4B1D86","primaryTextColor":"#E9DAFF","lineColor":"#7A3FF2","tertiaryColor":"#1B0B2A","noteBkgColor":"#1B0B2A","noteTextColor":"#E9DAFF"}}}%%
+sequenceDiagram
+    participant O as Owner
+    participant E as Employer
+    participant A as Agent
+    participant V as Validators
+    participant C as AGIJobManager
+    O->>C: configure moderators + roots
+    E->>C: createJob
+    A->>C: applyForJob
+    A->>C: requestJobCompletion
+    V->>C: validateJob (quorum)
+    E->>C: finalizeJob after challenge window
+    C-->>A: payout + bond return
+```
+
+## Lifecycle state diagram
+
+```mermaid
+stateDiagram-v2
+    [*] --> Draft
+    Draft --> Funded: createJob
+    Funded --> Assigned: applyForJob
+    Assigned --> Review: requestJobCompletion
+    Review --> Approved: validator approvals met
+    Review --> Disapproved: validator disapprovals met
+    Review --> Disputed: disputeJob
+    Approved --> Settled: finalizeJob
+    Disapproved --> Settled: finalizeJob (refund)
+    Disputed --> Settled: moderator resolution
+    Assigned --> Expired: expireJob
+```
+
+## Expected state checkpoints
+
+1. After deployment: owner, token, roots, and pause flags match intended baseline.
+2. After configuration: moderator and allowlist/merkle settings readable and event-confirmed.
+3. After job creation: escrow and active-job accounting incremented.
+4. After apply: assigned agent and agent bond lock visible.
+5. After completion request: review windows and timestamps populated.
+6. After voting: vote tallies and bond locks reconciled.
+7. After finalize/dispute/expire: job terminal, locked balances decremented, withdrawable totals sane.
+
+## Testnet/Mainnet checklist (safe)
+
+- Use hardware-backed or multisig owner custody.
+- Validate deploy and post-deploy scripts in staging before production.
+- Record all governance and parameter transactions.
+- Keep incident runbook and moderation rota active before enabling traffic.
+- Never publish secrets; use environment variables and `.env.example` patterns only.

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,32 +1,32 @@
-# AGIJobManager Documentation Hub
+# AGIJobManager Documentation
 
-Start with the documentation index:
-- [00_INDEX.md](./00_INDEX.md)
+Institutional documentation for operators, developers, auditors, and integrators.
 
-Primary operator/auditor references:
-- [Architecture](./ARCHITECTURE.md)
-- [Protocol Flow](./PROTOCOL_FLOW.md)
-- [Configuration](./CONFIGURATION.md)
-- [Deploy Runbook](./DEPLOY_RUNBOOK.md)
-- [ENS Integration](./ENS_INTEGRATION.md)
-- [Security Model](./SECURITY_MODEL.md)
-- [Troubleshooting](./TROUBLESHOOTING.md)
-- [Glossary](./GLOSSARY.md)
-- [Repository Inventory](./REPOSITORY_INVENTORY.md)
+## Audience map
 
-Implementation sources of truth:
-- `contracts/AGIJobManager.sol`
-- `contracts/ens/ENSJobPages.sol`
-- `migrations/2_deploy_contracts.js`
-- `migrations/deploy-config.js`
-- `scripts/postdeploy-config.js`
-- `scripts/verify-config.js`
-- `package.json`
-- `.github/workflows/ci.yml`
+- **New contributors**: [OVERVIEW.md](./OVERVIEW.md), [QUICKSTART.md](./QUICKSTART.md), [TESTING.md](./TESTING.md)
+- **Operators / SRE**: [QUINTESSENTIAL_USE_CASE.md](./QUINTESSENTIAL_USE_CASE.md), [OPERATIONS/RUNBOOK.md](./OPERATIONS/RUNBOOK.md), [OPERATIONS/INCIDENT_RESPONSE.md](./OPERATIONS/INCIDENT_RESPONSE.md), [OPERATIONS/MONITORING.md](./OPERATIONS/MONITORING.md)
+- **Auditors / security teams**: [SECURITY_MODEL.md](./SECURITY_MODEL.md), [CONTRACTS/AGIJobManager.md](./CONTRACTS/AGIJobManager.md), [REFERENCE/CONTRACT_INTERFACE.md](./REFERENCE/CONTRACT_INTERFACE.md)
+- **Integrators**: [CONTRACTS/INTEGRATIONS.md](./CONTRACTS/INTEGRATIONS.md), [ARCHITECTURE.md](./ARCHITECTURE.md)
 
+## Navigation
 
-## Audience quick links
+- [OVERVIEW.md](./OVERVIEW.md)
+- [REPO_MAP.md](./REPO_MAP.md) _(generated)_
+- [QUICKSTART.md](./QUICKSTART.md)
+- [QUINTESSENTIAL_USE_CASE.md](./QUINTESSENTIAL_USE_CASE.md)
+- [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [CONTRACTS/AGIJobManager.md](./CONTRACTS/AGIJobManager.md)
+- [CONTRACTS/INTEGRATIONS.md](./CONTRACTS/INTEGRATIONS.md)
+- [OPERATIONS/RUNBOOK.md](./OPERATIONS/RUNBOOK.md)
+- [OPERATIONS/INCIDENT_RESPONSE.md](./OPERATIONS/INCIDENT_RESPONSE.md)
+- [OPERATIONS/MONITORING.md](./OPERATIONS/MONITORING.md)
+- [SECURITY_MODEL.md](./SECURITY_MODEL.md)
+- [TESTING.md](./TESTING.md)
+- [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
+- [GLOSSARY.md](./GLOSSARY.md)
+- [REFERENCE/VERSIONS.md](./REFERENCE/VERSIONS.md) _(generated)_
+- [REFERENCE/CONTRACT_INTERFACE.md](./REFERENCE/CONTRACT_INTERFACE.md) _(generated)_
 
-- **Operators:** [DEPLOY_RUNBOOK.md](./DEPLOY_RUNBOOK.md), [OPERATIONS.md](./OPERATIONS.md), [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
-- **Developers:** [TESTING.md](./TESTING.md), [TEST_PLAN.md](./TEST_PLAN.md), [ARCHITECTURE.md](./ARCHITECTURE.md)
-- **Auditors:** [SECURITY_MODEL.md](./SECURITY_MODEL.md), [ARCHITECTURE.md](./ARCHITECTURE.md), [CONFIGURATION.md](./CONFIGURATION.md)
+> **Operator note**
+> Documentation freshness and structure are validated by `npm run docs:check`.

--- a/docs/REFERENCE/CONTRACT_INTERFACE.md
+++ b/docs/REFERENCE/CONTRACT_INTERFACE.md
@@ -1,0 +1,177 @@
+# AGIJobManager Contract Interface (Generated)
+
+Verified against repository state: `79d6495`.
+
+Generated at: `2026-02-13T14:45:51-05:00`.
+
+## Operator-facing interface
+
+- `addAGIType(address nftAddress, uint256 payoutPercentage) external onlyOwner`
+- `addAdditionalAgent(address agent) external onlyOwner`
+- `addAdditionalValidator(address validator) external onlyOwner`
+- `addModerator(address _moderator) external onlyOwner`
+- `applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenNotPaused whenSettlementNotPaused nonReentrant`
+- `blacklistAgent(address _agent, bool _status) external onlyOwner`
+- `blacklistValidator(address _validator, bool _status) external onlyOwner`
+- `cancelJob(uint256 _jobId) external whenSettlementNotPaused nonReentrant`
+- `createJob(string memory _jobSpecURI, uint256 _payout, uint256 _duration, string memory _details) external whenNotPaused whenSettlementNotPaused nonReentrant`
+- `delistJob(uint256 _jobId) external onlyOwner whenSettlementNotPaused nonReentrant`
+- `disableAGIType(address nftAddress) external onlyOwner`
+- `disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenSettlementNotPaused nonReentrant`
+- `disputeJob(uint256 _jobId) external whenSettlementNotPaused nonReentrant`
+- `expireJob(uint256 _jobId) external whenSettlementNotPaused nonReentrant`
+- `finalizeJob(uint256 _jobId) external whenSettlementNotPaused nonReentrant`
+- `getHighestPayoutPercentage(address agent) public view returns (uint256)`
+- `getJobCompletionURI(uint256 jobId) external view returns (string memory)`
+- `getJobCore(uint256 jobId) external view returns ( address employer, address assignedAgent, uint256 payout, uint256 duration, uint256 assignedAt, bool completed, bool disputed, bool expired, uint8 agentPayoutPct )`
+- `getJobSpecURI(uint256 jobId) external view returns (string memory)`
+- `getJobValidation(uint256 jobId) external view returns ( bool completionRequested, uint256 validatorApprovals, uint256 validatorDisapprovals, uint256 completionRequestedAt, uint256 disputedAt )`
+- `lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable`
+- `lockJobENS(uint256 jobId, bool burnFuses) external`
+- `ownerOf(uint256 id) external view returns (address)`
+- `pause() external onlyOwner`
+- `removeAdditionalAgent(address agent) external onlyOwner`
+- `removeAdditionalValidator(address validator) external onlyOwner`
+- `removeModerator(address _moderator) external onlyOwner`
+- `requestJobCompletion(uint256 _jobId, string calldata _jobCompletionURI) external whenSettlementNotPaused nonReentrant`
+- `rescueERC20(address token, address to, uint256 amount) external onlyOwner nonReentrant`
+- `rescueETH(uint256 amount) external onlyOwner nonReentrant`
+- `rescueToken(address token, bytes calldata data) external onlyOwner nonReentrant`
+- `resolveDisputeWithCode( uint256 _jobId, uint8 resolutionCode, string calldata reason ) external onlyModerator whenSettlementNotPaused nonReentrant`
+- `resolveStaleDispute(uint256 _jobId, bool employerWins) external onlyOwner whenSettlementNotPaused nonReentrant`
+- `resolver(bytes32 node) external view returns (address)`
+- `safeMintCompletionNFT(address to, uint256 tokenId) external`
+- `setAgentBond(uint256 bond) external onlyOwner`
+- `setAgentBondParams(uint256 bps, uint256 min, uint256 max) external onlyOwner`
+- `setBaseIpfsUrl(string calldata _url) external onlyOwner`
+- `setChallengePeriodAfterApproval(uint256 period) external onlyOwner`
+- `setCompletionReviewPeriod(uint256 _period) external onlyOwner`
+- `setDisputeReviewPeriod(uint256 _period) external onlyOwner`
+- `setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable`
+- `setJobDurationLimit(uint256 _limit) external onlyOwner`
+- `setMaxJobPayout(uint256 _maxPayout) external onlyOwner`
+- `setPremiumReputationThreshold(uint256 _threshold) external onlyOwner`
+- `setRequiredValidatorApprovals(uint256 _approvals) external onlyOwner`
+- `setRequiredValidatorDisapprovals(uint256 _disapprovals) external onlyOwner`
+- `setSettlementPaused(bool paused) external onlyOwner`
+- `setUseEnsJobTokenURI(bool enabled) external onlyOwner`
+- `setValidationRewardPercentage(uint256 _percentage) external onlyOwner`
+- `setValidatorBondParams(uint256 bps, uint256 min, uint256 max) external onlyOwner`
+- `setValidatorSlashBps(uint256 bps) external onlyOwner`
+- `setVoteQuorum(uint256 _quorum) external onlyOwner`
+- `tokenURI(uint256 tokenId) public view override returns (string memory)`
+- `unpause() external onlyOwner`
+- `updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable`
+- `updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable`
+- `updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot) external onlyOwner`
+- `updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable`
+- `updateRootNodes( bytes32 _clubRootNode, bytes32 _agentRootNode, bytes32 _alphaClubRootNode, bytes32 _alphaAgentRootNode ) external onlyOwner whenIdentityConfigurable`
+- `validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof) external whenSettlementNotPaused nonReentrant`
+- `withdrawAGI(uint256 amount) external onlyOwner whenSettlementNotPaused whenPaused nonReentrant`
+- `withdrawableAGI() public view returns (uint256)`
+
+## Public state variables (operator-relevant)
+
+- `additionalAgents`
+- `additionalValidators`
+- `agentBond = 1e18`
+- `agentBondBps = 500`
+- `agentBondMax = 88888888e18`
+- `agentMerkleRoot`
+- `agentRootNode`
+- `agiToken`
+- `alphaAgentRootNode`
+- `alphaClubRootNode`
+- `blacklistedAgents`
+- `blacklistedValidators`
+- `challengePeriodAfterApproval = 1 days`
+- `clubRootNode`
+- `completionReviewPeriod = 7 days`
+- `constant MAX_AGI_TYPES = 32`
+- `constant MAX_VALIDATORS_PER_JOB = 50`
+- `disputeReviewPeriod = 14 days`
+- `ensJobPages`
+- `jobDurationLimit = 10000000`
+- `lockIdentityConfig`
+- `lockedAgentBonds`
+- `lockedDisputeBonds`
+- `lockedEscrow`
+- `lockedValidatorBonds`
+- `maxJobPayout = 88888888e18`
+- `moderators`
+- `nextJobId`
+- `nextTokenId`
+- `premiumReputationThreshold = 10000`
+- `reputation`
+- `requiredValidatorApprovals = 3`
+- `requiredValidatorDisapprovals = 3`
+- `settlementPaused`
+- `validationRewardPercentage = 8`
+- `validatorBondBps = 1500`
+- `validatorBondMax = 88888888e18`
+- `validatorBondMin = 10e18`
+- `validatorMerkleRoot`
+- `validatorSlashBps = 8000`
+- `voteQuorum = 3`
+
+## Events index
+
+- `AGITokenAddressUpdated(address indexed oldToken, address indexed newToken)`
+- `AGITypeUpdated(address indexed nftAddress, uint256 indexed payoutPercentage)`
+- `AGIWithdrawn(address indexed to, uint256 indexed amount, uint256 remainingWithdrawable)`
+- `AgentBlacklisted(address indexed agent, bool indexed status)`
+- `AgentBondMinUpdated(uint256 indexed oldMin, uint256 indexed newMin)`
+- `AgentBondParamsUpdated( uint256 indexed oldBps, uint256 indexed oldMin, uint256 indexed oldMax, uint256 newBps, uint256 newMin, uint256 newMax )`
+- `ChallengePeriodAfterApprovalUpdated(uint256 indexed oldPeriod, uint256 indexed newPeriod)`
+- `CompletionReviewPeriodUpdated(uint256 indexed oldPeriod, uint256 indexed newPeriod)`
+- `DisputeResolvedWithCode( uint256 indexed jobId, address indexed resolver, uint8 indexed resolutionCode, string reason )`
+- `DisputeReviewPeriodUpdated(uint256 indexed oldPeriod, uint256 indexed newPeriod)`
+- `EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success)`
+- `EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages)`
+- `EnsRegistryUpdated(address newEnsRegistry)`
+- `IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp)`
+- `JobApplied(uint256 indexed jobId, address indexed agent)`
+- `JobCancelled(uint256 indexed jobId)`
+- `JobCompleted(uint256 indexed jobId, address indexed agent, uint256 indexed reputationPoints)`
+- `JobCompletionRequested(uint256 indexed jobId, address indexed agent, string jobCompletionURI)`
+- `JobCreated( uint256 indexed jobId, string jobSpecURI, uint256 indexed payout, uint256 indexed duration, string details )`
+- `JobDisapproved(uint256 indexed jobId, address indexed validator)`
+- `JobDisputed(uint256 indexed jobId, address indexed disputant)`
+- `JobExpired(uint256 indexed jobId, address indexed employer, address agent, uint256 indexed payout)`
+- `JobValidated(uint256 indexed jobId, address indexed validator)`
+- `MerkleRootsUpdated(bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot)`
+- `NFTIssued(uint256 indexed tokenId, address indexed employer, string tokenURI)`
+- `NameWrapperUpdated(address newNameWrapper)`
+- `PlatformRevenueAccrued(uint256 indexed jobId, uint256 indexed amount)`
+- `ReputationUpdated(address user, uint256 newReputation)`
+- `RequiredValidatorApprovalsUpdated(uint256 indexed oldApprovals, uint256 indexed newApprovals)`
+- `RequiredValidatorDisapprovalsUpdated(uint256 indexed oldDisapprovals, uint256 indexed newDisapprovals)`
+- `RootNodesUpdated( bytes32 indexed clubRootNode, bytes32 indexed agentRootNode, bytes32 indexed alphaClubRootNode, bytes32 alphaAgentRootNode )`
+- `SettlementPauseSet(address indexed setter, bool indexed paused)`
+- `ValidationRewardPercentageUpdated(uint256 indexed oldPercentage, uint256 indexed newPercentage)`
+- `ValidatorBlacklisted(address indexed validator, bool indexed status)`
+- `ValidatorBondParamsUpdated(uint256 indexed bps, uint256 indexed min, uint256 indexed max)`
+- `ValidatorSlashBpsUpdated(uint256 indexed oldBps, uint256 indexed newBps)`
+- `VoteQuorumUpdated(uint256 indexed oldQuorum, uint256 indexed newQuorum)`
+
+## Errors index
+
+- `Blacklisted()`
+- `ConfigLocked()`
+- `IneligibleAgentPayout()`
+- `InsolventEscrowBalance()`
+- `InsufficientWithdrawableBalance()`
+- `InvalidParameters()`
+- `InvalidState()`
+- `InvalidValidatorThresholds()`
+- `JobNotFound()`
+- `NotAuthorized()`
+- `NotModerator()`
+- `SettlementPaused()`
+- `TransferFailed()`
+- `ValidatorLimitReached()`
+
+## Notes on best-effort integrations
+
+- ENS ownership checks, ENSJobPages hooks, and `tokenURI` enrichment are best-effort integrations.
+- Escrow safety and settlement correctness must not depend on hook success.

--- a/docs/REFERENCE/EVENTS_AND_ERRORS.md
+++ b/docs/REFERENCE/EVENTS_AND_ERRORS.md
@@ -1,0 +1,5 @@
+# Events and Errors
+
+This repository uses generated canonical indexes in [CONTRACT_INTERFACE.md](./CONTRACT_INTERFACE.md).
+
+For operator troubleshooting mappings, see [../OPERATIONS/MONITORING.md](../OPERATIONS/MONITORING.md) and [../TROUBLESHOOTING.md](../TROUBLESHOOTING.md).

--- a/docs/REFERENCE/VERSIONS.md
+++ b/docs/REFERENCE/VERSIONS.md
@@ -1,0 +1,33 @@
+# Versions & Toolchain Snapshot
+
+Verified against repository state: `79d6495`.
+
+Generated at: `2026-02-13T14:45:51-05:00`.
+
+## Toolchain snapshot
+
+| Component | Version | Source |
+| --- | --- | --- |
+| node | 20.19.6 | runtime |
+| npm | 11.4.2 | package manager |
+| truffle | ^5.11.5 | framework |
+| solc | 0.8.23 | compiler |
+| solc optimizer runs | 50 | compiler setting |
+| solc viaIR | false | compiler setting |
+| @openzeppelin/contracts | 4.9.6 | contracts library |
+| package-lock lockfileVersion | 3 | dependency determinism |
+
+## Key dependencies
+
+| Package | Version |
+| --- | --- |
+| ganache | ^7.9.2 |
+| @truffle/hdwallet-provider | ^2.1.15 |
+| solhint | ^5.0.3 |
+| @playwright/test | ^1.49.1 |
+
+## Source files used
+
+- `package.json`
+- `package-lock.json`
+- `truffle-config.js`

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,0 +1,53 @@
+# Repository Map (Generated)
+
+Verified against repository state: `79d6495`.
+
+Generated at: `2026-02-13T14:45:51-05:00`.
+
+## Curated map
+
+| Folder/File | Purpose | Key entrypoint | Notes |
+| --- | --- | --- | --- |
+| `contracts/` | Solidity contracts and interfaces | `contracts/AGIJobManager.sol` | Primary escrow and settlement contract |
+| `contracts/ens/` | ENS and NameWrapper interfaces + ENSJobPages helper | `contracts/ens/ENSJobPages.sol` | Best-effort metadata/hook integration |
+| `contracts/test/` | Mock contracts for adversarial and integration tests | `contracts/test/MockENSJobPages.sol` | Test-only fixtures |
+| `test/` | Truffle/JS test suites | `test/jobLifecycle.core.test.js` | Lifecycle, invariants, and hardening coverage |
+| `migrations/` | Truffle deployment scripts | `migrations/2_deploy_contracts.js` | Network-aware deploy entrypoint |
+| `scripts/ops/` | Operational parameter validation scripts | `scripts/ops/validate-params.js` | Safety checks for deploy-time config |
+| `scripts/merkle/` | Merkle tree proof generation and smoke tests | `scripts/merkle/generate_merkle_proof.js` | Allowlist operations |
+| `scripts/ui/` | UI smoke and ABI sync tooling | `scripts/ui/run_ui_smoke_test.js` | Frontend contract compatibility |
+| `scripts/docs/` | Deterministic docs generators and checks | `scripts/docs/check-docs.mjs` | Freshness and structural enforcement |
+| `docs/` | Repository documentation source | `docs/README.md` | Institutional docs and references |
+| `.github/workflows/` | CI workflows | `.github/workflows/ci.yml` | Build, tests, docs, and policy checks |
+| `ui/` | Web user interface project | `ui/package.json` | Separate build and tests |
+| `truffle-config.js` | Compiler and network configuration | `truffle-config.js` | Pinned solc + network wiring |
+| `package.json` | Node scripts and dependencies | `package.json` | Canonical script entrypoints |
+
+## Top-level entries
+
+- `.github`
+- `CODE_OF_CONDUCT.md`
+- `CONTRIBUTING.md`
+- `LICENSE`
+- `MAINNET_DEPLOYMENT_CHECKLIST.md`
+- `README.md`
+- `SECURITY.md`
+- `SECURITY_TESTING.md`
+- `build`
+- `contracts`
+- `docs`
+- `forge-test`
+- `foundry.toml`
+- `integrations`
+- `lib`
+- `migrations`
+- `node_modules`
+- `package-lock.json`
+- `package.json`
+- `presentations`
+- `scripts`
+- `slither.config.json`
+- `test`
+- `truffle-config.js`
+- `ui`
+- `ui-tests`

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,104 +1,14 @@
-# Testing Guide
+# Testing
 
-This repository uses **Truffle + Mocha** against the local in-memory `test` Ganache provider configured in `truffle-config.js`.
+## Test matrix
 
-## CI-parity command order
+| Suite | Purpose | Command | Validates |
+| --- | --- | --- | --- |
+| Truffle + JS integration | Lifecycle and escrow behavior | `npm run test` | Core correctness and regression coverage |
+| Bytecode checks | Deployment feasibility | `npm run size` | EIP-170 runtime size policy |
+| UI smoke | ABI/UI contract alignment | `npm run test:ui` | Frontend basic flows |
+| Docs checks | Documentation freshness and policy | `npm run docs:check` | required files/diagrams/links/generation freshness |
 
-Mirror `.github/workflows/ci.yml` locally:
+## Optional hardening tools
 
-```bash
-npm install
-npm run lint
-npm run build
-npm run size
-npm test
-npm run test:ui
-```
-
-## Baseline at repository HEAD (inventory run)
-
-Executed in this exact order on a clean checkout:
-
-1. `npm install`
-2. `npm run lint`
-3. `npm run build`
-4. `npm run size`
-5. `npm run test`
-
-Observed baseline:
-
-- `npm run size`: `AGIJobManager runtime bytecode size: 24574 bytes` (within EIP-170 cap, near the limit).
-- `npm run test`: `264 passing` on local Ganache `test` network.
-
-> Note: CI also runs `npm run test:ui` after contract tests.
-
-## Canonical scripts (`package.json`)
-
-| Script | Command | Purpose |
-| --- | --- | --- |
-| `npm run build` | `truffle compile` | Compile all contracts with pinned solc settings. |
-| `npm run size` | `node scripts/check-bytecode-size.js` | EIP-170 runtime-size guard. |
-| `npm run lint` | `solhint "contracts/**/*.sol"` | Solidity lint policy. |
-| `npm test` | `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js` | Full contract test + artifact sanity. |
-| `npm run test:ui` | `node scripts/ui/run_ui_smoke_test.js` | UI smoke checks. |
-
-## Test strategy
-
-### Layers
-
-1. **Lifecycle integration tests** (`test/AGIJobManager.*`, `test/happyPath.test.js`, `test/livenessTimeouts.test.js`, `test/escrowAccounting.test.js`)
-   - Operator-run job lifecycle, payout/escrow transitions, dispute/timeout liveness.
-2. **Security/economic regression tests** (`test/securityRegression.test.js`, `test/disputeHardening.test.js`, `test/invariants.solvency.test.js`, `test/completionSettlementInvariant.test.js`)
-   - Solvency, no-double-release, race prevention, dispute and pause behavior.
-3. **ENS integration tests** (`test/ensJobPagesHooks.test.js`, `test/ensJobPagesHelper.test.js`, `test/namespaceAlpha.test.js`)
-   - ENS hooks are best-effort and must not brick core settlement.
-4. **Utility-library tests** (`test/invariants.libs.test.js`, `test/utils.uri-transfer.test.js`)
-   - Bond/reputation arithmetic, ENS ownership checks, URI validation, transfer wrappers.
-
-## Determinism runbook
-
-- Always run tests on `--network test`.
-- Use explicit EVM time helpers (`time.increase`, `time.advanceBlock`) in timeout/dispute tests.
-- Use `BN` math (`web3.utils.toBN`) for token arithmetic.
-- Keep tests offline: no public RPC endpoints and no secrets.
-
-## Running focused tests
-
-Single file:
-
-```bash
-npx truffle test --network test test/utils.uri-transfer.test.js
-```
-
-Patterned execution (shell glob):
-
-```bash
-npx truffle test --network test test/*dispute*.test.js
-```
-
-## Troubleshooting
-
-| Symptom | Likely cause | Remediation |
-| --- | --- | --- |
-| `contains unresolved libraries` on `UtilsHarness` | Truffle library links not deployed in test setup | Deploy/link required libraries inside `beforeEach` before `UtilsHarness.new()`. |
-| `TransferFailed` custom-error-style reverts | Token returned `false`, reverted, or under-delivered transfer amount | Validate approvals/balances; for fee-on-transfer tokens expect `safeTransferFromExact` to revert. |
-| Bytecode gate fails | Runtime crossed EIP-170 threshold | Run `npm run size`, inspect recent contract-size growth, avoid feature bloat in core contract. |
-| Flaky timeout tests | Missing deterministic block/time advancement | Add explicit time travel + mine step before timeout-sensitive actions. |
-
-
-## Additional deterministic suites (mainnet-grade additions)
-
-| Feature | New suite |
-| --- | --- |
-| Core lifecycle transitions / finalize branches | `test/jobLifecycle.core.test.js` |
-| Validator bonds and vote correctness | `test/validatorVoting.bonds.test.js` |
-| Moderator dispute and stale dispute owner recovery | `test/disputes.moderator.test.js` |
-| Escrow solvency pseudo-fuzz loop | `test/escrowAccounting.invariants.test.js` |
-| Pause and settlement pause access controls | `test/pausing.accessControl.test.js` |
-| AGIType safety and broken ERC721 isolation | `test/agiTypes.safety.test.js` |
-| ENS hook best-effort integration | `test/ensHooks.integration.test.js` |
-| Identity config locking lifecycle | `test/identityConfig.locking.test.js` |
-
-## Known offline-test limitation
-
-- ENS tokenURI malformed-return handling is constrained by the current production implementation: empty ENS tokenURI responses are covered and correctly fall back, but malformed ABI payload simulation is documented as an operational caveat because the decode path is inside production minting logic and the runtime bytecode budget is already near the EIP-170 ceiling.
+If desired, teams may run additional tools (e.g., Slither, Echidna, Foundry invariants) externally; this repo does not force heavy security-tool dependencies in default CI.

--- a/docs/TROUBLESHOOTING.md
+++ b/docs/TROUBLESHOOTING.md
@@ -1,51 +1,9 @@
 # Troubleshooting
 
-## Common operational issues
-
-| Symptom | Typical cause | Fix |
-|---|---|---|
-| `createJob` reverts | payout/duration exceeds limits or bad URI or token transfer failure | Verify `maxJobPayout`, `jobDurationLimit`, URI format, allowance/balance |
-| `applyForJob` reverts | agent unauthorized/blacklisted/no payout tier/max active jobs hit | Verify ENS/Merkle/additional lists, blacklist flags, AGI type eligibility |
-| `validateJob`/`disapproveJob` reverts | completion not requested, vote window closed, duplicate vote, unauthorized validator | Check `completionRequestedAt`, review period, prior vote flags, gating proofs |
-| `finalizeJob` reverts | called before challenge/review window or while disputed | Re-evaluate timing and dispute status |
-| `withdrawAGI` reverts | not paused, settlement paused, amount > withdrawable, insolvency | pause contract, ensure settlement not paused, re-check locked totals |
-| ENS hooks failing | ENSJobPages misconfigured or reverts | check `EnsHookAttempted` events and ENSJobPages configuration |
-
-## Runbook snippets
-
-### Pause / unpause
-1. Owner calls `pause()` for emergency stop.
-2. Investigate and resolve issue.
-3. Owner calls `unpause()` when safe.
-
-### Settlement pause toggle
-- Use `setSettlementPaused(true)` to freeze settlement-sensitive operations independently.
-- Restore with `setSettlementPaused(false)` after remediation.
-
-### Dispute intervention
-- Moderator uses `resolveDisputeWithCode(jobId, 1|2, reason)`.
-- If stale beyond dispute window, owner can use `resolveStaleDispute(jobId, employerWins)`.
-
-### Blacklist action
-- `blacklistAgent(address, bool)` or `blacklistValidator(address, bool)` by owner.
-- Document reason and expiration policy off-chain.
-
-## Custom errors map
-
-| Error | Meaning | Typical remediation |
-|---|---|---|
-| `NotModerator` | caller not in moderator set | add moderator or use correct account |
-| `NotAuthorized` | caller failed role/ownership check | verify role, ENS/Merkle proof, and caller identity |
-| `Blacklisted` | address currently blacklisted | remove from blacklist if appropriate |
-| `InvalidParameters` | invalid input/parameter combination | validate bounds and non-empty/valid URI constraints |
-| `InvalidState` | call not valid in current job/contract state | inspect job flags and required transitions |
-| `JobNotFound` | nonexistent job ID | query existing job range (`nextJobId`) |
-| `TransferFailed` | ERC20 transfer or transferFrom failed | verify token behavior, approvals, and balances |
-| `ValidatorLimitReached` | max validators per job exceeded | avoid extra validator vote attempts |
-| `InvalidValidatorThresholds` | approvals/disapprovals config invalid | adjust thresholds within `MAX_VALIDATORS_PER_JOB` |
-| `IneligibleAgentPayout` | agent has no positive AGI payout tier | add/enable AGI type holdings with non-zero payout tier |
-| `InsufficientWithdrawableBalance` | withdraw exceeds treasury surplus | reduce withdrawal amount or settle obligations |
-| `InsolventEscrowBalance` | token balance below locked totals | investigate token outflow anomaly immediately |
-| `ConfigLocked` | identity config locked | cannot update identity wiring after lock |
-| `SettlementPaused` | settlement pause guard active | unset settlement pause for those functions |
-| `DeprecatedParameter` | legacy setter disabled | do not use deprecated parameter path |
+| Symptom | Likely cause | Remedy |
+| --- | --- | --- |
+| `InvalidState` revert on lifecycle action | Function called out of lifecycle order | Verify job state via read getters before action |
+| `NotAuthorized` / role failures | ENS/Merkle/additional allowlist mismatch | Re-check proofs, root nodes, and additional allowlists |
+| Unable to finalize | Challenge window not elapsed or settlement paused | Wait required period or clear pause condition |
+| Treasury withdrawal blocked | `withdrawableAGI()` insufficient or contract not paused | Reconcile locked balances and pause before withdrawal |
+| Docs check fails as stale | Generated reference files not committed | Run `npm run docs:gen` and commit generated updates |

--- a/docs/assets/architecture-wireframe.svg
+++ b/docs/assets/architecture-wireframe.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1000" height="560" viewBox="0 0 1000 560">
+  <rect width="1000" height="560" fill="#14001F"/>
+  <text x="30" y="38" fill="#E9DAFF" font-family="Arial" font-size="24">AGIJobManager Architecture Wireframe</text>
+  <g stroke="#7A3FF2" stroke-width="2" fill="#1B0B2A" font-family="Arial" font-size="14" >
+    <rect x="40" y="90" width="220" height="80" rx="8"/><text x="56" y="130" fill="#E9DAFF">Owner / Moderator</text>
+    <rect x="40" y="220" width="220" height="80" rx="8"/><text x="56" y="260" fill="#E9DAFF">Employer / Agent / Validator</text>
+    <rect x="360" y="150" width="280" height="120" rx="10" fill="#4B1D86"/><text x="390" y="220" fill="#E9DAFF">AGIJobManager Contract</text>
+    <rect x="740" y="90" width="220" height="80" rx="8"/><text x="770" y="130" fill="#E9DAFF">AGI ERC20</text>
+    <rect x="740" y="220" width="220" height="80" rx="8"/><text x="780" y="260" fill="#E9DAFF">ENS / NameWrapper</text>
+    <rect x="740" y="350" width="220" height="80" rx="8"/><text x="776" y="390" fill="#E9DAFF">ENSJobPages (optional)</text>
+    <rect x="360" y="360" width="280" height="80" rx="10"/><text x="392" y="404" fill="#E9DAFF">Off-chain Monitoring/Indexers</text>
+  </g>
+  <g stroke="#A7A7B6" stroke-width="2" fill="none" marker-end="url(#arrow)">
+    <line x1="260" y1="130" x2="360" y2="190"/>
+    <line x1="260" y1="260" x2="360" y2="220"/>
+    <line x1="640" y1="205" x2="740" y2="130"/>
+    <line x1="640" y1="220" x2="740" y2="260"/>
+    <line x1="640" y1="235" x2="740" y2="390"/>
+    <line x1="500" y1="270" x2="500" y2="360"/>
+  </g>
+  <defs>
+    <marker id="arrow" markerWidth="8" markerHeight="8" refX="7" refY="4" orient="auto">
+      <path d="M0,0 L8,4 L0,8 z" fill="#A7A7B6"/>
+    </marker>
+  </defs>
+</svg>

--- a/docs/assets/palette.svg
+++ b/docs/assets/palette.svg
@@ -1,0 +1,16 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="980" height="280" viewBox="0 0 980 280">
+  <rect width="980" height="280" fill="#14001F"/>
+  <text x="20" y="30" fill="#E9DAFF" font-family="Arial" font-size="22">ASI Superintelligence Sovereign Purple Palette</text>
+  <g font-family="Arial" font-size="14" fill="#E7E7EA">
+    <rect x="20" y="50" width="140" height="60" fill="#14001F"/><text x="20" y="130">ASI Deep #14001F</text>
+    <rect x="180" y="50" width="140" height="60" fill="#1B0B2A"/><text x="180" y="130">Sovereign Ink #1B0B2A</text>
+    <rect x="340" y="50" width="140" height="60" fill="#4B1D86"/><text x="340" y="130">Imperial Purple #4B1D86</text>
+    <rect x="500" y="50" width="140" height="60" fill="#7A3FF2"/><text x="500" y="130">Amethyst #7A3FF2</text>
+    <rect x="660" y="50" width="140" height="60" fill="#E9DAFF"/><text x="660" y="130">Orchid Mist #E9DAFF</text>
+    <rect x="820" y="50" width="140" height="60" fill="#A7A7B6"/><text x="820" y="130">Slate #A7A7B6</text>
+    <rect x="20" y="170" width="140" height="60" fill="#1FAD7A"/><text x="20" y="250">Success #1FAD7A</text>
+    <rect x="180" y="170" width="140" height="60" fill="#D4A017"/><text x="180" y="250">Warning #D4A017</text>
+    <rect x="340" y="170" width="140" height="60" fill="#E24A5A"/><text x="340" y="250">Danger #E24A5A</text>
+    <rect x="500" y="170" width="140" height="60" fill="#E7E7EA"/><text x="500" y="250">Platinum #E7E7EA</text>
+  </g>
+</svg>

--- a/package.json
+++ b/package.json
@@ -6,13 +6,15 @@
   "scripts": {
     "build": "truffle compile",
     "size": "node scripts/check-bytecode-size.js",
-    "check:no-binaries": "npm --prefix ui run check:no-binaries",
+    "check:no-binaries": "node scripts/check-no-binaries.mjs",
     "docs:interface": "node scripts/generate-interface-doc.js",
     "lint": "solhint \"contracts/**/*.sol\"",
     "test": "truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js",
     "test:ui": "node scripts/ui/run_ui_smoke_test.js",
     "ui:abi": "node scripts/ui/export_abi.js",
-    "ui:abi:check": "node scripts/ui/check_ui_abi.js"
+    "ui:abi:check": "node scripts/ui/check_ui_abi.js",
+    "docs:gen": "node scripts/docs/gen-docs.mjs",
+    "docs:check": "node scripts/docs/check-docs.mjs"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.9.6"

--- a/scripts/check-no-binaries.mjs
+++ b/scripts/check-no-binaries.mjs
@@ -1,0 +1,34 @@
+import fs from 'fs';
+import { execSync } from 'child_process';
+
+const forbiddenExt = new Set(['.png','.jpg','.jpeg','.gif','.webp','.pdf','.ico','.woff','.woff2','.ttf','.otf','.zip','.tar','.gz','.7z']);
+
+const base = process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'HEAD~1';
+let files = [];
+try {
+  files = execSync(`git diff --name-only --diff-filter=A ${base}...HEAD`).toString().trim().split('\n').filter(Boolean);
+} catch {
+  files = execSync('git diff --name-only --diff-filter=A HEAD').toString().trim().split('\n').filter(Boolean);
+}
+
+const violations = [];
+for (const file of files) {
+  const lower = file.toLowerCase();
+  const ext = lower.slice(lower.lastIndexOf('.'));
+  if (forbiddenExt.has(ext)) {
+    violations.push(`${file}: forbidden extension ${ext}`);
+    continue;
+  }
+  if (!fs.existsSync(file)) continue;
+  const buf = fs.readFileSync(file);
+  if (buf.includes(0)) violations.push(`${file}: appears binary (contains NUL byte)`);
+}
+
+if (violations.length) {
+  console.error('Binary policy violation(s) detected:');
+  for (const v of violations) console.error(` - ${v}`);
+  console.error('Remove the file(s) or convert assets to Markdown/Mermaid/SVG text formats.');
+  process.exit(1);
+}
+
+console.log('No forbidden/binary files detected in newly added files.');

--- a/scripts/docs/check-docs.mjs
+++ b/scripts/docs/check-docs.mjs
@@ -1,0 +1,67 @@
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const root = process.cwd();
+const requiredFiles = [
+  'docs/README.md','docs/OVERVIEW.md','docs/REPO_MAP.md','docs/QUICKSTART.md','docs/QUINTESSENTIAL_USE_CASE.md','docs/ARCHITECTURE.md',
+  'docs/CONTRACTS/AGIJobManager.md','docs/CONTRACTS/INTEGRATIONS.md',
+  'docs/OPERATIONS/RUNBOOK.md','docs/OPERATIONS/INCIDENT_RESPONSE.md','docs/OPERATIONS/MONITORING.md',
+  'docs/SECURITY_MODEL.md','docs/TESTING.md','docs/TROUBLESHOOTING.md','docs/GLOSSARY.md',
+  'docs/REFERENCE/VERSIONS.md','docs/REFERENCE/CONTRACT_INTERFACE.md','docs/assets/palette.svg','docs/assets/architecture-wireframe.svg'
+];
+
+for (const f of requiredFiles) {
+  if (!fs.existsSync(path.join(root, f))) throw new Error(`Missing required doc file: ${f}`);
+}
+
+const mermaidChecks = [
+  ['docs/ARCHITECTURE.md', /```mermaid[\s\S]*flowchart/i],
+  ['docs/CONTRACTS/AGIJobManager.md', /```mermaid[\s\S]*stateDiagram-v2/i],
+  ['docs/CONTRACTS/AGIJobManager.md', /```mermaid[\s\S]*sequenceDiagram/i],
+  ['docs/OPERATIONS/INCIDENT_RESPONSE.md', /```mermaid[\s\S]*flowchart/i],
+  ['docs/QUINTESSENTIAL_USE_CASE.md', /```mermaid[\s\S]*sequenceDiagram/i],
+  ['docs/QUINTESSENTIAL_USE_CASE.md', /```mermaid[\s\S]*stateDiagram-v2/i],
+];
+for (const [file, regex] of mermaidChecks) {
+  const c = fs.readFileSync(path.join(root, file), 'utf8');
+  if (!regex.test(c)) throw new Error(`Missing required Mermaid block in ${file}`);
+}
+
+for (const svg of ['docs/assets/palette.svg', 'docs/assets/architecture-wireframe.svg']) {
+  const c = fs.readFileSync(path.join(root, svg), 'utf8');
+  if (!c.trim().startsWith('<svg') && !c.includes('<svg')) throw new Error(`${svg} is not valid SVG/XML`);
+}
+
+const tmp = fs.mkdtempSync(path.join(os.tmpdir(), 'docs-check-'));
+const generated = ['docs/REFERENCE/VERSIONS.md','docs/REFERENCE/CONTRACT_INTERFACE.md','docs/REPO_MAP.md'];
+const backups = new Map();
+for (const f of generated) {
+  const abs = path.join(root, f);
+  const bak = path.join(tmp, path.basename(f));
+  backups.set(f, bak);
+  fs.copyFileSync(abs, bak);
+}
+execSync('node scripts/docs/gen-docs.mjs', { stdio: 'inherit' });
+for (const f of generated) {
+  const abs = path.join(root, f);
+  const old = fs.readFileSync(backups.get(f), 'utf8');
+  const now = fs.readFileSync(abs, 'utf8');
+  if (old !== now) throw new Error(`Generated docs stale: ${f}. Run npm run docs:gen and commit changes.`);
+}
+
+const mdFiles = execSync("rg --files docs -g '*.md'").toString().trim().split('\n').filter(Boolean);
+for (const file of mdFiles) {
+  const text = fs.readFileSync(path.join(root, file), 'utf8');
+  const links = Array.from(text.matchAll(/\[[^\]]+\]\(([^)]+)\)/g)).map((m) => m[1]);
+  for (const link of links) {
+    if (/^(https?:|mailto:|#)/.test(link)) continue;
+    const normalized = link.split('#')[0];
+    if (!normalized) continue;
+    const target = path.resolve(path.dirname(path.join(root, file)), normalized);
+    if (!fs.existsSync(target)) throw new Error(`Broken relative link in ${file}: ${link}`);
+  }
+}
+
+console.log('docs:check passed');

--- a/scripts/docs/gen-docs.mjs
+++ b/scripts/docs/gen-docs.mjs
@@ -1,0 +1,12 @@
+import { execSync } from 'child_process';
+
+const commands = [
+  'node scripts/docs/generate-versions.mjs',
+  'node scripts/docs/generate-contract-interface.mjs',
+  'node scripts/docs/generate-repo-map.mjs',
+];
+
+for (const cmd of commands) {
+  console.log(`> ${cmd}`);
+  execSync(cmd, { stdio: 'inherit' });
+}

--- a/scripts/docs/generate-contract-interface.mjs
+++ b/scripts/docs/generate-contract-interface.mjs
@@ -1,0 +1,56 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const root = process.cwd();
+const sourcePath = path.join(root, 'contracts/AGIJobManager.sol');
+const outPath = path.join(root, 'docs/REFERENCE/CONTRACT_INTERFACE.md');
+const source = fs.readFileSync(sourcePath, 'utf8');
+const shortSha = execSync('git rev-parse --short HEAD').toString().trim();
+const generatedAt = execSync('git show -s --format=%cI HEAD').toString().trim();
+
+const clean = (s) => s.replace(/\s+/g, ' ').trim();
+const getMatches = (re) => Array.from(source.matchAll(re)).map((m) => m[1]);
+
+const errors = getMatches(/^\s*error\s+([^;]+);/gm).map(clean).sort();
+const events = getMatches(/^\s*event\s+([^;]+);/gm).map(clean).sort();
+const funcs = getMatches(/^\s*function\s+([^;{]+)(?:\{|;)/gm)
+  .map(clean)
+  .filter((x) => /\b(external|public)\b/.test(x))
+  .sort();
+const publicVars = getMatches(/^\s*(?:IERC20|address|bool|bytes32|uint\d*|string|mapping\([^\)]*\))\s+public\s+([^;]+);/gm)
+  .map(clean)
+  .sort();
+
+const bullets = (arr) => (arr.length ? arr.map((x) => `- \`${x}\``).join('\n') : '- _None detected_');
+
+const content = `# AGIJobManager Contract Interface (Generated)
+
+Verified against repository state: \`${shortSha}\`.
+
+Generated at: \`${generatedAt}\`.
+
+## Operator-facing interface
+
+${bullets(funcs)}
+
+## Public state variables (operator-relevant)
+
+${bullets(publicVars)}
+
+## Events index
+
+${bullets(events)}
+
+## Errors index
+
+${bullets(errors)}
+
+## Notes on best-effort integrations
+
+- ENS ownership checks, ENSJobPages hooks, and \`tokenURI\` enrichment are best-effort integrations.
+- Escrow safety and settlement correctness must not depend on hook success.
+`;
+
+fs.writeFileSync(outPath, content);
+console.log(`Wrote ${path.relative(root, outPath)}`);

--- a/scripts/docs/generate-repo-map.mjs
+++ b/scripts/docs/generate-repo-map.mjs
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const root = process.cwd();
+const outPath = path.join(root, 'docs/REPO_MAP.md');
+const shortSha = execSync('git rev-parse --short HEAD').toString().trim();
+const generatedAt = execSync('git show -s --format=%cI HEAD').toString().trim();
+
+const curated = [
+  ['contracts/', 'Solidity contracts and interfaces', 'contracts/AGIJobManager.sol', 'Primary escrow and settlement contract'],
+  ['contracts/ens/', 'ENS and NameWrapper interfaces + ENSJobPages helper', 'contracts/ens/ENSJobPages.sol', 'Best-effort metadata/hook integration'],
+  ['contracts/test/', 'Mock contracts for adversarial and integration tests', 'contracts/test/MockENSJobPages.sol', 'Test-only fixtures'],
+  ['test/', 'Truffle/JS test suites', 'test/jobLifecycle.core.test.js', 'Lifecycle, invariants, and hardening coverage'],
+  ['migrations/', 'Truffle deployment scripts', 'migrations/2_deploy_contracts.js', 'Network-aware deploy entrypoint'],
+  ['scripts/ops/', 'Operational parameter validation scripts', 'scripts/ops/validate-params.js', 'Safety checks for deploy-time config'],
+  ['scripts/merkle/', 'Merkle tree proof generation and smoke tests', 'scripts/merkle/generate_merkle_proof.js', 'Allowlist operations'],
+  ['scripts/ui/', 'UI smoke and ABI sync tooling', 'scripts/ui/run_ui_smoke_test.js', 'Frontend contract compatibility'],
+  ['scripts/docs/', 'Deterministic docs generators and checks', 'scripts/docs/check-docs.mjs', 'Freshness and structural enforcement'],
+  ['docs/', 'Repository documentation source', 'docs/README.md', 'Institutional docs and references'],
+  ['.github/workflows/', 'CI workflows', '.github/workflows/ci.yml', 'Build, tests, docs, and policy checks'],
+  ['ui/', 'Web user interface project', 'ui/package.json', 'Separate build and tests'],
+  ['truffle-config.js', 'Compiler and network configuration', 'truffle-config.js', 'Pinned solc + network wiring'],
+  ['package.json', 'Node scripts and dependencies', 'package.json', 'Canonical script entrypoints'],
+];
+
+const top = fs.readdirSync(root, { withFileTypes: true })
+  .filter((d) => !d.name.startsWith('.') || d.name === '.github')
+  .map((d) => d.name)
+  .sort();
+
+const content = `# Repository Map (Generated)
+
+Verified against repository state: \`${shortSha}\`.
+
+Generated at: \`${generatedAt}\`.
+
+## Curated map
+
+| Folder/File | Purpose | Key entrypoint | Notes |
+| --- | --- | --- | --- |
+${curated.map((r) => `| \`${r[0]}\` | ${r[1]} | \`${r[2]}\` | ${r[3]} |`).join('\n')}
+
+## Top-level entries
+
+${top.map((name) => `- \`${name}\``).join('\n')}
+`;
+
+fs.writeFileSync(outPath, content);
+console.log(`Wrote ${path.relative(root, outPath)}`);

--- a/scripts/docs/generate-versions.mjs
+++ b/scripts/docs/generate-versions.mjs
@@ -1,0 +1,71 @@
+import fs from 'fs';
+import path from 'path';
+import { execSync } from 'child_process';
+
+const root = process.cwd();
+const outFile = path.join(root, 'docs/REFERENCE/VERSIONS.md');
+const pkgPath = path.join(root, 'package.json');
+const lockPath = path.join(root, 'package-lock.json');
+const trufflePath = path.join(root, 'truffle-config.js');
+
+const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+const lock = JSON.parse(fs.readFileSync(lockPath, 'utf8'));
+const shortSha = execSync('git rev-parse --short HEAD').toString().trim();
+const generatedAt = execSync('git show -s --format=%cI HEAD').toString().trim();
+const nodeVersion = process.version.replace(/^v/, '');
+const npmVersion = execSync('npm --version').toString().trim();
+const truffleVersion = (pkg.devDependencies?.truffle || pkg.dependencies?.truffle || 'n/a');
+const ozVersion = (pkg.dependencies?.['@openzeppelin/contracts'] || pkg.devDependencies?.['@openzeppelin/contracts'] || 'n/a');
+const lockVersion = lock.lockfileVersion ?? 'n/a';
+
+const truffleConfig = fs.readFileSync(trufflePath, 'utf8');
+const solcVersionMatch = truffleConfig.match(/const\s+solcVersion\s*=\s*'([^']+)'/);
+const solcRunsMatch = truffleConfig.match(/const\s+solcRuns\s*=\s*(\d+)/);
+const solcViaIRMatch = truffleConfig.match(/const\s+solcViaIR\s*=\s*(true|false)/);
+
+const depRows = [
+  ['node', nodeVersion, 'runtime'],
+  ['npm', npmVersion, 'package manager'],
+  ['truffle', truffleVersion, 'framework'],
+  ['solc', solcVersionMatch?.[1] || 'n/a', 'compiler'],
+  ['solc optimizer runs', solcRunsMatch?.[1] || 'n/a', 'compiler setting'],
+  ['solc viaIR', solcViaIRMatch?.[1] || 'n/a', 'compiler setting'],
+  ['@openzeppelin/contracts', ozVersion, 'contracts library'],
+  ['package-lock lockfileVersion', String(lockVersion), 'dependency determinism'],
+];
+
+const additionalDeps = ['ganache', '@truffle/hdwallet-provider', 'solhint', '@playwright/test'];
+const depTable = additionalDeps
+  .map((name) => {
+    const v = pkg.dependencies?.[name] || pkg.devDependencies?.[name] || 'n/a';
+    return `| ${name} | ${v} |`;
+  })
+  .join('\n');
+
+const content = `# Versions & Toolchain Snapshot
+
+Verified against repository state: \`${shortSha}\`.
+
+Generated at: \`${generatedAt}\`.
+
+## Toolchain snapshot
+
+| Component | Version | Source |
+| --- | --- | --- |
+${depRows.map((r) => `| ${r[0]} | ${r[1]} | ${r[2]} |`).join('\n')}
+
+## Key dependencies
+
+| Package | Version |
+| --- | --- |
+${depTable}
+
+## Source files used
+
+- \`package.json\`
+- \`package-lock.json\`
+- \`truffle-config.js\`
+`;
+
+fs.writeFileSync(outFile, content);
+console.log(`Wrote ${path.relative(root, outFile)}`);


### PR DESCRIPTION
### Motivation

- Provide an institutional‑grade documentation surface that is operator/auditor/developer friendly and maps claims to on‑repo source of truth. 
- Make documentation continuously correct and auditable by generating reference pieces deterministically from source and enforcing freshness in CI. 
- Protect the repo from accidental binary assets and ensure diagrams are text-first (Mermaid / SVG) so docs remain reviewable and diffable.

### Description

- Added a full docs IA under `docs/` (landing, OVERVIEW, QUICKSTART, QUINTESSENTIAL_USE_CASE, ARCHITECTURE, SECURITY_MODEL, TESTING, TROUBLESHOOTING, GLOSSARY) and contract/operations subpages (`docs/CONTRACTS/*`, `docs/OPERATIONS/*`) with required Mermaid diagrams and operator runbooks. 
- Added text-only SVG assets using the Sovereign Purple palette at `docs/assets/palette.svg` and `docs/assets/architecture-wireframe.svg` and included the Mermaid `init` theme variables in diagrams for consistent rendering. 
- Implemented deterministic generators under `scripts/docs/` (`generate-versions.mjs`, `generate-contract-interface.mjs`, `generate-repo-map.mjs`, and a `gen-docs.mjs` orchestrator) to produce `docs/REFERENCE/VERSIONS.md`, `docs/REFERENCE/CONTRACT_INTERFACE.md`, and `docs/REPO_MAP.md`. 
- Implemented docs validation `scripts/docs/check-docs.mjs` that asserts required files exist, required Mermaid blocks exist, SVG validity, generated-doc freshness (regenerate-and-diff), and relative link resolution; exposed as `npm` scripts `docs:gen` and `docs:check`. 
- Implemented repository-level no-binaries guard `scripts/check-no-binaries.mjs` (forbidden extension denylist + NUL-byte heuristic) and wired it into `package.json` and a new GitHub Actions workflow `.github/workflows/docs.yml` that runs with `fetch-depth: 0` and executes `npm ci`, `check:no-binaries`, and `docs:check`. 
- Updated `package.json` scripts (`docs:gen`, `docs:check`, repo `check:no-binaries`), and added a minimal README.md update pointing to `docs/README.md` and the Quintessential Use Case (no binary embeds). 

### Testing

- Performed full repo validation locally: `npm ci` completed successfully.
- Build: `npm run build` (Truffle compile) completed successfully and wrote artifacts to `build/contracts`.
- Contract test suite: `npm run test` executed full Truffle + JS suite and reported `290 passing` tests (all passing); bytecode size checks and ABI smoke tests also passed. 
- Docs generation and freshness: `npm run docs:gen` produced generated reference files and `npm run docs:check` passed (regeneration diff check, Mermaid presence, SVG validity, and link checks). 
- No-binaries policy: `npm run check:no-binaries` passed locally and confirmed no forbidden/binary files were added; CI workflow added to enforce this on PRs. 

All automated checks listed above passed in the rollout environment. No binary files were added; the no-binaries policy is enforced by the included script and CI workflow.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698f82baefa0833398b56d9149865a25)