### PR TITLE
test: strengthen ENS label hardening vectors

### DIFF
--- a/test/ensLabelHardening.test.js
+++ b/test/ensLabelHardening.test.js
@@ -30,12 +30,14 @@ contract("ENS label hardening", (accounts) => {
       harness = await EnsLabelUtilsHarness.new({ from: owner });
     });
 
-    it("accepts alice", async () => {
-      await harness.check("alice");
+    it("accepts deterministic valid labels", async () => {
+      for (const label of ["alice", "a", "a-1", "0", "abc123"]) {
+        await harness.check(label);
+      }
     });
 
     it("rejects deterministic invalid labels", async () => {
-      for (const label of ["alice.bob", "", "A", "a_b", "-a", "a-"]) {
+      for (const label of ["", "alice.bob", "A", "a_b", "-a", "a-", ".", "..", "a..b", "a b", "\n"]) {
         await expectCustomError(harness.check(label), "InvalidENSLabel");
       }
 


### PR DESCRIPTION
### Motivation
- Increase deterministic coverage for ENS label validation to prevent ENS routing surprises by exercising a representative valid set and additional malformed inputs that previously went untested.

### Description
- Update `test/ensLabelHardening.test.js` to assert multiple deterministic valid labels (`"alice","a","a-1","0","abc123"`) and to expand invalid-label vectors to include dot-only/multi-dot and whitespace/newline cases (`".","..","a..b","a b","\n"`) while preserving the `InvalidENSLabel` assertions and 64-byte overflow check.

### Testing
- Ran the Truffle test matrix against selected ENS/util test suites with a local Ganache node and `npx truffle test --network development test/ensLabelHardening.test.js test/ensAbiCompatibility.test.js test/utils.uri-transfer.test.js test/invariants.libs.test.js test/ensHooks.integration.test.js test/bytecodeSize.test.js`, which passed (51 passing) and `npx truffle compile` completed successfully; `npm run size` reports `AGIJobManager` runtime bytecode 23935 bytes (<= 24576).
- Note: `forge test` was not available in the environment (`forge: command not found`), so Foundry-side tests were not executed here.

Commands to reproduce locally:
- `npx ganache --wallet.mnemonic "test test test test test test test test test test test junk" --chain.chainId 1337 --server.port 8545 --quiet &`
- `npx truffle test --network development test/ensLabelHardening.test.js test/ensAbiCompatibility.test.js test/utils.uri-transfer.test.js test/invariants.libs.test.js test/ensHooks.integration.test.js test/bytecodeSize.test.js`
- `npx truffle compile`
- `npm run size`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922eecbf8483339d22b5b3daef879d)