### PR TITLE
test: enforce exact EIP-170 bytecode limit and strengthen governance-lock regression

### DIFF
--- a/test/bytecodeSize.test.js
+++ b/test/bytecodeSize.test.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 
-const MAX_DEPLOYED_BYTES = 24575;
+const MAX_DEPLOYED_BYTES = 24576;
 
 function deployedSizeBytes(artifact) {
   const deployedBytecode =

--- a/test/mainnetGovernanceAndOps.regression.test.js
+++ b/test/mainnetGovernanceAndOps.regression.test.js
@@ -100,6 +100,22 @@ contract('mainnet governance + ops regressions', (accounts) => {
     await expectCustomError(ctx.manager.setValidatorSlashBps.call(100, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setChallengePeriodAfterApproval.call(1, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.updateMerkleRoots.call(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner }), 'InvalidState');
+
+    await ctx.manager.requestJobCompletion(0, 'ipfs://done', { from: agent });
+    const review = await ctx.manager.completionReviewPeriod();
+    await time.increase(review.addn(1));
+    await ctx.manager.finalizeJob(0, { from: employer });
+
+    await ctx.manager.updateMerkleRoots(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner });
+    await ctx.manager.setVoteQuorum((await ctx.manager.voteQuorum()).toString(), { from: owner });
+    await ctx.manager.setRequiredValidatorApprovals((await ctx.manager.requiredValidatorApprovals()).toString(), { from: owner });
+    await ctx.manager.setRequiredValidatorDisapprovals((await ctx.manager.requiredValidatorDisapprovals()).toString(), { from: owner });
+    await ctx.manager.setCompletionReviewPeriod((await ctx.manager.completionReviewPeriod()).toString(), { from: owner });
+    await ctx.manager.setDisputeReviewPeriod((await ctx.manager.disputeReviewPeriod()).toString(), { from: owner });
+    await ctx.manager.setValidatorSlashBps((await ctx.manager.validatorSlashBps()).toString(), { from: owner });
+    await ctx.manager.setChallengePeriodAfterApproval((await ctx.manager.challengePeriodAfterApproval()).toString(), {
+      from: owner,
+    });
   });
 
   it('enforces MAX_JOB_DETAILS_BYTES during createJob', async () => {


### PR DESCRIPTION
### Motivation
- Tighten deterministic merge gates used to certify mainnet deployability by enforcing the exact EIP-170 runtime ceiling and verify governance knobs behave correctly while funds are in-flight and after settlement.

### Description
- Update the bytecode-size guard test to use `MAX_DEPLOYED_BYTES = 24576` to match the EIP-170 runtime-code upper bound by one byte. (`test/bytecodeSize.test.js`)
- Extend the governance/ops regression test to exercise the full lock lifecycle by finalizing an in-flight job deterministically and then asserting the same owner-setters that previously reverted now succeed, proving no permanent admin lock. (`test/mainnetGovernanceAndOps.regression.test.js`)

### Testing
- Ran targeted Truffle tests: `npx truffle test test/mainnetGovernanceAndOps.regression.test.js test/ensAbiCompatibility.test.js test/bytecodeSize.test.js --network test`, and all tests in that run passed (reported as 14 passing for the selected suites). 
- Ran the contract size checker `node scripts/check-contract-sizes.js` which reports `AGIJobManager deployedBytecode size: 24556 bytes`, which is below the `24576` byte limit. 
- `forge test` was attempted but the `forge` binary is not available in this environment; `npm test` was attempted but the full run was not completed here due to long-running compile steps, while the focused runs above succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992952748148333ba6d2e7bdd9a8a1c)