### PR TITLE
Add deterministic regression coverage for ENS label validation and auth routing

### DIFF
--- a/test/ensLabelAuthRouting.regression.test.js
+++ b/test/ensLabelAuthRouting.regression.test.js
@@ -1,0 +1,110 @@
+const assert = require("assert");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const EnsLabelUtilsHarness = artifacts.require("EnsLabelUtilsHarness");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { expectCustomError } = require("./helpers/errors");
+
+const ZERO_ROOT = "0x" + "00".repeat(32);
+
+function singleLeafRoot(account) {
+  return web3.utils.soliditySha3({ type: "address", value: account });
+}
+
+contract("ENS label and auth routing deterministic regressions", (accounts) => {
+  const [owner, employer, agent, validator, outsider] = accounts;
+
+  describe("EnsLabelUtils.requireValidLabel", () => {
+    let harness;
+
+    beforeEach(async () => {
+      harness = await EnsLabelUtilsHarness.new({ from: owner });
+    });
+
+    it('accepts "alice"', async () => {
+      await harness.check("alice");
+    });
+
+    it("reverts with InvalidENSLabel for known invalid labels", async () => {
+      const invalidLabels = ["alice.bob", "", "A", "a_b", "-a", "a-", "a".repeat(64)];
+      for (const label of invalidLabels) {
+        await expectCustomError(harness.check(label), "InvalidENSLabel");
+      }
+    });
+  });
+
+  describe("Option A auth routing", () => {
+    let token;
+    let manager;
+    const payout = web3.utils.toWei("10");
+
+    beforeEach(async () => {
+      token = await MockERC20.new({ from: owner });
+
+      manager = await AGIJobManager.new(
+        ...buildInitConfig(
+          token.address,
+          "ipfs://base",
+          "0x0000000000000000000000000000000000000000",
+          "0x0000000000000000000000000000000000000000",
+          ZERO_ROOT,
+          ZERO_ROOT,
+          ZERO_ROOT,
+          ZERO_ROOT,
+          ZERO_ROOT,
+          ZERO_ROOT,
+        ),
+        { from: owner },
+      );
+
+      await token.mint(employer, payout, { from: owner });
+      await token.approve(manager.address, payout, { from: employer });
+
+      await token.mint(agent, web3.utils.toWei("100"), { from: owner });
+      await token.approve(manager.address, web3.utils.toWei("100"), { from: agent });
+
+      await token.mint(validator, web3.utils.toWei("100"), { from: owner });
+      await token.approve(manager.address, web3.utils.toWei("100"), { from: validator });
+
+      const agiType = await MockERC721.new({ from: owner });
+      await agiType.mint(agent, { from: owner });
+      await manager.addAGIType(agiType.address, 50, { from: owner });
+    });
+
+    it("allows Merkle-authorized agent to applyForJob with empty subdomain", async () => {
+      await manager.updateMerkleRoots(ZERO_ROOT, singleLeafRoot(agent), { from: owner });
+
+      const createReceipt = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+      const jobId = createReceipt.logs[0].args.jobId.toNumber();
+
+      await manager.applyForJob(jobId, "", [], { from: agent });
+
+      const job = await manager.getJobCore(jobId);
+      assert.equal(job.assignedAgent, agent, "agent should be assigned through Merkle auth");
+    });
+
+    it("allows Merkle-authorized validator to validateJob with empty subdomain", async () => {
+      await manager.updateMerkleRoots(singleLeafRoot(validator), singleLeafRoot(agent), { from: owner });
+
+      const createReceipt = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+      const jobId = createReceipt.logs[0].args.jobId.toNumber();
+
+      await manager.applyForJob(jobId, "", [], { from: agent });
+      await manager.requestJobCompletion(jobId, "ipfs-completion", { from: agent });
+      await manager.validateJob(jobId, "", [], { from: validator });
+
+      const validation = await manager.getJobValidation(jobId);
+      assert.equal(validation.validatorApprovals.toString(), "1", "validator Merkle vote should be recorded");
+    });
+
+    it("reverts with InvalidENSLabel (not NotAuthorized) for invalid ENS label on ENS path", async () => {
+      const createReceipt = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+      const jobId = createReceipt.logs[0].args.jobId.toNumber();
+
+      await expectCustomError(manager.applyForJob.call(jobId, "alice.bob", [], { from: outsider }), "InvalidENSLabel");
+    });
+  });
+});


### PR DESCRIPTION
### Motivation
- Close two remaining mainnet blockers by providing deterministic regression tests for ENS label validation and auth routing behavior. 
- Ensure the ENS label validator is byte-safe (no bytes1 vs string literal comparisons) and that invalid ENS labels are rejected before any ENS staticcalls. 
- Prove Option A routing (allowlist → Merkle → ENS) remains permissive for allowlist/Merkle paths while ENS path still validates labels early.

### Description
- Added a new deterministic test suite at `test/ensLabelAuthRouting.regression.test.js` that exercises `EnsLabelUtils.requireValidLabel` and Option A auth routing regressions. 
- Tests cover a passing label (`"alice"`) and the specified invalid inputs (`"alice.bob"`, `""`, `"A"`, `"a_b"`, `"-a"`, `"a-"`, 64-byte label) which must revert with `InvalidENSLabel`. 
- Routing tests use deterministic 1-leaf Merkle roots (`keccak256(abi.encodePacked(addr))` with empty proofs) and zeroed ENS/namewrapper addresses to isolate label validation and Merkle/allowlist behavior. 
- No behavioral changes to `AGIJobManager` routing or ENSOwnership semantics were made, and `EnsLabelUtils` is validated to use `bytes1` constants for comparisons (byte-safe) so no contract logic changes were required.

### Testing
- Ran the single-suite regression with `npx truffle test test/ensLabelAuthRouting.regression.test.js --network test` and observed the new tests pass. 
- Ran the full project test suite with `npm run test` and observed the full test run succeed (all tests passed and the bytecode size check passed). 
- All automated tests mentioned above completed successfully and are deterministic (single-leaf Merkle roots, empty proofs, no network forks or time-based flakiness).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6991da7ee69c8333a83be65921915e48)