### PR TITLE
docs(ci): enforce institutional documentation section integrity checks

### DIFF
--- a/scripts/docs/check-docs.mjs
+++ b/scripts/docs/check-docs.mjs
@@ -110,5 +110,29 @@ for (const row of mustIncludeColumns) {
   if (!quintessential.includes(row)) fail('Quintessential use case step table is missing required columns');
 }
 
+const requiredSectionSnippets = [
+  ['README.md', ['## Documentation', 'docs/README.md', 'docs/QUINTESSENTIAL_USE_CASE.md', 'docs:gen', 'docs:check', 'check-no-binaries']],
+  ['docs/CONTRACTS/AGIJobManager.md', [
+    '| Action | Owner | Moderator | Employer | Agent | Validator | Anyone |',
+    '| Parameter | Purpose | Safe range guidance | Operational note | Where set |',
+    '## Operational invariants',
+    '## Lifecycle'
+  ]],
+  ['docs/SECURITY_MODEL.md', ['## Threat model', '| Vector | Impact | Mitigation | Residual risk | Operator responsibility |']],
+  ['docs/TESTING.md', ['## Test matrix', '| Suite | Purpose | Command | Validates |']],
+  ['docs/OPERATIONS/RUNBOOK.md', ['## Parameter change checklist']],
+  ['docs/OPERATIONS/MONITORING.md', ['## Events catalog']],
+  ['docs/OPERATIONS/INCIDENT_RESPONSE.md', ['active exploit', 'settlementPaused', 'blacklist', 'lockIdentityConfiguration']]
+];
+
+for (const [file, snippets] of requiredSectionSnippets) {
+  const content = fs.readFileSync(path.join(root, file), 'utf8');
+  for (const snippet of snippets) {
+    if (!content.toLowerCase().includes(snippet.toLowerCase())) {
+      fail(`Missing required section snippet in ${file}: ${snippet}`);
+    }
+  }
+}
+
 if (process.exitCode) process.exit(process.exitCode);
 ok('Documentation checks passed');


### PR DESCRIPTION
### Motivation
- Raise documentation governance by ensuring core institutional sections remain present and machine‑verifiable so docs do not silently drift out of coverage. 
- Complement existing freshness/link/Mermaid/SVG checks with semantic presence checks for operational, security, testing and contract reference anchors. 

### Description
- Extended `scripts/docs/check-docs.mjs` to assert required snippet/section presence across a curated set of authoritative docs (`README.md`, `docs/CONTRACTS/AGIJobManager.md`, `docs/SECURITY_MODEL.md`, `docs/TESTING.md`, `docs/OPERATIONS/*`, and `docs/QUINTESSENTIAL_USE_CASE.md`).
- The new checks validate permission/config tables, lifecycle/invariant anchors, threat‑model table shape, test matrix headings, runbook/monitoring/incident anchors and required columns in the quintessential step table.
- Kept existing deterministic generators and freshness checks untouched (generators remain at `scripts/docs/*` and `npm run docs:gen` still produces `docs/REFERENCE/*`).
- No binaries added and a no‑binaries enforcement script (`scripts/check-no-binaries.mjs`) is used by CI; new checks integrate with the repo’s `docs` CI workflow `.github/workflows/docs.yml`.

### Testing
- Ran `node scripts/check-no-binaries.mjs` (exits clean) and confirmed: no forbidden binary additions detected.
- Ran `npm run docs:gen` and observed generation of `docs/REFERENCE/VERSIONS.md`, `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REPO_MAP.md`, and `docs/REFERENCE/EVENTS_AND_ERRORS.md`.
- Ran `npm run docs:check` and observed `✅ Documentation checks passed` (includes the new section presence assertions).
- Ran full test suite with `npm test` and observed all tests passing (`290 passing`) and contract bytecode size checks succeeding.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698fa9f690d8833381b45e97f76a2a2d)