### PR TITLE
Tighten ENSJobPages configuration locking and enforce wrapper/jobManager preconditions

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -34,6 +34,7 @@ contract ENSJobPages is Ownable {
     error ENSNotConfigured();
     error ENSNotAuthorized();
     error InvalidParameters();
+    error ConfigLocked();
 
     // NameWrapper fuses (ENSIP-10).
     uint32 private constant CANNOT_SET_RESOLVER = 1 << 3;
@@ -54,6 +55,9 @@ contract ENSJobPages is Ownable {
     );
     event JobManagerUpdated(address indexed oldJobManager, address indexed newJobManager);
     event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);
+    event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);
+    event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);
+    event ConfigurationLocked(address indexed locker);
 
     IENSRegistry public ens;
     INameWrapper public nameWrapper;
@@ -62,6 +66,7 @@ contract ENSJobPages is Ownable {
     string public jobsRootName;
     address public jobManager;
     bool public useEnsJobTokenURI;
+    bool public configLocked;
 
     constructor(
         address ensAddress,
@@ -84,6 +89,7 @@ contract ENSJobPages is Ownable {
     }
 
     function setENSRegistry(address ensAddress) external onlyOwner {
+        if (configLocked) revert ConfigLocked();
         address old = address(ens);
         if (ensAddress == address(0) || ensAddress.code.length == 0) revert InvalidParameters();
         ens = IENSRegistry(ensAddress);
@@ -91,6 +97,7 @@ contract ENSJobPages is Ownable {
     }
 
     function setNameWrapper(address nameWrapperAddress) external onlyOwner {
+        if (configLocked) revert ConfigLocked();
         address old = address(nameWrapper);
         if (nameWrapperAddress != address(0) && nameWrapperAddress.code.length == 0) revert InvalidParameters();
         nameWrapper = INameWrapper(nameWrapperAddress);
@@ -98,6 +105,7 @@ contract ENSJobPages is Ownable {
     }
 
     function setPublicResolver(address publicResolverAddress) external onlyOwner {
+        if (configLocked) revert ConfigLocked();
         address old = address(publicResolver);
         if (publicResolverAddress == address(0) || publicResolverAddress.code.length == 0) revert InvalidParameters();
         publicResolver = IPublicResolver(publicResolverAddress);
@@ -105,6 +113,7 @@ contract ENSJobPages is Ownable {
     }
 
     function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner {
+        if (configLocked) revert ConfigLocked();
         bytes32 oldNode = jobsRootNode;
         string memory oldName = jobsRootName;
         if (rootNode == bytes32(0)) revert InvalidParameters();
@@ -115,6 +124,7 @@ contract ENSJobPages is Ownable {
     }
 
     function setJobManager(address manager) external onlyOwner {
+        if (configLocked) revert ConfigLocked();
         address old = jobManager;
         if (manager == address(0) || manager.code.length == 0) revert InvalidParameters();
         jobManager = manager;
@@ -125,6 +135,12 @@ contract ENSJobPages is Ownable {
         bool old = useEnsJobTokenURI;
         useEnsJobTokenURI = enabled;
         emit UseEnsJobTokenURIUpdated(old, enabled);
+    }
+
+    function lockConfiguration() external onlyOwner {
+        if (!_isFullyConfigured()) revert ENSNotConfigured();
+        configLocked = true;
+        emit ConfigurationLocked(msg.sender);
     }
 
     modifier onlyJobManager() {
@@ -138,12 +154,14 @@ contract ENSJobPages is Ownable {
     }
 
     function jobEnsName(uint256 jobId) public view returns (string memory) {
-        if (!_isRootConfigured()) revert ENSNotConfigured();
+        if (!_isRootConfigured()) return "";
         return string(abi.encodePacked(jobEnsLabel(jobId), ".", jobsRootName));
     }
 
     function jobEnsURI(uint256 jobId) public view returns (string memory) {
-        return string(abi.encodePacked("ens://", jobEnsName(jobId)));
+        string memory ensName = jobEnsName(jobId);
+        if (bytes(ensName).length == 0) return "";
+        return string(abi.encodePacked("ens://", ensName));
     }
 
 
@@ -168,21 +186,34 @@ contract ENSJobPages is Ownable {
     }
 
     function handleHook(uint8 hook, uint256 jobId) external onlyJobManager {
+        if (!_isFullyConfigured()) {
+            emit ENSHookSkipped(hook, jobId, "NOT_CONFIGURED");
+            emit ENSHookProcessed(hook, jobId, false, false);
+            return;
+        }
+
+        bool success;
         IAGIJobManagerView jobManagerView = IAGIJobManagerView(msg.sender);
         if (hook == 1) {
             string memory specURI = jobManagerView.getJobSpecURI(jobId);
             (address employer, , , , , , , , ) = jobManagerView.getJobCore(jobId);
             _createJobPage(jobId, employer, specURI);
+            success = true;
+            emit ENSHookProcessed(hook, jobId, true, success);
             return;
         }
         if (hook == 2) {
             (, address agent, , , , , , , ) = jobManagerView.getJobCore(jobId);
             _onAgentAssigned(jobId, agent);
+            success = true;
+            emit ENSHookProcessed(hook, jobId, true, success);
             return;
         }
         if (hook == 3) {
             string memory completionURI = jobManagerView.getJobCompletionURI(jobId);
             _onCompletionRequested(jobId, completionURI);
+            success = true;
+            emit ENSHookProcessed(hook, jobId, true, success);
             return;
         }
         if (hook == 4) {
@@ -198,9 +229,12 @@ contract ENSJobPages is Ownable {
                 uint8
             ) {
                 _revokePermissions(jobId, employer, agent);
+                success = true;
             } catch {
                 _revokePermissions(jobId, address(0), address(0));
+                success = true;
             }
+            emit ENSHookProcessed(hook, jobId, true, success);
             return;
         }
         if (hook == 5 || hook == 6) {
@@ -217,11 +251,16 @@ contract ENSJobPages is Ownable {
                 uint8
             ) {
                 _lockJobENS(jobId, employer, agent, burnFuses);
+                success = true;
             } catch {
                 _lockJobENS(jobId, address(0), address(0), burnFuses);
+                success = true;
             }
+            emit ENSHookProcessed(hook, jobId, true, success);
             return;
         }
+        emit ENSHookSkipped(hook, jobId, "UNKNOWN_HOOK");
+        emit ENSHookProcessed(hook, jobId, true, false);
     }
 
     function onAgentAssigned(uint256 jobId, address agent) public onlyOwner {
@@ -340,9 +379,28 @@ contract ENSJobPages is Ownable {
     }
 
     function _requireConfigured() internal view {
-        if (address(ens) == address(0)) revert ENSNotConfigured();
-        if (address(publicResolver) == address(0)) revert ENSNotConfigured();
-        if (!_isRootConfigured()) revert ENSNotConfigured();
+        if (!_isBaseConfigured()) revert ENSNotConfigured();
+    }
+
+    function _isBaseConfigured() internal view returns (bool) {
+        if (address(ens) == address(0)) return false;
+        if (address(publicResolver) == address(0)) return false;
+        if (!_isRootConfigured()) return false;
+        return true;
+    }
+
+    function _isFullyConfigured() internal view returns (bool) {
+        if (!_isBaseConfigured()) return false;
+        if (jobManager == address(0) || jobManager.code.length == 0) return false;
+
+        address rootOwner = ens.owner(jobsRootNode);
+        if (rootOwner == address(this)) {
+            return true;
+        }
+        if (address(nameWrapper) == address(0) || address(nameWrapper).code.length == 0) {
+            return false;
+        }
+        return rootOwner == address(nameWrapper);
     }
 
     function _isRootConfigured() internal view returns (bool) {

--- a/contracts/ens/IENSJobPages.sol
+++ b/contracts/ens/IENSJobPages.sol
@@ -8,6 +8,8 @@ interface IENSJobPages {
     function onCompletionRequested(uint256 jobId, string calldata completionURI) external;
     function revokePermissions(uint256 jobId, address employer, address agent) external;
     function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) external;
+    function lockConfiguration() external;
+    function configLocked() external view returns (bool);
     function jobEnsName(uint256 jobId) external view returns (string memory);
     function jobEnsURI(uint256 jobId) external view returns (string memory);
     function setUseEnsJobTokenURI(bool enabled) external;

--- a/contracts/utils/ENSOwnership.sol
+++ b/contracts/utils/ENSOwnership.sol
@@ -5,6 +5,8 @@ import "@openzeppelin/contracts/utils/cryptography/MerkleProof.sol";
 import "./EnsLabelUtils.sol";
 
 library ENSOwnership {
+    // Legacy note: keep this library limited to deterministic ownership checks used by
+    // AGIJobManager routing (`verifyENSOwnership` + `verifyMerkleOwnership`).
     uint256 private constant ENS_STATICCALL_GAS_LIMIT = 80_000;
     bytes4 private constant OWNER_OF_SELECTOR = 0x6352211e;
     bytes4 private constant GET_APPROVED_SELECTOR = 0x081812fc;

--- a/test/ensAbiCompatibility.test.js
+++ b/test/ensAbiCompatibility.test.js
@@ -1,4 +1,4 @@
-const { time } = require("@openzeppelin/test-helpers");
+const { time, expectEvent } = require("@openzeppelin/test-helpers");
 
 const AGIJobManager = artifacts.require("AGIJobManager");
 const ENSJobPages = artifacts.require("ENSJobPages");
@@ -53,7 +53,7 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     await time.increase(reviewPeriod.addn(1));
   }
 
-  it("matches required selectors and AGI calldata sizing", async () => {
+  it("matches required selectors, calldata size, and string ABI shape", async () => {
     const expectedHandleSelector = "0x1f76f7a2";
     const expectedJobUriSelector = "0x751809b4";
 
@@ -96,12 +96,23 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
       from: owner,
     });
     await pages.setJobManager(caller.address, { from: owner });
+    await ens.setOwner(rootNode, pages.address, { from: owner });
 
-    await caller.callHandleHook(pages.address, 0, 123, { from: owner });
+    const hookReceipt = await caller.callHandleHook(pages.address, 0, 123, { from: owner });
+    await expectEvent.inTransaction(hookReceipt.tx, pages, "ENSHookSkipped", {
+      hook: "0",
+      jobId: "123",
+      reason: web3.utils.padRight(web3.utils.asciiToHex("UNKNOWN_HOOK"), 64),
+    });
 
     const raw = await web3.eth.call({ to: pages.address, data: jobUriCalldata });
+    const offsetWord = web3.utils.toBN("0x" + raw.slice(2, 66));
+    const stringLenWord = web3.utils.toBN("0x" + raw.slice(66, 130));
     const decoded = web3.eth.abi.decodeParameter("string", raw);
+    assert.equal(offsetWord.toString(), "32", "ABI offset should be 32 for single string return");
+    assert.equal(stringLenWord.toString(), decoded.length.toString(), "ABI string length word should match");
     assert.equal(decoded, "ens://job-123.jobs.agi.eth");
+    assert.isAtMost(decoded.length, 1024, "ENS URI should stay within AGIJobManager bounds");
   });
 
   it("uses ENS job URI for completion NFT when enabled", async () => {
@@ -123,7 +134,7 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     assert.isAtMost(uri.length, 1024, "ENS URI should stay within AGIJobManager bounds");
   });
 
-  it("keeps AGI job creation live when ENSJobPages reverts on misconfigured root", async () => {
+  it("keeps AGI job creation live when ENSJobPages is present but unconfigured", async () => {
     const token = await MockERC20.new({ from: owner });
     const ens = await MockENSRegistry.new({ from: owner });
     const wrapper = await MockNameWrapper.new({ from: owner });

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -246,4 +246,63 @@ contract("ENSJobPages helper", (accounts) => {
     await expectRevert.unspecified(helper.setJobManager(owner, { from: owner }));
   });
 
+
+  it("returns safe empty URI when root config is absent", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const helper = await ENSJobPages.new(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      resolver.address,
+      "0x0000000000000000000000000000000000000000000000000000000000000000",
+      "",
+      { from: owner }
+    );
+
+    const uri = await helper.jobEnsURI(99);
+    assert.equal(uri, "");
+  });
+
+  it("locks configuration only when fully configured", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const helper = await ENSJobPages.new(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      resolver.address,
+      rootNode,
+      rootName,
+      { from: owner }
+    );
+
+    await expectRevert.unspecified(helper.lockConfiguration({ from: owner }));
+
+    await helper.setJobManager(helper.address, { from: owner });
+    await ens.setOwner(rootNode, helper.address, { from: owner });
+
+    await helper.lockConfiguration({ from: owner });
+    await expectRevert.unspecified(helper.setJobsRoot(namehash("new.jobs.agi.eth"), "new.jobs.agi.eth", { from: owner }));
+    await expectRevert.unspecified(helper.setJobManager(owner, { from: owner }));
+  });
+
+
+  it("does not allow lockConfiguration when root is wrapper-owned but wrapper is unset", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const helper = await ENSJobPages.new(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      resolver.address,
+      rootNode,
+      rootName,
+      { from: owner }
+    );
+
+    await helper.setJobManager(helper.address, { from: owner });
+    await ens.setOwner(rootNode, wrapper.address, { from: owner });
+
+    await expectRevert.unspecified(helper.lockConfiguration({ from: owner }));
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Prevent irreversibly locking ENSJobPages when `jobManager` is unset or when a wrapped root lacks proper `nameWrapper` wiring. 
- Make ENS hook calls observable and best-effort so ENS failures degrade safely instead of silently breaking flows. 

### Description
- Split configuration checks into `_isBaseConfigured()` (ENS, resolver, root) used by `_requireConfigured()`, and `_isFullyConfigured()` (base + usable `jobManager` + valid root ownership mode) used for lock gating. 
- Added `lockConfiguration()` with `configLocked` state and `ConfigurationLocked` event, and made setters (`setENSRegistry`, `setNameWrapper`, `setPublicResolver`, `setJobsRoot`, `setJobManager`) refuse changes when configuration is locked. 
- Enforced `jobManager` to be a non-zero contract before allowing `lockConfiguration()`, and require that wrapped roots are only considered fully-configured when `nameWrapper` is set and matches the root owner. 
- Made `jobEnsName()`/`jobEnsURI()` return empty string when root is unconfigured to avoid reverts; added `ENSHookProcessed` / `ENSHookSkipped` events and emitted them for hook outcomes and unknown/misconfigured paths without changing existing hook ABI. 
- Updated `IENSJobPages` to expose `lockConfiguration()` and `configLocked()`, added a legacy note to `ENSOwnership` and updated tests to cover the new lock preconditions and ABI-return shape assertions. 

### Testing
- Ran targeted Truffle tests with `npx truffle test --network test test/ensJobPagesHelper.test.js test/ensAbiCompatibility.test.js` and all tests in those files passed. 
- Ran ENS hook and integration suites with `npx truffle test --network test test/ensHooks.integration.test.js test/ensJobPagesHooks.test.js` and all tests passed. 
- Overall modified ENS-related suites passed locally (tests validating selector/calldata sizes, ABI string shape, safe-unconfigured fallback, and lock behavior all succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ca28a0908333888ebe2343fb8edc)