### PR TITLE
Harden utils integration regressions for ENS labels and strict ERC20 failure handling

### DIFF
--- a/contracts/test/RevertingERC20.sol
+++ b/contracts/test/RevertingERC20.sol
@@ -1,0 +1,16 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.19;
+
+contract RevertingERC20 {
+    function transfer(address, uint256) external pure returns (bool) {
+        revert();
+    }
+
+    function transferFrom(address, address, uint256) external pure returns (bool) {
+        revert();
+    }
+
+    function balanceOf(address) external pure returns (uint256) {
+        return 0;
+    }
+}

--- a/test/utils.uri-transfer.test.js
+++ b/test/utils.uri-transfer.test.js
@@ -8,6 +8,7 @@ const FeeOnTransferToken = artifacts.require("FeeOnTransferToken");
 const MalformedReturnERC20 = artifacts.require("MalformedReturnERC20");
 const RevertingBalanceOfERC20 = artifacts.require("RevertingBalanceOfERC20");
 const InvalidBoolReturnERC20 = artifacts.require("InvalidBoolReturnERC20");
+const RevertingERC20 = artifacts.require("RevertingERC20");
 const BondMath = artifacts.require("BondMath");
 const ENSOwnership = artifacts.require("ENSOwnership");
 const ReputationMath = artifacts.require("ReputationMath");
@@ -119,6 +120,18 @@ contract("Utility libraries: UriUtils + TransferUtils", (accounts) => {
       );
       await expectRevert.unspecified(
         harness.safeTransferFromExact(failing.address, owner, recipient, web3.utils.toWei("3"), { from: owner })
+      );
+    });
+
+    it("reverts when token transfer/transferFrom calls revert", async () => {
+      const token = await RevertingERC20.new({ from: owner });
+
+      await expectRevert.unspecified(
+        harness.safeTransfer(token.address, recipient, web3.utils.toWei("1"), { from: owner })
+      );
+
+      await expectRevert.unspecified(
+        harness.safeTransferFromExact(token.address, owner, recipient, web3.utils.toWei("1"), { from: owner })
       );
     });
 


### PR DESCRIPTION
### Motivation
- Tighten deterministic test coverage around ENS label validation and ENS-routing to guarantee invalid labels fail fast and valid labels reach the ENS ownership checks used by `AGIJobManager`.
- Verify `TransferUtils` fails closed against hostile ERC20 implementations that revert in `transfer`/`transferFrom` so AGI token flows cannot be silently corrupted.
- Make no behavioral changes to production utils or `AGIJobManager` runtime logic to avoid accidental regressions or bytecode inflation.

### Description
- Added a hostile ERC20 mock `contracts/test/RevertingERC20.sol` that always reverts on `transfer`/`transferFrom` to exercise reverting-token failure modes.
- Extended ENS label regression tests in `test/ensLabelAuthRouting.regression.test.js` to accept additional valid labels (`a`, `a-1`, `0`, `abc123`) and to reject extra edge cases (`.`, `..`, `a..b`) under `InvalidENSLabel`, and added a routing assertion that a valid label (`alice`) proceeds to the ENS verification path (returns `NotAuthorized` when ownership is absent).
- Extended `test/utils.uri-transfer.test.js` to assert that `TransferUtils.safeTransfer` and `TransferUtils.safeTransferFromExact` revert when token `transfer`/`transferFrom` calls themselves revert.
- No changes were made to production utility libraries (`contracts/utils/*`) or `contracts/AGIJobManager.sol` (this PR only adds tests/mocks and does not change library code or external linking strategy).

### Testing
- Ran `npx truffle compile --all` successfully using Truffle's solc (solc 0.8.23) and wrote artifacts to `build/contracts`.
- Ran targeted Truffle tests and the full test suite via `npx truffle test` / `npm test`; the test run in this environment completed successfully (all tests passed; full suite report: 345 passing).
- The repository's existing bytecode size guard passed and reports `AGIJobManager deployedBytecode size: 24526 bytes` which is <= the EIP-170 limit of 24,576 bytes.
- Attempted `forge test` but `forge` is not available in this container (so Foundry tests were not executed here); recommend running `forge test` in CI or locally where Foundry is installed to complete dual-compiler validation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699211938dd08333b50f728a4f97a5c0)