### PR TITLE
test: tighten ENS ABI/selectors and auth-routing regressions

### DIFF
--- a/test/ensAbiCompatibility.test.js
+++ b/test/ensAbiCompatibility.test.js
@@ -55,6 +55,26 @@ contract("ENS ABI compatibility + URI path", (accounts) => {
     await time.increase(reviewPeriod.addn(1));
   }
 
+  it("keccak selectors and hook identifiers are fixed for AGIJobManager assembly integration", async () => {
+    const selectors = {
+      handleHook: web3.utils.keccak256("handleHook(uint8,uint256)").slice(0, 10),
+      jobEnsURI: web3.utils.keccak256("jobEnsURI(uint256)").slice(0, 10),
+    };
+
+    assert.equal(selectors.handleHook, "0x1f76f7a2", "handleHook selector drifted");
+    assert.equal(selectors.jobEnsURI, "0x751809b4", "jobEnsURI selector drifted");
+
+    const HOOKS = {
+      CREATE: 1,
+      ASSIGN: 2,
+      COMPLETION: 3,
+      REVOKE: 4,
+      LOCK: 5,
+      LOCK_BURN: 6,
+    };
+    assert.deepEqual(Object.values(HOOKS), [1, 2, 3, 4, 5, 6], "hook IDs must remain stable");
+  });
+
   it("matches required selectors, calldata size, and string ABI shape", async () => {
     const expectedHandleSelector = "0x1f76f7a2";
     const expectedJobUriSelector = "0x751809b4";

--- a/test/ensLabelAuthRouting.regression.test.js
+++ b/test/ensLabelAuthRouting.regression.test.js
@@ -92,6 +92,18 @@ contract("ENS label and auth routing deterministic regressions", (accounts) => {
       assert.equal(job.assignedAgent, agent, "agent should be assigned through Merkle auth");
     });
 
+    it("allows Merkle-authorized agent to applyForJob with garbage subdomain", async () => {
+      await manager.updateMerkleRoots(ZERO_ROOT, singleLeafRoot(agent), { from: owner });
+
+      const createReceipt = await manager.createJob("ipfs-job", payout, 3600, "details", { from: employer });
+      const jobId = createReceipt.logs[0].args.jobId.toNumber();
+
+      await manager.applyForJob(jobId, "not-an-ens-label!!!", [], { from: agent });
+
+      const job = await manager.getJobCore(jobId);
+      assert.equal(job.assignedAgent, agent, "agent should still route through Merkle auth");
+    });
+
     it("allows Merkle-authorized validator to validateJob with empty subdomain", async () => {
       await manager.updateMerkleRoots(singleLeafRoot(validator), singleLeafRoot(agent), { from: owner });
 

--- a/test/invariants.libs.test.js
+++ b/test/invariants.libs.test.js
@@ -265,6 +265,20 @@ contract("Utility library invariants", (accounts) => {
     assert.equal(ok, false, "reverting resolver.addr should fail closed");
   });
 
+  it("reverts InvalidENSLabel before any ENS staticcalls on invalid labels", async () => {
+    const ens = await RevertingENSRegistry.new({ from: owner });
+    const wrapper = await RevertingNameWrapper.new({ from: owner });
+    const root = rootNode("club-root");
+
+    await ens.setRevertResolver(true, { from: owner });
+    await wrapper.setRevertOwnerOf(true, { from: owner });
+
+    await expectCustomError(
+      harness.verifyENSOwnership.call(ens.address, wrapper.address, claimant, "alice.bob", root),
+      "InvalidENSLabel"
+    );
+  });
+
   it("fails closed on malformed ENS/resolver/name-wrapper return data", async () => {
     const ens = await MalformedENSRegistry.new({ from: owner });
     const wrapper = await MalformedNameWrapper.new({ from: owner });


### PR DESCRIPTION
### Motivation
- Ensure AGIJobManager's low-level assembly integration with ENSJobPages is selector- and calldata-exact and cannot silently drift. 
- Prove ENS routing is defensive: Merkle-based auth must remain usable even when subdomain parsing is garbage and ENS ownership checks must validate labels before issuing external staticcalls. 
- Add deterministic regression tests rather than changing runtime contracts to guarantee mainnet-grade behavior without forking live chain state.

### Description
- Added a deterministic test in `test/ensAbiCompatibility.test.js` that asserts the keccak selectors for `handleHook(uint8,uint256)` and `jobEnsURI(uint256)` exactly match `0x1f76f7a2` and `0x751809b4` respectively, and added a hard assertion that hook IDs `CREATE..LOCK_BURN` map to `1..6`.
- Extended `test/ensLabelAuthRouting.regression.test.js` with a case proving a Merkle-authorized agent can `applyForJob` when passed a garbage subdomain (ensuring Merkle path bypasses ENS label validation as intended).
- Extended `test/invariants.libs.test.js` to add a regression proving `ENSOwnership.verifyENSOwnership` reverts with `InvalidENSLabel` before issuing any ENS staticcalls when given an invalid label, even if ENS/name-wrapper/resolver mocks are configured to revert.
- No Solidity runtime contracts were modified; this PR is focused on tightening test coverage and regression guards.

### Testing
- Ran targeted Truffle tests for the modified suites with deterministic Ganache network and observed all tests passing: `npx truffle test test/ensLabelAuthRouting.regression.test.js test/invariants.libs.test.js test/ensAbiCompatibility.test.js --network test` (31 passing).
- Compiled contracts via Truffle: `truffle compile --all` — compile succeeded using `solc 0.8.23`.
- Confirmed AGIJobManager runtime bytecode is within EIP-170 limit via `node scripts/check-contract-sizes.js` which reported `AGIJobManager deployedBytecode size: 24526 bytes` (<= 24,575 B safety threshold in repo script).
- Note: `forge build` was attempted in CI validation but `forge` is not available in the environment (`bash: command not found: forge`); this does not affect the deterministic Truffle test pass reported above.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992201f510883339b4e14cfa5c9dbae)