### PR TITLE
Fix ENSJobPages wrapped auth fallback regression and refresh ENS docs

### DIFF
--- a/contracts/test/MockNameWrapper.sol
+++ b/contracts/test/MockNameWrapper.sol
@@ -12,6 +12,7 @@ contract MockNameWrapper {
     bytes32 public lastLabelhash;
     uint32 public lastChildFuses;
     uint64 public lastChildExpiry;
+    bool public revertGetApproved;
 
     function setOwner(uint256 id, address owner) external {
         owners[id] = owner;
@@ -34,7 +35,12 @@ contract MockNameWrapper {
     }
 
     function getApproved(uint256 id) external view returns (address) {
+        if (revertGetApproved) revert();
         return tokenApprovals[id];
+    }
+
+    function setRevertGetApproved(bool value) external {
+        revertGetApproved = value;
     }
 
     function isWrapped(bytes32 node) external view returns (bool) {

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,6 +1,6 @@
 # ENS Reference (Generated)
 
-Source fingerprint: 453e7f1ca93113b9
+Source fingerprint: c23fca0df3a218fe
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -20,14 +20,14 @@ Source files used:
 - `NameWrapper public nameWrapper;` (contracts/AGIJobManager.sol:141)
 - `address public ensJobPages;` (contracts/AGIJobManager.sol:142)
 - `bool public lockIdentityConfig;` (contracts/AGIJobManager.sol:145)
-- `IENSRegistry public ens;` (contracts/ens/ENSJobPages.sol:63)
-- `INameWrapper public nameWrapper;` (contracts/ens/ENSJobPages.sol:64)
-- `IPublicResolver public publicResolver;` (contracts/ens/ENSJobPages.sol:65)
-- `bytes32 public jobsRootNode;` (contracts/ens/ENSJobPages.sol:66)
-- `string public jobsRootName;` (contracts/ens/ENSJobPages.sol:67)
-- `address public jobManager;` (contracts/ens/ENSJobPages.sol:68)
-- `bool public useEnsJobTokenURI;` (contracts/ens/ENSJobPages.sol:69)
-- `bool public configLocked;` (contracts/ens/ENSJobPages.sol:70)
+- `IENSRegistry public ens;` (contracts/ens/ENSJobPages.sol:65)
+- `INameWrapper public nameWrapper;` (contracts/ens/ENSJobPages.sol:66)
+- `IPublicResolver public publicResolver;` (contracts/ens/ENSJobPages.sol:67)
+- `bytes32 public jobsRootNode;` (contracts/ens/ENSJobPages.sol:68)
+- `string public jobsRootName;` (contracts/ens/ENSJobPages.sol:69)
+- `address public jobManager;` (contracts/ens/ENSJobPages.sol:70)
+- `bool public useEnsJobTokenURI;` (contracts/ens/ENSJobPages.sol:71)
+- `bool public configLocked;` (contracts/ens/ENSJobPages.sol:72)
 
 ## Config and locks
 
@@ -48,13 +48,13 @@ Source files used:
 - `function verifyENSOwnership(` (contracts/utils/ENSOwnership.sol:32)
 - `function verifyENSOwnership(` (contracts/utils/ENSOwnership.sol:47)
 - `function verifyMerkleOwnership(address claimant, bytes32[] calldata proof, bytes32 merkleRoot)` (contracts/utils/ENSOwnership.sol:60)
-- `function setENSRegistry(address ensAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:92)
-- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:100)
-- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` (contracts/ens/ENSJobPages.sol:116)
-- `function lockConfiguration() external onlyOwner` (contracts/ens/ENSJobPages.sol:141)
-- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` (contracts/ens/ENSJobPages.sol:189)
-- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` (contracts/ens/ENSJobPages.sol:299)
-- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` (contracts/ens/ENSJobPages.sol:304)
+- `function setENSRegistry(address ensAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:95)
+- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` (contracts/ens/ENSJobPages.sol:103)
+- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` (contracts/ens/ENSJobPages.sol:119)
+- `function lockConfiguration() external onlyOwner` (contracts/ens/ENSJobPages.sol:144)
+- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` (contracts/ens/ENSJobPages.sol:192)
+- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` (contracts/ens/ENSJobPages.sol:302)
+- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` (contracts/ens/ENSJobPages.sol:307)
 
 ## Events and errors
 
@@ -70,14 +70,14 @@ Source files used:
 - `error ENSNotConfigured();` (contracts/ens/ENSJobPages.sol:34)
 - `error ENSNotAuthorized();` (contracts/ens/ENSJobPages.sol:35)
 - `error InvalidParameters();` (contracts/ens/ENSJobPages.sol:36)
-- `event JobENSPageCreated(uint256 indexed jobId, bytes32 indexed node);` (contracts/ens/ENSJobPages.sol:44)
-- `event JobENSPermissionsUpdated(uint256 indexed jobId, address indexed account, bool isAuthorised);` (contracts/ens/ENSJobPages.sol:45)
-- `event JobENSLocked(uint256 indexed jobId, bytes32 indexed node, bool fusesBurned);` (contracts/ens/ENSJobPages.sol:46)
-- `event ENSRegistryUpdated(address indexed oldEns, address indexed newEns);` (contracts/ens/ENSJobPages.sol:47)
-- `event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);` (contracts/ens/ENSJobPages.sol:57)
-- `event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);` (contracts/ens/ENSJobPages.sol:58)
-- `event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);` (contracts/ens/ENSJobPages.sol:59)
-- `event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);` (contracts/ens/ENSJobPages.sol:60)
+- `event JobENSPageCreated(uint256 indexed jobId, bytes32 indexed node);` (contracts/ens/ENSJobPages.sol:46)
+- `event JobENSPermissionsUpdated(uint256 indexed jobId, address indexed account, bool isAuthorised);` (contracts/ens/ENSJobPages.sol:47)
+- `event JobENSLocked(uint256 indexed jobId, bytes32 indexed node, bool fusesBurned);` (contracts/ens/ENSJobPages.sol:48)
+- `event ENSRegistryUpdated(address indexed oldEns, address indexed newEns);` (contracts/ens/ENSJobPages.sol:49)
+- `event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);` (contracts/ens/ENSJobPages.sol:59)
+- `event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);` (contracts/ens/ENSJobPages.sol:60)
+- `event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);` (contracts/ens/ENSJobPages.sol:61)
+- `event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);` (contracts/ens/ENSJobPages.sol:62)
 
 ## Notes / caveats from code comments
 

--- a/test/ensJobPagesHelper.test.js
+++ b/test/ensJobPagesHelper.test.js
@@ -358,4 +358,67 @@ contract("ENSJobPages helper", (accounts) => {
     await helper.lockConfiguration({ from: owner });
   });
 
+  it("accepts NameWrapper getApproved authorization for wrapped roots", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const hookCaller = await MockHookCaller.new({ from: owner });
+
+    const helper = await ENSJobPages.new(
+      ens.address,
+      wrapper.address,
+      resolver.address,
+      rootNode,
+      rootName,
+      { from: owner }
+    );
+
+    await ens.setOwner(rootNode, wrapper.address, { from: owner });
+    await wrapper.setOwner(web3.utils.toBN(rootNode), owner, { from: owner });
+    await wrapper.setApproved(web3.utils.toBN(rootNode), helper.address, { from: owner });
+    await helper.setJobManager(hookCaller.address, { from: owner });
+    await helper.lockConfiguration({ from: owner });
+    await helper.createJobPage(77, employer, "ipfs://spec77", { from: owner });
+  });
+
+  it("keeps operator authorization path live when getApproved reverts", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const hookCaller = await MockHookCaller.new({ from: owner });
+
+    const helper = await ENSJobPages.new(
+      ens.address,
+      wrapper.address,
+      resolver.address,
+      rootNode,
+      rootName,
+      { from: owner }
+    );
+
+    await ens.setOwner(rootNode, wrapper.address, { from: owner });
+    await wrapper.setOwner(web3.utils.toBN(rootNode), owner, { from: owner });
+    await wrapper.setRevertGetApproved(true, { from: owner });
+    await wrapper.setApprovalForAll(helper.address, true, { from: owner });
+    await helper.setJobManager(hookCaller.address, { from: owner });
+    await helper.lockConfiguration({ from: owner });
+    await helper.createJobPage(78, employer, "ipfs://spec78", { from: owner });
+  });
+
+  it("rejects oversized root names to keep ENS URIs bounded", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const helper = await ENSJobPages.new(
+      ens.address,
+      "0x0000000000000000000000000000000000000000",
+      resolver.address,
+      rootNode,
+      rootName,
+      { from: owner }
+    );
+
+    const tooLongRoot = "a".repeat(241);
+    await expectRevert.unspecified(helper.setJobsRoot(rootNode, tooLongRoot, { from: owner }));
+  });
+
 });


### PR DESCRIPTION
### Motivation
- Prevent wrapped-root flows from being blocked when `NameWrapper.getApproved(tokenId)` reverts by restoring a best-effort read that falls back to operator (`isApprovedForAll`) checks.
- Allow testing of hostile/partial NameWrapper implementations that revert on token-level approval queries.
- Keep generated ENS documentation in sync with code so docs integrity checks pass.

### Description
- Made `getApproved(rootTokenId)` a best-effort call in `ENSJobPages` using `try/catch` and always falling back to `isApprovedForAll` when `getApproved` reverts or is unsupported, in both `_requireWrapperAuthorization` and `_isWrapperAuthorizationReady`.
- Added `revertGetApproved` toggle and `setRevertGetApproved` helper to `MockNameWrapper` to simulate wrappers that revert on `getApproved`.
- Added a deterministic regression test `keeps operator authorization path live when getApproved reverts` to `test/ensJobPagesHelper.test.js` proving operator approval still grants authorization when `getApproved` reverts, and preserved the `getApproved` success-path test.
- Regenerated `docs/REFERENCE/ENS_REFERENCE.md` to resolve stale docs and ensure `docs:check` passes.

### Testing
- Ran Truffle unit tests with `npx truffle test --network test test/ensJobPagesHelper.test.js test/ensAbiCompatibility.test.js test/bytecodeSize.test.js`, which completed successfully (`22 passing`).
- Regenerated and verified documentation with `npm run docs:ens:gen && npm run docs:check`, which passed ENS docs integrity checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699120707f7483338c903fc2108341fe)