### PR TITLE
Harden reputation saturation and deterministic mainnet safety gates

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1002,7 +1002,10 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
 
     function enforceReputationGrowth(address _user, uint256 _points) internal {
         uint256 current = reputation[_user];
-        uint256 updated = current + _points;
+        uint256 updated;
+        unchecked {
+            updated = current + _points;
+        }
         if (updated < current || updated > 88888) {
             updated = 88888;
         }

--- a/test/bytecodeSize.test.js
+++ b/test/bytecodeSize.test.js
@@ -2,7 +2,7 @@ const assert = require("assert");
 const fs = require("fs");
 const path = require("path");
 
-const MAX_DEPLOYED_BYTES = 24575;
+const MAX_DEPLOYED_BYTES = 24576;
 
 function deployedSizeBytes(artifact) {
   const deployedBytecode =
@@ -28,7 +28,7 @@ function loadArtifact(name) {
 }
 
 contract("Bytecode size guard", () => {
-  it("keeps deployed bytecode within the EIP-170 safety margin", () => {
+  it("keeps deployed bytecode at or below the EIP-170 runtime code size limit", () => {
     ["AGIJobManager"].forEach((name) => {
       const artifact = loadArtifact(name);
       if (!artifact) {


### PR DESCRIPTION
### Motivation

- Prevent reputation decreases and wrap-related surprises by making reputation updates overflow-safe and strictly monotone when adding positive points. 
- Avoid operator footguns by making governance/auth configuration setters deterministically locked while funds/bonds are in-flight and demonstrably reinstated once obligations settle. 
- Ensure CI merge-gate checks assert the exact EIP-170 runtime code-size limit to prevent accidental mainnet-un-deployable regressions.

### Description

- Replace checked addition in `enforceReputationGrowth` with an `unchecked` add and explicit saturation to `88888`, then store and emit `ReputationUpdated` (no new storage or external APIs). (contracts/AGIJobManager.sol)
- Extend `test/mainnetGovernanceAndOps.regression.test.js` to (a) include a max-uint256-sized reputation grant to validate deterministic saturation, and (b) prove protected owner setters revert while escrow/bonds are nonzero and succeed again after settling the in-flight job. (test/mainnetGovernanceAndOps.regression.test.js)
- Update the bytecode merge-gate test to assert `<= 24,576` bytes and clarify the test description. (test/bytecodeSize.test.js)

### Testing

- Ran the full automated suite via `npm test` (this runs `truffle compile --all && truffle test --network test && node test/AGIJobManager.test.js && node scripts/check-contract-sizes.js`), and all tests passed: the suite reported `351 passing` and the added regression tests succeeded. 
- The runtime deployed bytecode for `AGIJobManager` observed by the size check is `24533` bytes which is at or below the `24,576`-byte EIP-170 limit. 
- Attempted `forge test` in this environment but `forge` was not available (`bash: command not found: forge`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6992952748148333ba6d2e7bdd9a8a1c)