### PR TITLE
Harden ENSJobPages for mainnet-safe hooks and ABI compatibility

### DIFF
--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -11,4 +11,5 @@ interface IENSJobPages {
     function jobEnsName(uint256 jobId) external view returns (string memory);
     function jobEnsURI(uint256 jobId) external view returns (string memory);
     function setUseEnsJobTokenURI(bool enabled) external;
+    function lockConfiguration() external;
 }

--- a/contracts/test/MockHookCaller.sol
+++ b/contracts/test/MockHookCaller.sol
@@ -9,4 +9,8 @@ contract MockHookCaller {
     function callHandleHook(address target, uint8 hook, uint256 jobId) external {
         IENSJobPagesLike(target).handleHook(hook, jobId);
     }
+
+    function callRaw(address target, bytes calldata payload) external returns (bool success, bytes memory returndata) {
+        (success, returndata) = target.call(payload);
+    }
 }

--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "./EnsLabelUtils.sol";
 
 library ENSOwnership {
+    // NOTE: Legacy `verifyOwnership(...)` helper was intentionally removed.
+    // Use verifyENSOwnership(...) and verifyMerkleOwnership(...) for canonical AGIJobManager flows.
     uint256 private constant ENS_STATICCALL_GAS_LIMIT = 80_000;
     bytes4 private constant OWNER_OF_SELECTOR = 0x6352211e;
     bytes4 private constant GET_APPROVED_SELECTOR = 0x081812fc;

--- a/test/ensAbiCompatibility.test.js
+++ b/test/ensAbiCompatibility.test.js
@@ -53,7 +53,7 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     await time.increase(reviewPeriod.addn(1));
   }
 
-  it("matches required selectors and AGI calldata sizing", async () => {
+  it("matches required selectors, calldata sizes, and ABI return encoding", async () => {
     const expectedHandleSelector = "0x1f76f7a2";
     const expectedJobUriSelector = "0x751809b4";
 
@@ -97,11 +97,32 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     });
     await pages.setJobManager(caller.address, { from: owner });
 
-    await caller.callHandleHook(pages.address, 0, 123, { from: owner });
+    const hookRaw = await caller.callRaw.call(pages.address, handleCalldata, { from: owner });
+    assert.equal(hookRaw.success, true, "0x44 calldata call should succeed for authorized caller");
 
     const raw = await web3.eth.call({ to: pages.address, data: jobUriCalldata });
     const decoded = web3.eth.abi.decodeParameter("string", raw);
     assert.equal(decoded, "ens://job-123.jobs.agi.eth");
+    const abiOffset = web3.utils.toBN("0x" + raw.slice(2, 66));
+    const strLen = web3.utils.toBN("0x" + raw.slice(66, 130));
+    assert.equal(abiOffset.toString(), "32", "ABI offset should be 32");
+    assert.equal(strLen.toString(), decoded.length.toString(), "ABI string length should match");
+  });
+
+  it("returns empty URI instead of reverting when root is unconfigured", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const pages = await ENSJobPages.new(
+      ens.address,
+      wrapper.address,
+      resolver.address,
+      "0x" + "00".repeat(32),
+      "",
+      { from: owner }
+    );
+
+    assert.equal(await pages.jobEnsURI(7), "");
   });
 
   it("uses ENS job URI for completion NFT when enabled", async () => {
@@ -123,18 +144,21 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     assert.isAtMost(uri.length, 1024, "ENS URI should stay within AGIJobManager bounds");
   });
 
-  it("keeps AGI job creation live when ENSJobPages reverts on misconfigured root", async () => {
+  it("keeps AGI job creation live when ENSJobPages is misconfigured", async () => {
     const token = await MockERC20.new({ from: owner });
     const ens = await MockENSRegistry.new({ from: owner });
     const wrapper = await MockNameWrapper.new({ from: owner });
     const resolver = await MockPublicResolver.new({ from: owner });
     const manager = await deployManager(token, ens, wrapper);
 
-    const rootName = "jobs.agi.eth";
-    const rootNode = namehash(rootName);
-    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, rootNode, rootName, {
-      from: owner,
-    });
+    const pages = await ENSJobPages.new(
+      ens.address,
+      wrapper.address,
+      resolver.address,
+      "0x" + "00".repeat(32),
+      "",
+      { from: owner }
+    );
     await pages.setJobManager(manager.address, { from: owner });
     await manager.setEnsJobPages(pages.address, { from: owner });
 


### PR DESCRIPTION
### Motivation
- Ensure ENS integration contracts are safe under mainnet conditions and remain perfectly compatible with AGIJobManager’s low-level assembly hook and tokenURI paths.
- Prevent ENS misconfiguration, malformed resolver responses, or wrapper differences from bricking AGIJobManager flows while preserving exact ABI/selector expectations.
- Improve observability and provide an admin lock to avoid accidental post-deploy config drift.

### Description
- ENSJobPages: add config lock (`configLocked`, `lockConfiguration()`, `ConfigLocked`) and guard setters with `notConfigLocked`; return empty `jobEnsName`/`jobEnsURI` when root unconfigured to avoid tokenURI path reverts; add `HookHandled` event and refactor hook handling into bounded helper functions that tolerate view failures and perform non-critical resolver writes best-effort; critical ownership actions remain fail-closed. (contracts/ens/ENSJobPages.sol)
- IENSJobPages: expose `lockConfiguration()` in the interface so admin tooling can call the lock consistently. (contracts/ens/IENSJobPages.sol)
- Tests & mocks: add `callRaw(...)` to MockHookCaller to exercise exact calldata sizes, and extend deterministic ABI + integration tests to assert selectors, calldata lengths, ABI string return encoding (offset==32), unconfigured root fallback, config-lock behavior, and hook no-op observability. (contracts/test/MockHookCaller.sol, test/ensAbiCompatibility.test.js, test/ensJobPagesHelper.test.js)
- ENSOwnership: add a prominent note removing/declaring legacy helper as intentionally removed to reduce footguns. (contracts/utils/ENSOwnership.sol)
- All changes avoid altering AGIJobManager external behavior or selectors; hook selector and calldata sizes expected by AGIJobManager are preserved exactly.

### Testing
- Ran targeted Truffle tests and integration suites: `test/ensAbiCompatibility.test.js`, `test/ensHooks.integration.test.js`, `test/ensJobPagesHelper.test.js`, and `test/ensJobPagesHooks.test.js`, and they passed (all assertions green in the environment used).
- Full Truffle test harness (`npx truffle test`) and compilation completed successfully under the repository toolchain (solc via Truffle); selected ENS-related tests verified selector values, calldata sizes (0x44 and 0x24), and ABI string return shape (offset==32).
- Local `forge test` was not executed in this environment because `forge` was not available, but code changes are conservative (no version-fragile constructs) to maintain Foundry compatibility and were kept within the repo’s existing pragma constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ca28a0908333888ebe2343fb8edc)