### PR TITLE
Harden ENSJobPages integration for mainnet-safe AGIJobManager hooks

### DIFF
--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -11,4 +11,5 @@ interface IENSJobPages {
     function jobEnsName(uint256 jobId) external view returns (string memory);
     function jobEnsURI(uint256 jobId) external view returns (string memory);
     function setUseEnsJobTokenURI(bool enabled) external;
+    function lockConfiguration() external;
 }

--- a/contracts/ens/INameWrapper.sol
+++ b/contracts/ens/INameWrapper.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 interface INameWrapper {
     function ownerOf(uint256 id) external view returns (address);
+    function getApproved(uint256 id) external view returns (address);
     function isApprovedForAll(address owner, address operator) external view returns (bool);
     function isWrapped(bytes32 node) external view returns (bool);
     function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external;

--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -20,6 +20,10 @@ contract MockNameWrapper {
         return owners[id];
     }
 
+    function getApproved(uint256) external pure returns (address) {
+        return address(0);
+    }
+
     function setApprovalForAll(address operator, bool approved) external {
         approvals[msg.sender][operator] = approved;
     }


### PR DESCRIPTION
### Motivation

- Make the ENS subsystem mainnet-grade and safe to integrate with the low-level assembly hooks and tokenURI path in `AGIJobManager`. 
- Ensure ABI/selector exactness and calldata shapes used by `AGIJobManager` are preserved and provably tested. 
- Defensively handle misconfiguration, resolver/wrapper/registry failures and bounded-gas situations so hooks remain best-effort and cannot brick `AGIJobManager` flows.

### Description

- Hardened `ENSJobPages.sol` configuration and lifecycle by adding a `configurationLocked` flag, `lockConfiguration()` and `ConfigLocked` error to prevent accidental post-lock setter changes. 
- Made hook execution robust and observable by wrapping job-manager reads in `try/catch`, skipping when not operationally configured, and emitting `HookHandled` / `HookSkipped` events for diagnostics. 
- Made `jobEnsURI(uint256)` safe under missing root config by returning an empty string (instead of reverting) so `AGIJobManager`’s tokenURI staticcall path cannot be forced to revert. 
- Improved wrapped-root detection and ENS owner reads with a defensive `_tryRootOwner()` helper and an `_isOperationallyConfigured()` predicate to avoid propagating registry call failures. 
- Updated ENS interfaces/mocks: added `lockConfiguration()` to `IENSJobPages`, added `getApproved(uint256)` to `INameWrapper`, and added the matching stub to `MockNameWrapper.sol` so tests and wrapper-aware code compile against mainnet-like ABIs. 
- Added deterministic tests exercising ABI/selector compatibility and operational behaviors (exact calldata lengths, ABI string offset/shape, empty-URI fallback, configuration lock behavior, wrapped/unwrapped flows and best-effort resolver writes).

### Testing

- Ran the Truffle test subset covering ENS integration and the new low-level ABI tests: `test/ensJobPagesHelper.test.js`, `test/ensAbiCompatibility.test.js`, and `test/ensHooks.integration.test.js`; all Truffle tests in that run passed (16 passing across these suites). 
- The new tests assert selector values and exact calldata sizes for `handleHook(uint8,uint256)` and `jobEnsURI(uint256)`, validate ABI return shape (offset==32) and URI length bounds, and exercise wrapped/unwrapped and failure-path behavior; these tests succeeded. 
- Attempted `forge test -q` but `forge` was not available in the execution environment (so Forge suite was not executed here).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ca28a0908333888ebe2343fb8edc)