### PR TITLE
test: expand ENS label invalid-case coverage

### DIFF
--- a/test/ensLabelAuthRouting.regression.test.js
+++ b/test/ensLabelAuthRouting.regression.test.js
@@ -35,7 +35,20 @@ contract("ENS label and auth routing deterministic regressions", (accounts) => {
     });
 
     it("reverts with InvalidENSLabel for known invalid labels", async () => {
-      const invalidLabels = ["alice.bob", "", "A", "a_b", "-a", "a-", ".", "..", "a..b", "a".repeat(64)];
+      const invalidLabels = [
+        "",
+        "alice.bob",
+        "A",
+        "a_b",
+        "-a",
+        "a-",
+        ".",
+        "..",
+        "a..b",
+        "a b",
+        "\n",
+        "a".repeat(64),
+      ];
       for (const label of invalidLabels) {
         await expectCustomError(harness.check(label), "InvalidENSLabel");
       }

--- a/test/ensLabelHardening.test.js
+++ b/test/ensLabelHardening.test.js
@@ -35,7 +35,7 @@ contract("ENS label hardening", (accounts) => {
     });
 
     it("rejects deterministic invalid labels", async () => {
-      for (const label of ["alice.bob", "", "A", "a_b", "-a", "a-"]) {
+      for (const label of ["", "alice.bob", "A", "a_b", "-a", "a-", ".", "..", "a..b", "a b", "\n"]) {
         await expectCustomError(harness.check(label), "InvalidENSLabel");
       }
 


### PR DESCRIPTION
### Motivation

- Tighten deterministic test coverage for ENS label validation to include whitespace and control-character edge cases so the strict `[a-z0-9-]` policy is exhaustively asserted before any ENS staticcalls.

### Description

- Expanded invalid-label test vectors in `test/ensLabelAuthRouting.regression.test.js` to include `"a b"` and `"\n"` and reorganized the list for clarity.
- Expanded invalid-label test vectors in `test/ensLabelHardening.test.js` to include dotted edge cases (`".", "..", "a..b"`) and whitespace/control inputs (`"a b", "\n"`) while preserving the existing max-length check.

### Testing

- Ran the full JS test suite with `npm test`, which executed Truffle + node tests and returned `345 passing` and the repository bytecode size checks passing (AGIJobManager runtime bytecode 23935 bytes), all green.
- Noted `forge test` is not available in this environment (`bash: command not found: forge`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69922eecbf8483339d22b5b3daef879d)