### PR TITLE
Fix BondMath overflow handling, harden balance checks, improve ENSJobPages resilience, and regenerate docs

### DIFF
--- a/contracts/test/RevertingBalanceOfERC20.sol
+++ b/contracts/test/RevertingBalanceOfERC20.sol
@@ -1,0 +1,44 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract RevertingBalanceOfERC20 {
+    mapping(address => uint256) public balance;
+    mapping(address => mapping(address => uint256)) public allowance;
+
+    function mint(address to, uint256 amount) external {
+        balance[to] += amount;
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        revert();
+    }
+
+    function approve(address spender, uint256 amount) external returns (bool) {
+        allowance[msg.sender][spender] = amount;
+        return true;
+    }
+
+    function transfer(address to, uint256 amount) external returns (bool) {
+        uint256 bal = balance[msg.sender];
+        require(bal >= amount, "bal");
+        unchecked {
+            balance[msg.sender] = bal - amount;
+            balance[to] += amount;
+        }
+        return true;
+    }
+
+    function transferFrom(address from, address to, uint256 amount) external returns (bool) {
+        uint256 allowed = allowance[from][msg.sender];
+        require(allowed >= amount, "allowance");
+        allowance[from][msg.sender] = allowed - amount;
+
+        uint256 bal = balance[from];
+        require(bal >= amount, "bal");
+        unchecked {
+            balance[from] = bal - amount;
+            balance[to] += amount;
+        }
+        return true;
+    }
+}

--- a/contracts/utils/BondMath.sol
+++ b/contracts/utils/BondMath.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.19;
 
+import "@openzeppelin/contracts/utils/math/Math.sol";
+
 library BondMath {
     function computeValidatorBond(
         uint256 payout,
@@ -28,10 +30,11 @@ library BondMath {
         if (bps == 0 && minBond == 0 && maxBond == 0) {
             return 0;
         }
-        bond = (payout * bps) / 10_000;
+        bond = Math.mulDiv(payout, bps, 10_000);
         if (bond < minBond) bond = minBond;
         if (durationLimit != 0) {
-            bond += (bond * duration) / durationLimit;
+            uint256 durationPremium = Math.mulDiv(bond, duration, durationLimit);
+            bond += durationPremium;
         }
         if (maxBond != 0 && bond > maxBond) bond = maxBond;
         if (bond > payout) bond = payout;

--- a/contracts/utils/TransferUtils.sol
+++ b/contracts/utils/TransferUtils.sol
@@ -19,10 +19,18 @@ library TransferUtils {
     function safeTransferFromExact(address token, address from, address to, uint256 amount) external {
         if (amount == 0) return;
         if (token.code.length == 0) revert TransferFailed();
-        uint256 balanceBefore = IERC20(token).balanceOf(to);
+        uint256 balanceBefore = _safeBalanceOf(token, to);
         _callOptionalReturn(token, abi.encodeWithSelector(IERC20.transferFrom.selector, from, to, amount));
-        uint256 balanceAfter = IERC20(token).balanceOf(to);
+        uint256 balanceAfter = _safeBalanceOf(token, to);
         if (balanceAfter < balanceBefore || balanceAfter - balanceBefore != amount) revert TransferFailed();
+    }
+
+    function _safeBalanceOf(address token, address account) private view returns (uint256 balance) {
+        (bool success, bytes memory returndata) = token.staticcall(
+            abi.encodeWithSelector(IERC20.balanceOf.selector, account)
+        );
+        if (!success || returndata.length != 32) revert TransferFailed();
+        balance = abi.decode(returndata, (uint256));
     }
 
     function _callOptionalReturn(address token, bytes memory data) private {

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,6 +1,6 @@
 # ENS Reference (Generated)
 
-Source fingerprint: b534704c98cab8f4
+Source fingerprint: 3fab7e9d48b8b7c6
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -20,14 +20,14 @@ Source files used:
 - `NameWrapper public nameWrapper;` (contracts/AGIJobManager.sol:141)
 - `address public ensJobPages;` (contracts/AGIJobManager.sol:142)
 - `bool public lockIdentityConfig;` (contracts/AGIJobManager.sol:145)
-- `IENSRegistry public ens;` (contracts/ens/ENSJobPages.sol:62)
-- `INameWrapper public nameWrapper;` (contracts/ens/ENSJobPages.sol:63)
-- `IPublicResolver public publicResolver;` (contracts/ens/ENSJobPages.sol:64)
-- `bytes32 public jobsRootNode;` (contracts/ens/ENSJobPages.sol:65)
-- `string public jobsRootName;` (contracts/ens/ENSJobPages.sol:66)
-- `address public jobManager;` (contracts/ens/ENSJobPages.sol:67)
-- `bool public useEnsJobTokenURI;` (contracts/ens/ENSJobPages.sol:68)
-- `bool public configLocked;` (contracts/ens/ENSJobPages.sol:69)
+- `IENSRegistry public ens;` (contracts/ens/ENSJobPages.sol:63)
+- `INameWrapper public nameWrapper;` (contracts/ens/ENSJobPages.sol:64)
+- `IPublicResolver public publicResolver;` (contracts/ens/ENSJobPages.sol:65)
+- `bytes32 public jobsRootNode;` (contracts/ens/ENSJobPages.sol:66)
+- `string public jobsRootName;` (contracts/ens/ENSJobPages.sol:67)
+- `address public jobManager;` (contracts/ens/ENSJobPages.sol:68)
+- `bool public useEnsJobTokenURI;` (contracts/ens/ENSJobPages.sol:69)
+- `bool public configLocked;` (contracts/ens/ENSJobPages.sol:70)
 
 ## Config and locks
 
@@ -48,13 +48,13 @@ Source files used:
 - `function verifyENSOwnership(` (contracts/utils/ENSOwnership.sol:32)
 - `function verifyENSOwnership(` (contracts/utils/ENSOwnership.sol:47)
 - `function verifyMerkleOwnership(address claimant, bytes32[] calldata proof, bytes32 merkleRoot)` (contracts/utils/ENSOwnership.sol:60)
-- `function setENSRegistry(address ensAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:91)
-- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:99)
-- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` (contracts/ens/ENSJobPages.sol:115)
-- `function lockConfiguration() external onlyOwner` (contracts/ens/ENSJobPages.sol:140)
-- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` (contracts/ens/ENSJobPages.sol:188)
-- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` (contracts/ens/ENSJobPages.sol:298)
-- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` (contracts/ens/ENSJobPages.sol:303)
+- `function setENSRegistry(address ensAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:92)
+- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:100)
+- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` (contracts/ens/ENSJobPages.sol:116)
+- `function lockConfiguration() external onlyOwner` (contracts/ens/ENSJobPages.sol:141)
+- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` (contracts/ens/ENSJobPages.sol:189)
+- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` (contracts/ens/ENSJobPages.sol:299)
+- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` (contracts/ens/ENSJobPages.sol:304)
 
 ## Events and errors
 
@@ -77,6 +77,7 @@ Source files used:
 - `event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);` (contracts/ens/ENSJobPages.sol:57)
 - `event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);` (contracts/ens/ENSJobPages.sol:58)
 - `event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);` (contracts/ens/ENSJobPages.sol:59)
+- `event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);` (contracts/ens/ENSJobPages.sol:60)
 
 ## Notes / caveats from code comments
 

--- a/test/utils.uri-transfer.test.js
+++ b/test/utils.uri-transfer.test.js
@@ -6,6 +6,7 @@ const ERC20NoReturn = artifacts.require("ERC20NoReturn");
 const FailingERC20 = artifacts.require("FailingERC20");
 const FeeOnTransferToken = artifacts.require("FeeOnTransferToken");
 const MalformedReturnERC20 = artifacts.require("MalformedReturnERC20");
+const RevertingBalanceOfERC20 = artifacts.require("RevertingBalanceOfERC20");
 const BondMath = artifacts.require("BondMath");
 const ENSOwnership = artifacts.require("ENSOwnership");
 const ReputationMath = artifacts.require("ReputationMath");
@@ -134,6 +135,18 @@ contract("Utility libraries: UriUtils + TransferUtils", (accounts) => {
 
       await expectRevert.unspecified(
         harness.safeTransferFromExact("0x0000000000000000000000000000000000000001", owner, recipient, 1, { from: owner })
+      );
+    });
+
+
+
+    it("reverts when balanceOf staticcalls revert during exact-transfer checks", async () => {
+      const token = await RevertingBalanceOfERC20.new({ from: owner });
+      await token.mint(owner, web3.utils.toWei("10"), { from: owner });
+      await token.approve(harness.address, web3.utils.toWei("2"), { from: owner });
+
+      await expectRevert.unspecified(
+        harness.safeTransferFromExact(token.address, owner, recipient, web3.utils.toWei("2"), { from: owner })
       );
     });
 


### PR DESCRIPTION
### Motivation
- Prevent silent integer wrap in agent bond calculation so an overflow reverts instead of under-collateralizing bonds.  
- Make ERC20 balance reads robust to tokens that revert or return malformed data when measuring recipient deltas.  
- Improve ENSJobPages resilience to ENS registry reverts and emit failure telemetry for best-effort ENS hook operations.  
- Keep generated ENS reference docs in sync with the codebase.

### Description
- Restored checked arithmetic for the agent premium addition in `BondMath.computeAgentBond` by removing the `unchecked` block and switched mul/div operations to `Math.mulDiv` for safer precision (`contracts/utils/BondMath.sol`).
- Added a safe staticcall-based ` _safeBalanceOf` helper and switched `safeTransferFromExact` to use it so that reverting or malformed `balanceOf` responses are handled as transfer failures (`contracts/utils/TransferUtils.sol`).
- Added a test fixture contract `RevertingBalanceOfERC20` to simulate `balanceOf` reverts (`contracts/test/RevertingBalanceOfERC20.sol`) and updated tests to exercise this case (`test/utils.uri-transfer.test.js`).
- Made `ENSJobPages` more robust by emitting `ENSHookBestEffortFailure` on failing best-effort resolver/authorisation calls, and by using a safe `_tryRootOwner` wrapper to handle `ens.owner(...)` reverts in `_isWrappedRoot` and `_isFullyConfigured` (`contracts/ens/ENSJobPages.sol`).
- Regenerated `docs/REFERENCE/ENS_REFERENCE.md` to reflect the current code surface and satisfy docs checks.

### Testing
- Ran `npm run docs:ens:gen` and it completed successfully.
- Ran `npm run docs:check` and documentation integrity checks passed.
- Ran `npx truffle test --network test test/invariants.libs.test.js` and the invariants suite passed (7 tests passing).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ea82bb2883338408c571a99301ff)