### PR TITLE
Harden ENS wrapped auth and hook failure telemetry

### DIFF
--- a/contracts/ens/INameWrapper.sol
+++ b/contracts/ens/INameWrapper.sol
@@ -3,6 +3,7 @@ pragma solidity ^0.8.19;
 
 interface INameWrapper {
     function ownerOf(uint256 id) external view returns (address);
+    function getApproved(uint256 tokenId) external view returns (address);
     function isApprovedForAll(address owner, address operator) external view returns (bool);
     function isWrapped(bytes32 node) external view returns (bool);
     function setChildFuses(bytes32 parentNode, bytes32 labelhash, uint32 fuses, uint64 expiry) external;


### PR DESCRIPTION
### Motivation
- Reduce integration risk with mainnet NameWrapper semantics by supporting ERC721-style token approvals in wrapped-root authorization checks. 
- Improve observability and deterministic failure behavior when resolver writes fail from hook paths so AGIJobManager flows remain best-effort and predictable. 
- Add deterministic tests covering the new authorization path and hook-aware telemetry without changing AGIJobManager external behavior or inflating runtime bytecode beyond the EIP-170 limit.

### Description
- Added `getApproved(uint256)` to `contracts/ens/INameWrapper.sol` to explicitly expose token-approval ABI used by NameWrapper-like wrappers. 
- Updated `contracts/ens/ENSJobPages.sol` to accept either `isApprovedForAll(owner, operator)` OR `getApproved(tokenId) == operator` when validating wrapper authorization for `jobsRootNode` and to check token approval during wrapper-authorization readiness. 
- Threaded hook context into resolver best-effort writes by changing `_setTextBestEffort(...)` to include `hook` and `jobId` and emitting `ENSHookBestEffortFailure(hook, jobId, operation)` on failure. 
- Added deterministic regression tests in `test/ensJobPagesHelper.test.js` that validate: (a) wrapped-root token-approval flow (token-level approval allows ENSJobPages to set records) and (b) hook-aware best-effort failure telemetry is emitted from the create path. 
- Kept all changes localized to ENS + utils testing surface; no behavioral changes to `contracts/AGIJobManager.sol` runtime logic or ABI calls were made and no new external dependencies were added.

### Testing
- Ran focused Truffle test suites verifying selector/ABI compatibility and modified-area behavior with:
  - `npx truffle test test/ensJobPagesHelper.test.js test/ensAbiCompatibility.test.js --network test` which completed successfully (tests covering ENSJobPages helper and ABI compatibility passed). 
  - `npx truffle test test/ensLabelHardening.test.js test/utils.uri-transfer.test.js --network test` which completed successfully (ENS label hardening and utils tests passed). 
- Verified selectors/ABI assertions (handleHook and jobEnsURI calldata sizing and returned string ABI) remained exact and passing in the test suite. 
- Verified AGIJobManager runtime bytecode stays within the EIP-170 limit by running `npm run size` which reported `AGIJobManager runtime bytecode size: 24526 bytes` (<= 24,576 bytes limit). 
- All automated tests exercised above completed without regressions for the modified areas (deterministic test runs shown above passed).

Exact commands used locally for validation (copy-paste):
- `npx truffle test test/ensJobPagesHelper.test.js test/ensAbiCompatibility.test.js --network test`
- `npx truffle test test/ensLabelHardening.test.js test/utils.uri-transfer.test.js --network test`
- `npm run size`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990fca5658c8333839dd8c731c30c87)