### PR TITLE
test: assert ENS auth grant→revoke transition in unwrapped-root hooks

### DIFF
--- a/test/ensHooks.integration.test.js
+++ b/test/ensHooks.integration.test.js
@@ -11,13 +11,22 @@ const MockPublicResolver = artifacts.require('MockPublicResolver');
 const MockERC721 = artifacts.require('MockERC721');
 
 const { buildInitConfig } = require('./helpers/deploy');
-const { namehash, rootNode } = require('./helpers/ens');
+const { namehash, rootNode, subnode } = require('./helpers/ens');
 
 const leafFor = (address) => Buffer.from(web3.utils.soliditySha3({ type: 'address', value: address }).slice(2), 'hex');
 const mkTree = (list) => { const t = new MerkleTree(list.map(leafFor), keccak256, { sortPairs: true }); return { root: t.getHexRoot(), proofFor: (a) => t.getHexProof(leafFor(a)) }; };
 
 contract('ensHooks.integration', (accounts) => {
   const [owner, employer, agent, validator] = accounts;
+
+  async function seedSettledJob({ manager, token, payout, proof }) {
+    await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
+    await manager.applyForJob(0, 'agent', proof, { from: agent });
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await time.increase(2);
+    await manager.finalizeJob(0, { from: employer });
+  }
 
   it('invokes ENS hooks best-effort and lockJobENS fuse burn path', async () => {
     const token = await MockERC20.new();
@@ -41,12 +50,7 @@ contract('ensHooks.integration', (accounts) => {
     await token.mint(validator, payout); await token.approve(manager.address, payout, { from: validator });
     await token.mint(agent, payout); await token.approve(manager.address, payout, { from: agent });
 
-    await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
-    await manager.applyForJob(0, 'agent', mkTree([agent]).proofFor(agent), { from: agent });
-    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
-    await manager.setCompletionReviewPeriod(1, { from: owner });
-    await time.increase(2);
-    await manager.finalizeJob(0, { from: employer });
+    await seedSettledJob({ manager, token, payout, proof: mkTree([agent]).proofFor(agent) });
 
     const lockReceipt = await manager.lockJobENS(0, true, { from: owner });
     await expectEvent.inTransaction(lockReceipt.tx, pages, 'JobENSLocked', {
@@ -56,5 +60,98 @@ contract('ensHooks.integration', (accounts) => {
     assert.equal((await wrapper.setChildFusesCalls()).toString(), '1');
     assert.equal((await wrapper.lastParentNode()), rootNodeHash);
     assert.equal((await wrapper.lastLabelhash()), web3.utils.keccak256('job-0'));
+  });
+
+  it('supports unwrapped-root mode across CREATE/ASSIGN/COMPLETION/REVOKE/LOCK hooks', async () => {
+    const token = await MockERC20.new();
+    const ens = await MockENSRegistry.new();
+    const wrapper = await MockNameWrapper.new();
+    const resolver = await MockPublicResolver.new();
+    const nft = await MockERC721.new();
+
+    const rootName = 'jobs.alpha.agi.eth';
+    const rootNodeHash = namehash(rootName);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, wrapper.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), mkTree([validator]).root, mkTree([agent]).root), { from: owner });
+    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, rootNodeHash, rootName, { from: owner });
+    await pages.setJobManager(manager.address, { from: owner });
+    await manager.setEnsJobPages(pages.address, { from: owner });
+    await ens.setOwner(rootNodeHash, pages.address);
+
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent);
+    const payout = new BN(web3.utils.toWei('1000'));
+    await token.mint(employer, payout);
+    await token.approve(manager.address, payout, { from: employer });
+    await token.mint(validator, payout);
+    await token.approve(manager.address, payout, { from: validator });
+    await token.mint(agent, payout);
+    await token.approve(manager.address, payout, { from: agent });
+
+    const proof = mkTree([agent]).proofFor(agent);
+    await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
+
+    const node = subnode(rootNodeHash, 'job-0');
+    const employerAuthAfterCreate = await resolver.isAuthorised(node, employer);
+    const agentAuthAfterCreate = await resolver.isAuthorised(node, agent);
+    assert.equal(employerAuthAfterCreate, true, 'CREATE hook must authorise employer');
+    assert.equal(agentAuthAfterCreate, false, 'agent should not be authorised before ASSIGN');
+
+    await manager.applyForJob(0, 'agent', proof, { from: agent });
+    const agentAuthAfterAssign = await resolver.isAuthorised(node, agent);
+    assert.equal(agentAuthAfterAssign, true, 'ASSIGN hook must authorise agent');
+
+    await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+    await manager.setCompletionReviewPeriod(1, { from: owner });
+    await time.increase(2);
+    await manager.finalizeJob(0, { from: employer });
+
+    const employerAuthAfterRevoke = await resolver.isAuthorised(node, employer);
+    const agentAuthAfterRevoke = await resolver.isAuthorised(node, agent);
+    assert.equal(employerAuthAfterRevoke, false, 'REVOKE hook must de-authorise employer');
+    assert.equal(agentAuthAfterRevoke, false, 'REVOKE hook must de-authorise agent');
+
+    const lockReceipt = await manager.lockJobENS(0, false, { from: owner });
+    const employerAuthAfterLock = await resolver.isAuthorised(node, employer);
+    const agentAuthAfterLock = await resolver.isAuthorised(node, agent);
+    assert.equal(employerAuthAfterLock, false, 'LOCK hook must keep employer de-authorised');
+    assert.equal(agentAuthAfterLock, false, 'LOCK hook must keep agent de-authorised');
+    await expectEvent.inTransaction(lockReceipt.tx, pages, 'JobENSLocked', {
+      jobId: new BN(0),
+      fusesBurned: false,
+    });
+  });
+
+  it('keeps AGIJobManager flows live when resolver writes revert (best-effort degradation)', async () => {
+    const token = await MockERC20.new();
+    const ens = await MockENSRegistry.new();
+    const wrapper = await MockNameWrapper.new();
+    const resolver = await MockPublicResolver.new();
+    const nft = await MockERC721.new();
+
+    const rootName = 'jobs.alpha.agi.eth';
+    const rootNodeHash = namehash(rootName);
+    const manager = await AGIJobManager.new(...buildInitConfig(token.address, 'ipfs://', ens.address, wrapper.address, rootNode('club'), rootNode('agent'), rootNode('club'), rootNode('agent'), mkTree([validator]).root, mkTree([agent]).root), { from: owner });
+    const pages = await ENSJobPages.new(ens.address, wrapper.address, resolver.address, rootNodeHash, rootName, { from: owner });
+    await pages.setJobManager(manager.address, { from: owner });
+    await manager.setEnsJobPages(pages.address, { from: owner });
+    await ens.setOwner(rootNodeHash, pages.address);
+    await resolver.setRevertSetAuthorisation(true);
+    await resolver.setRevertSetText(true);
+
+    await manager.addAGIType(nft.address, 90, { from: owner });
+    await nft.mint(agent);
+    const payout = new BN(web3.utils.toWei('1000'));
+    await token.mint(employer, payout);
+    await token.approve(manager.address, payout, { from: employer });
+    await token.mint(agent, payout);
+    await token.approve(manager.address, payout, { from: agent });
+
+    const createTx = await manager.createJob('QmSpec', payout, 5000, 'd', { from: employer });
+    const applyTx = await manager.applyForJob(0, 'agent', mkTree([agent]).proofFor(agent), { from: agent });
+    const completionTx = await manager.requestJobCompletion(0, 'QmDone', { from: agent });
+
+    await expectEvent.inTransaction(createTx.tx, pages, 'ENSHookBestEffortFailure', { hook: new BN(1) });
+    await expectEvent.inTransaction(applyTx.tx, pages, 'ENSHookBestEffortFailure', { hook: new BN(2) });
+    await expectEvent.inTransaction(completionTx.tx, pages, 'ENSHookBestEffortFailure', { hook: new BN(3) });
   });
 });


### PR DESCRIPTION
### Motivation
- Strengthen the unwrapped-root ENS hook integration test so it actually proves authorisation lifecycle transitions instead of relying on default `false` resolver values.
- Reduce duplicated lifecycle setup across ENS hook tests for clarity and to make the suite easier to reason about.

### Description
- Added a `seedSettledJob({ manager, token, payout, proof })` helper to centralize CREATE/APPLY/COMPLETE/FINALIZE test setup and avoid duplication in `test/ensHooks.integration.test.js`.
- Imported `subnode` from `./helpers/ens` and updated the unwrapped-root test to assert resolver auth state after each lifecycle event: post-`CREATE` authorises the employer, post-`ASSIGN` authorises the agent, post-`FINALIZE` (REVOKE) de-authorises both, and `lockJobENS` preserves the de-authorised state.
- Rewrote the previous post-lock-only assertions to explicit before/after checks to close the false-positive gap identified in review.

### Testing
- Ran `npx truffle test --network test test/ensHooks.integration.test.js` and observed `3 passing` for the ENS hooks integration file.
- Ran `npx truffle test --network test test/ensAbiCompatibility.test.js test/ensJobPagesHelper.test.js` and observed `24 passing` for the targeted ENS helper/ABI tests.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699200454fc08333958c6b746dbeafac)