### PR TITLE
Etherscan-first docs + offline Etherscan helper CLIs (merkle, advisor, paste-ready CLI)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,412 +1,76 @@
-# AGIJobManager ALPHA v0
+# AGIJobManager
 
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Solidity](https://img.shields.io/badge/solidity-0.8.19-363636.svg)](contracts/AGIJobManager.sol)
-[![Truffle](https://img.shields.io/badge/truffle-5.x-3fe0c5.svg)](https://trufflesuite.com/)
 [![CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml)
 
-**AGIJobManager** is MONTREAL.AI’s on-chain enforcement layer for agent–employer workflows: validator-gated job escrow, payouts, dispute resolution, and reputation tracking, with ENS/Merkle role gating and ERC‑721 job NFT issuance. It is the *enforcement* half of a “Full‑Stack Trust Layer for AI Agents.”
+AGIJobManager is an owner-operated on-chain escrow workflow for AI jobs: employers fund jobs, agents do work, validators vote, moderators resolve disputes, and the contract settles payouts/refunds.
 
-> **Status / Caution**: Experimental research software. Treat deployments as high-risk until you have performed independent security review, validated parameters, and ensured operational readiness. No public audit report is included in this repository.
+## Start here
 
+- Etherscan step-by-step guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
+- Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
+- Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
+- Etherscan verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
+- User FAQ: [`docs/FAQ.md`](docs/FAQ.md)
 
-## Start here (Etherscan-first)
+## Roles (plain language)
 
-- **Etherscan user guide (all roles):** [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
-- **Owner/operator runbook:** [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
-- **Verification guide:** [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
+- **Employer**: funds escrow and creates jobs, can cancel before assignment, can finalize/dispute once completion is requested.
+- **Agent**: applies for jobs through allowlist/Merkle/ENS authorization, may post a bond, requests completion with a URI.
+- **Validator**: authorized reviewer that votes approve/disapprove and may post a per-vote bond.
+- **Moderator**: resolves active disputes with `resolveDisputeWithCode`.
+- **Owner**: configures risk controls and operations.
 
-## Role overview (plain language)
+## Trust model (important)
 
-- **Employer**: funds jobs, hires agents, can cancel before assignment, can finalize/dispute after completion request.
-- **Agent**: applies to jobs (allowlist/Merkle/ENS-gated), posts bond when required, submits completion URI.
-- **Validator**: votes approve/disapprove during review window, posts per-vote bond, may earn rewards or be slashed.
-- **Moderator**: resolves active disputes with explicit outcome codes.
-- **Owner**: operates risk controls (pause switches, parameters, allowlists, moderators, ENS wiring, treasury withdrawal of non-escrow funds).
+This is **not trustless governance**. The owner is privileged and can:
 
-## Trust model (one paragraph)
+- pause/unpause intake (`pause`, `unpause`) and settlement (`setSettlementPaused`, `pauseAll`, `unpauseAll`),
+- set core risk parameters (quorum, approval/disapproval thresholds, bond/slash params, windows, limits),
+- manage moderators, allowlists (`additionalAgents`, `additionalValidators`) and blacklists,
+- update identity wiring before lock (AGI token, ENS registry, NameWrapper, roots, ENSJobPages),
+- withdraw only treasury surplus with `withdrawAGI` (while paused, solvency-checked via `withdrawableAGI`),
+- call rescue functions (high risk; runbook process required).
 
-AGIJobManager is intentionally **owner-operated** rather than trustless: owner and moderators have meaningful operational authority. The owner can pause/unpause intake, pause settlement, adjust core risk parameters (quorum, thresholds, review windows, bond/slash parameters), manage allowlists/blacklists and moderators, manage ENS identity wiring, and withdraw only treasury surplus that remains after escrow and bond locks. Users should treat this as a business-operated escrow system with transparent on-chain controls, not a decentralized court.
+Users should assume a business-operated escrow with transparent on-chain controls.
 
-## Quick glossary
+## One-screen quickstart (Etherscan)
 
-- **jobId**: numeric identifier for each job.
-- **payout**: escrowed AGI amount for a job (token base units).
-- **duration**: work window in seconds from assignment.
-- **completion review period**: validator voting window after completion request.
-- **dispute review period**: stale-dispute timeout before owner can resolve stale disputes.
-- **quorum**: minimum total validator votes considered sufficient participation.
-- **bond**: AGI amount staked by agents/validators/dispute initiator.
-- **slashing**: penalty reducing bond for incorrect validator side.
+1. **Approve AGI** on the AGI token contract: `approve(AGIJobManagerAddress, amountInBaseUnits)`.
+2. Employer: **create job** with `createJob(jobSpecURI, payout, duration, details)`.
+3. Agent: **apply** with `applyForJob(jobId, subdomain, proof)`.
+4. Agent: **request completion** with `requestJobCompletion(jobId, completionURI)`.
+5. Validators: vote with `validateJob(...)` / `disapproveJob(...)` during review window.
+6. Employer/agent: **finalize** with `finalizeJob(jobId)` after windows; if needed call `disputeJob(jobId)`.
+7. Moderator (if disputed): resolve with `resolveDisputeWithCode(jobId, code, reason)`.
 
+## Glossary
 
-## At a glance
+- **jobId**: integer ID for each job.
+- **payout**: escrow amount in token base units (usually 18 decimals).
+- **duration**: seconds from assignment to expected completion.
+- **completion review window**: `completionReviewPeriod` after completion request.
+- **quorum**: `voteQuorum`, minimum total validator votes for normal finalize logic.
+- **bond**: stake posted by agent/validator/dispute initiator.
+- **slashing**: bond penalty applied to validators on incorrect side.
 
-**What it is**
-- **Job escrow & settlement engine**: employer-funded jobs, agent assignment, validator approvals/disapprovals (thresholded), moderator dispute resolution, payouts/refunds.
-- **Reputation mapping**: on-chain reputation updates for agents and validators derived from job outcomes.
-- **Job NFT issuance**: mints an ERC‑721 “job NFT” on completion for the employer.
-- **Trust gating**: role eligibility enforced via explicit allowlists, Merkle proofs, and ENS/NameWrapper/Resolver ownership checks.
+## Tooling for low-touch operations
 
-**What it is NOT**
-- **Not an on-chain ERC‑8004 implementation**: ERC‑8004 is consumed off-chain; this repo does not integrate it on-chain.
-- **Not a generalized identity or reputation registry**: only contract-local reputation mappings and ENS/Merkle gating are provided.
-- **Not a generalized NFT marketplace**: this contract does not embed a marketplace; NFTs trade externally via standard ERC‑721 approvals and transfers.
-- **Not a decentralized court or DAO**: moderators and the owner have significant authority; validator membership remains permissioned even with bonded voting.
+- Merkle root/proof generator: `scripts/merkle/export_merkle_proofs.js`
+- Etherscan paste helper: `scripts/etherscan/cli.js`
+- Offline job-state advisor: `scripts/advisor/job_state_advisor.js`
 
-## Important trust notes
-- **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
-- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, `lockedAgentBonds`, `lockedValidatorBonds`, and `lockedDisputeBonds`) and only while paused; escrowed funds and bonds are not withdrawable.
-- **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available.
-- **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
-- **Validator incentives**: validators post a bond per vote (capped at payout), earn rewards when their vote matches the final outcome, and are slashed when they are wrong.
-- **Agent incentives**: agents post a payout‑proportional bond (minimum floor, capped at payout) at apply time; bonds are returned on agent wins and fully slashed to employers on employer wins/expiry.
-- **Reputation**: reputation increases with payout size and job duration (delayed completion requests do not increase scores).
-
-### Platform retained revenue (agent wins)
-When a job settles in favor of the agent, any remainder after the agent payout and validator budget (caused by integer division rounding or intentional headroom) is **retained by the platform**. This retained amount stays in the contract and becomes owner‑withdrawable **only while paused** via `withdrawAGI()`, subject to the `withdrawableAGI()` escrow‑solvency checks.
-
-**Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
-
-## Incentives & game theory
-AGIJobManager is optimized for a **business‑run escrow** with a **permissioned validator club** and a **trusted moderator/owner backstop**—not a trustless court.
-“Optimal” here means **liveness**, **priced deviations**, **predictable validator turnout**, and **cheap operations** under that explicit trust model.
-Validators opt‑in **per job** by voting within `completionReviewPeriod`; disputes freeze voting and rely on moderators.
-For the full incentive map, deviation strategies, and parameter playbooks, see
-[`docs/game-theory.md`](docs/game-theory.md).
-Validators should review the 10‑minute workflow in [`docs/validators.md`](docs/validators.md);
-operators should review parameter‑tuning and off‑chain governance before production use.
-
-## NFT trading
-
-AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other marketplaces using normal approvals and transfers. This contract does not implement an internal marketplace.
+See examples in [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md).
 
 ## Documentation
 
-Start with the documentation index: [`docs/00_INDEX.md`](docs/00_INDEX.md).
+- Documentation index: [`docs/README.md`](docs/README.md)
+- Core walkthrough: [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
 
-Documentation hub: [`docs/README.md`](docs/README.md).
-
-Institutional docs set (generated + curated) for contracts, operations, security, testing, deployment, and integrations:
-- [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
-- [`docs/CONTRACTS/AGIJobManager.md`](docs/CONTRACTS/AGIJobManager.md)
-- [`docs/OPERATIONS/RUNBOOK.md`](docs/OPERATIONS/RUNBOOK.md)
-- [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
-- [`docs/REFERENCE/CONTRACT_INTERFACE.md`](docs/REFERENCE/CONTRACT_INTERFACE.md)
-
-Documentation graphics are text-only Mermaid/SVG assets. Freshness is enforced through deterministic generators (`npm run docs:gen`) and CI validation (`npm run docs:check`). Binary-file additions are blocked by policy and CI (`node scripts/check-no-binaries.mjs`).
-
-Core operator/integrator/auditor docs:
-
-ENS integration docs:
-- [`docs/INTEGRATIONS/ENS.md`](docs/INTEGRATIONS/ENS.md)
-- [`docs/INTEGRATIONS/ENS_ROBUSTNESS.md`](docs/INTEGRATIONS/ENS_ROBUSTNESS.md)
-- [`docs/INTEGRATIONS/ENS_USE_CASE.md`](docs/INTEGRATIONS/ENS_USE_CASE.md)
-- [`docs/REFERENCE/ENS_REFERENCE.md`](docs/REFERENCE/ENS_REFERENCE.md) *(generated)*
-
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- [`docs/PROTOCOL_FLOW.md`](docs/PROTOCOL_FLOW.md)
-- [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
-- [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
-- [`docs/ENS_INTEGRATION.md`](docs/ENS_INTEGRATION.md)
-- [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
-- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
-- [`docs/GLOSSARY.md`](docs/GLOSSARY.md)
-- [`docs/REPOSITORY_INVENTORY.md`](docs/REPOSITORY_INVENTORY.md)
-
-## Quickstart
+Docs maintenance commands:
 
 ```bash
-npm ci  # deterministic install from package-lock.json
-npm run build
-npm run test
+npm run docs:gen
+npm run docs:check
+node scripts/check-no-binaries.mjs
 ```
-
-Additional checks used in CI:
-
-```bash
-npm run lint
-npm run size
-```
-
-## Testing
-
-- Testing runbook and deterministic guidance: [`docs/TESTING.md`](docs/TESTING.md)
-- Risk-based coverage matrix and regression policy: [`docs/TEST_PLAN.md`](docs/TEST_PLAN.md)
-- Diagram-first architecture of test harness and failure modes: [`docs/ARCHITECTURE_TESTS.md`](docs/ARCHITECTURE_TESTS.md)
-
-## Architecture + illustrations
-
-### Job lifecycle (state machine)
-```mermaid
-stateDiagram-v2
-    [*] --> Open: createJob
-    Open --> InProgress: applyForJob
-    InProgress --> CompletionRequested: requestJobCompletion
-
-    CompletionRequested --> ApprovalWindow: validateJob (approval threshold)
-    ApprovalWindow --> Completed: finalizeJob (after challenge window)
-    CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
-    CompletionRequested --> Refunded: finalizeJob (timeout, employer win)
-
-    CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
-    CompletionRequested --> Disputed: disputeJob (manual)
-
-    Disputed --> Completed: resolveDisputeWithCode(AGENT_WIN)
-    Disputed --> Refunded: resolveDisputeWithCode(EMPLOYER_WIN)
-    Disputed --> Completed: resolveStaleDispute (owner, timeout)
-
-    InProgress --> Expired: expireJob (timeout, no completion request)
-
-    Open --> Deleted: cancelJob (employer)
-    Open --> Deleted: delistJob (owner)
-```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string maps to `NO_ACTION` and leaves the dispute active. Agent‑win dispute resolution requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed or while paused for dispute recovery. `Deleted` corresponds to cancelled/delisted jobs where the job struct is cleared (`employer == address(0)`).
-
-**Settlement invariant (payout + NFT)**: the agent can only be paid and the completion NFT can only be minted after a completion request is recorded on-chain **and** a non-empty, valid completion metadata URI is stored. Moderators/owners cannot award an agent win without that completion request, and the job NFT always points to the completion metadata (not the job spec).
-
-**Dispute lane policy**
-- Disputes can only be initiated after completion is requested (`completionRequested == true`).
-- Once disputed, validator voting is frozen; approvals/disapprovals no longer progress settlement.
-- Settlement while disputed happens only via moderator resolution or owner stale‑dispute resolution (pause optional, after the dispute review window).
-
-### Full‑stack trust layer (signaling → enforcement)
-```mermaid
-flowchart LR
-    subgraph Off-chain signaling
-        A[Agents, Validators, Observers] --> B[ERC-8004 signals]
-        B --> C[Indexers / Rankers]
-        C --> D[Policy decisions<br/>allowlists, trust tiers]
-    end
-
-    D -->|Merkle roots & allowlists| E[AGIJobManager contract]
-    E <-->|ENS + NameWrapper + Resolver| F[ENS contracts]
-    E --> G[Escrow, payouts,<br/>reputation, job NFTs]
-```
-
-## Roles & permissions
-
-| Role | Capabilities | Trust considerations |
-| --- | --- | --- |
-| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw surplus ERC‑20 (balance minus locked escrow + bonds). | Highly privileged. Compromise or misuse can override operational safety. |
-| **Moderator** | Resolve disputes via `resolveDispute`. | Central dispute authority; outcomes depend on moderator integrity. |
-| **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
-| **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
-| **Validator** | Approve/disapprove jobs, earn payout share and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
-
-## Deploy & Ops
-
-- Deployment sequence: [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
-- Day-2 operations and incident playbooks: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
-- Configuration reference for owner-settable knobs: [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
-- Mainnet institutional runbook (deploy + incident + diagrams): [`docs/MAINNET_OPERATIONS.md`](docs/MAINNET_OPERATIONS.md)
-
-### Mainnet token assumptions (production)
-
-- AGIALPHA token address: `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
-- The system expects exact-transfer ERC20 semantics (no fee-on-transfer/rebase behavior).
-- AGIALPHA token-level pause must remain unpaused for normal operation.
-- ENS integration is intentionally best-effort; core escrow/settlement correctness does not depend on ENS success.
-
-### Dependency pinning note
-
-- `@openzeppelin/contracts` is pinned to `4.9.6` to keep v4 import paths and Ownable constructor behavior stable across deterministic builds.
-
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to keep runtime bytecode under the EIP‑170 cap; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
-
-## Contract documentation
-
-Detailed contract documentation lives in `docs/`:
-
-- [Configure-once operations guide](docs/CONFIGURE_ONCE.md)
-- [Configure-once deployment profile](docs/DEPLOYMENT_PROFILE.md)
-- [Deployment checklist](docs/deployment-checklist.md)
-- [Minimal governance operations](docs/minimal-governance.md)
-- [Minimal governance model](docs/GOVERNANCE.md)
-- [AGI Jobs one-pager (canonical narrative)](docs/AGI_JOBS_ONE_PAGER.md)
-- [AGIJobManager overview](docs/AGIJobManager.md)
-- [AGIJobManager interface reference](docs/AGIJobManager_Interface.md)
-- [Contract read API (job getters)](docs/contract-read-api.md)
-- [Bytecode size & job getters](docs/bytecode-and-getters.md)
-- [AGIJobManager operator guide](docs/AGIJobManager_Operator_Guide.md)
-- [AGIJobManager security considerations](docs/AGIJobManager_Security.md)
-- [Identity lock & treasury pause semantics](docs/identity-lock-and-treasury.md)
-- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
-- [Security policy](SECURITY.md)
-
-## Mainnet bytecode size (EIP-170)
-
-Ethereum mainnet enforces a **24,576-byte** runtime bytecode cap (Spurious Dragon / EIP‑170). Always check the deployed runtime size before deploying:
-
-```bash
-node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
-```
-
-The mainnet deployment settings that keep `AGIJobManager` under the limit are:
-- Optimizer: enabled
-- `optimizer.runs`: **50** (pinned in `truffle-config.js`)
-- `viaIR`: **false** by default
-- `metadata.bytecodeHash`: **none**
-- `debug.revertStrings`: **strip**
-- `solc` version: **0.8.23** (pinned in `truffle-config.js`)
-- `evmVersion`: **london** (or the target chain default)
-
-To check runtime sizes locally after compilation:
-```bash
-node scripts/check-contract-sizes.js
-```
-
-To enforce a deterministic size gate on deployable contracts:
-```bash
-node scripts/check-bytecode-size.js
-```
-
-## Web UI (GitHub Pages)
-
-- Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)
-- Usage guide: [`docs/ui/README.md`](docs/ui/README.md)
-- Expected Pages URL pattern: `https://<org>.github.io/<repo>/ui/agijobmanager.html`
-- GitHub Pages setup: Settings → Pages → Source “Deploy from branch” → Branch `main` → Folder `/docs`.
-- The contract address is user-configurable and must be provided until the new mainnet deployment is finalized.
-- Contract address override: query param `?contract=0x...` or the UI **Save address** button (stored in `localStorage`).
-
-## ERC‑8004 integration (control plane ↔ execution plane)
-See [`docs/ERC8004.md`](docs/ERC8004.md) and [`docs/erc8004/README.md`](docs/erc8004/README.md) for the mapping spec, threat model, and adapter notes. Quick export example:
-
-```bash
-AGIJOBMANAGER_ADDRESS=0xYourContract \
-ERC8004_IDENTITY_REGISTRY=0xIdentityRegistry \
-ERC8004_REPUTATION_REGISTRY=0xReputationRegistry \
-FROM_BLOCK=0 \
-TO_BLOCK=latest \
-OUT_DIR=integrations/erc8004/out \
-truffle exec scripts/erc8004/export_feedback.js --network sepolia
-```
-
-Local dev chain (Ganache):
-```bash
-npx ganache -p 8545
-npx truffle migrate --network development
-```
-
-## Deployment & verification (Truffle)
-
-`truffle-config.js` is the source of truth for networks and env vars. A full guide lives in [`docs/Deployment.md`](docs/Deployment.md).
-
-**Environment setup**
-- Copy `.env.example` → `.env` (keep it local):
-  ```bash
-  cp .env.example .env
-  ```
-- `.env.example` lists every variable read by `truffle-config.js`, with optional defaults.
-
-**Required (Sepolia / Mainnet)**
-- `PRIVATE_KEYS`: comma-separated private keys.
-- RPC configuration, one of:
-  - `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`, or
-  - `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN`, or
-  - `INFURA_KEY`.
-
-**Verification**
-- `ETHERSCAN_API_KEY` for `truffle-plugin-verify`.
-
-**Optional tuning**
-- Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
-- Provider polling: `RPC_POLLING_INTERVAL_MS`.
-- EVM version override: `SOLC_EVM_VERSION` (defaults to `london`).
-- Compiler settings are pinned in `truffle-config.js` (solc `0.8.23`, runs `50`, `evmVersion` `london`).
-- Local chain: `GANACHE_MNEMONIC`.
-
-**Network notes**
-- `test` uses an in-process Ganache provider for deterministic `truffle test` runs.
-- `development`/Ganache typically needs no env vars.
-- `sepolia` needs `ALCHEMY_KEY` (or `SEPOLIA_RPC_URL`) + `PRIVATE_KEYS`.
-- `mainnet` needs `ALCHEMY_KEY_MAIN` (or `MAINNET_RPC_URL`) + `PRIVATE_KEYS`.
-- `PRIVATE_KEYS` format: comma-separated, no spaces, keep it local.
-
-> **Deployment caution**: `migrations/2_deploy_contracts.js` reads constructor parameters from environment variables. Ensure token/ENS/NameWrapper/root nodes/Merkle roots are set correctly before any production deployment.
-
-## Security considerations
-
-- **Centralization risk**: the owner can change critical parameters and withdraw surplus AGI (balance minus `lockedEscrow`) while paused; moderators can resolve disputes.
-- **Eligibility gating**: ENS registry/NameWrapper/root nodes are intended to be configured before any job exists and then locked; Merkle roots remain configurable for allowlist updates.
-- **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
-- **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
-- **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline **once completion is requested** unless off‑chain policies intervene.
-- **Dispute resolution codes**: moderators should use `resolveDisputeWithCode(jobId, code, reason)` with `code = 0 (NO_ACTION)`, `1 (AGENT_WIN)`, or `2 (EMPLOYER_WIN)`. The `reason` is freeform and does not control settlement. The legacy string-based `resolveDispute` is deprecated; non‑canonical strings map to `NO_ACTION` and keep the dispute active.
-- **Agent payout snapshot**: the agent payout percentage is snapshotted at `applyForJob` and used at completion; later NFT transfers do **not** change payout for that job. Agents must have a nonzero AGI‑type payout tier at apply time (0% tiers cannot accept jobs), and `additionalAgents` only bypass identity checks (not payout eligibility).
-
-## Pause behavior
-
-Pause is an incident-response safety control. When paused, **new activity** is blocked (job creation, applications, validation/disputes), but safe exits remain available. Assigned agents can still call `requestJobCompletion`, and settlement exits (`cancelJob`, `expireJob`, `finalizeJob`) still work when their normal predicates are satisfied. Resume operations by unpausing once the issue is resolved.
-
-See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known limitations.
-
-## Ecosystem links
-
-- **Repository**: https://github.com/MontrealAI/AGIJobManager
-- **Etherscan (deployment-specific)**: https://etherscan.io/address/<contract-address>
-- **OpenSea (job NFTs, deployment-specific)**: https://opensea.io/assets/ethereum/<contract-address>
-- **ERC‑8004 specification**: https://eips.ethereum.org/EIPS/eip-8004
-- **ERC‑8004 deck (framing)**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/presentation/MONTREALAI_x_ERC8004_v0.pdf
-- **ERC‑8004 deck (repo copy)**: [`presentations/MONTREALAI_x_ERC8004_v0.pdf`](presentations/MONTREALAI_x_ERC8004_v0.pdf)
-- **Institutional overview (repo PDF)**: [`presentations/AGI_Eth_Institutional_v0.pdf`](presentations/AGI_Eth_Institutional_v0.pdf)
-- **AGI‑Alpha‑Agent reference repo**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
-- **ENS docs**: https://docs.ens.domains/
-- **ENS NameWrapper**: https://docs.ens.domains/ens-improvement-proposals/ensip-10-namewrapper
-- **OpenZeppelin Contracts**: https://docs.openzeppelin.com/contracts/4.x/
-- **Truffle**: https://trufflesuite.com/docs/truffle/
-
-## Documentation index
-
-Start here:
-- [`docs/README.md`](docs/README.md)
-- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
-- [Security policy](SECURITY.md)
-- **Non‑technical user guides**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
-- [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
-- [`docs/ParameterSafety.md`](docs/ParameterSafety.md)
-- [`docs/ops/parameter-safety.md`](docs/ops/parameter-safety.md)
-- [`docs/Deployment.md`](docs/Deployment.md)
-- [`docs/Security.md`](docs/Security.md)
-- [`docs/Testing.md`](docs/Testing.md)
-- [`docs/ERC8004.md`](docs/ERC8004.md)
-- [`docs/Interface.md`](docs/Interface.md)
-  - To regenerate from ABI: `npm run build` then `npm run docs:interface`.
-- **ERC‑8004 integration (control plane ↔ execution plane)**: [`docs/erc8004/README.md`](docs/erc8004/README.md)
-- **AGI.Eth Namespace (alpha)**:
-  - User guide: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md)
-  - Quickstart: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md)
-  - Identity gating appendix: [`docs/namespace/ENS_IDENTITY_GATING.md`](docs/namespace/ENS_IDENTITY_GATING.md)
-  - FAQ: [`docs/namespace/FAQ.md`](docs/namespace/FAQ.md)
-
-## UI / Sovereign Ops Console
-
-[![UI CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ui.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ui.yml)
-
-A standalone institutional Next.js UI lives in [`ui/`](./ui) with deterministic demo fixtures, read-only-first navigation, and simulation-first transaction safety.
-
-### Quick start
-```bash
-cd ui
-npm ci
-NEXT_PUBLIC_DEMO_MODE=1 npm run dev
-```
-
-### Documentation
-- [docs/ui/README.md](./docs/ui/README.md)
-- [Architecture](./docs/ui/ARCHITECTURE.md)
-- [Job lifecycle](./docs/ui/JOB_LIFECYCLE.md)
-- [Ops runbook](./docs/ui/OPS_RUNBOOK.md)
-- [Security model](./docs/ui/SECURITY_MODEL.md)
-- [Design system](./docs/ui/DESIGN_SYSTEM.md)
-- [Demo mode](./docs/ui/DEMO.md)
-- [Testing](./docs/ui/TESTING.md)
-- [Contract interface](./docs/ui/CONTRACT_INTERFACE.md)
-- [Pinned versions](./docs/ui/VERSIONS.md)
-
-### Text-only graphics (no binary screenshots)
-![Sovereign palette](./docs/ui/assets/palette.svg)
-![UI wireframe](./docs/ui/assets/ui-wireframe.svg)
-
-Security highlights: read-only mode without wallet, simulation-first write paths, URI allowlisting, strict security headers, and CI-enforced no-binaries checks (`npm run check:no-binaries`).

--- a/docs/MODERATOR_RUNBOOK.md
+++ b/docs/MODERATOR_RUNBOOK.md
@@ -1,0 +1,64 @@
+# Moderator Runbook
+
+Moderators resolve active disputes consistently using `resolveDisputeWithCode(jobId, code, reason)`.
+
+## 1) Dispute triage decision tree
+
+```text
+Is job currently disputed?
+  ├─ No -> stop (do not write)
+  └─ Yes
+      Is evidence package complete?
+        ├─ No -> request evidence; do not resolve yet
+        └─ Yes
+            Which side satisfies policy better?
+              ├─ Agent -> code 1
+              ├─ Employer -> code 2
+              └─ Insufficient confidence -> code 0 (log-only) and escalate
+```
+
+## 2) Resolution matrix
+
+| Situation | Code | Effect |
+|---|---:|---|
+| Agent performed work per policy and evidence | 1 | agent-win settlement path |
+| Employer dispute is substantiated | 2 | employer refund path |
+| Evidence incomplete / procedural hold | 0 | emits event only; dispute remains active |
+
+## 3) SOP for `resolveDisputeWithCode`
+
+Minimum evidence checklist:
+- `getJobCore(jobId)` and `getJobValidation(jobId)` outputs captured,
+- job spec URI and completion URI snapshots,
+- relevant communication/evidence references,
+- rationale mapped to policy/rules.
+
+Reason string format (required for consistency):
+```text
+CASE:<id>|EVIDENCE:<refs>|RULE:<policy>|OUTCOME:<0|1|2>|NOTE:<short text>
+```
+
+Examples:
+- `CASE:117|EVIDENCE:specHash,completionHash|RULE:DELIVERY-1|OUTCOME:1|NOTE:deliverable matched acceptance criteria`
+- `CASE:118|EVIDENCE:deadlineLog|RULE:DEADLINE-2|OUTCOME:2|NOTE:completion not submitted in valid window`
+
+Consistency controls:
+- Always use the matrix above.
+- Avoid free-form outcomes; only 0/1/2.
+- Use comparable evidence standards across similar cases.
+
+## 4) Etherscan-only workflow
+
+1. Read `getJobCore(jobId)`.
+2. Read `getJobValidation(jobId)`.
+3. Confirm dispute is active (`disputed == true`).
+4. Confirm settlement not paused (`settlementPaused == false`).
+5. Write `resolveDisputeWithCode(jobId, code, reason)`.
+6. Save tx hash with case record.
+
+## 5) Escalation
+
+Escalate to owner when:
+- repeated low-quality disputes indicate policy gap,
+- suspected abuse/blacklist need,
+- settlement pause may be necessary.

--- a/docs/REFERENCE/VERSIONS.md
+++ b/docs/REFERENCE/VERSIONS.md
@@ -1,7 +1,7 @@
 # Versions Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `04498d330052`.
-- Source snapshot fingerprint: `04498d330052`.
+- Generated at (deterministic source fingerprint): `fe5ecf442ef8`.
+- Source snapshot fingerprint: `fe5ecf442ef8`.
 - Generation mode: deterministic from repository source files.
 
 ## Toolchain snapshot

--- a/docs/VERIFY_ON_ETHERSCAN.md
+++ b/docs/VERIFY_ON_ETHERSCAN.md
@@ -1,51 +1,45 @@
-# Verify AGIJobManager on Etherscan (Reproducible)
+# Verify on Etherscan (Exact Repo Settings)
 
-Etherscan Read/Write UX depends on correct source verification.
+Etherscan Read/Write usability depends on successful source verification.
 
-## 1) Identify the compiler profile used for deployment
+## 1) Toolchain settings used in this repo
 
-This repo has two compiler profiles:
+## Truffle compile/deploy profile (`truffle-config.js`)
+- `solc`: `0.8.23`
+- optimizer: enabled, runs `50`
+- `viaIR: true`
+- `evmVersion: london`
+- `metadata.bytecodeHash: none`
+- `debug.revertStrings: strip`
 
-- **Truffle profile** (deployment/tests in `package.json`):
-  - `solc 0.8.23`
-  - optimizer enabled, runs `50`
-  - `viaIR: true`
-  - metadata bytecode hash `none`
-  - EVM `london`
-- **Foundry profile** (`foundry.toml`):
-  - `solc 0.8.19`
-  - optimizer enabled, runs `50`
+## Foundry profile (`foundry.toml`)
+- `solc`: `0.8.19`
+- optimizer: enabled, runs `50`
+- `evm_version: london`
 
-For normal repo deployments (`truffle migrate`), verify with the **Truffle profile**.
+If deployment was done with Truffle scripts, verify with the Truffle profile.
 
-## 2) Install and compile exactly as CI/deployment expects
+## 2) Build exactly
 
 ```bash
 npm install
 npm run build
 ```
 
-Artifacts are produced in `build/contracts/`.
+## 3) Linked libraries (required)
 
-## 3) Linked library requirements
-
-AGIJobManager uses external libraries:
-
+AGIJobManager is externally linked to:
 - `UriUtils`
 - `TransferUtils`
 - `BondMath`
 - `ReputationMath`
 - `ENSOwnership`
 
-Verification must include exact deployed addresses for each linked library.
+Verification must include exact library-name → deployed-address mappings used at deployment time.
 
-## 4) Verification paths
+## 4) Verification methods
 
-## A) Truffle plugin path (preferred for this repo)
-
-`truffle-config.js` includes `truffle-plugin-verify` and etherscan API settings.
-
-Example mainnet command:
+## A) Truffle plugin
 
 ```bash
 ETHERSCAN_API_KEY=... \
@@ -54,52 +48,22 @@ MAINNET_RPC_URL=https://... \
 npx truffle run verify AGIJobManager --network mainnet
 ```
 
-If constructor args are required explicitly, use plugin options for constructor params according to deployment values.
+## B) Manual Standard JSON input
+Use exact compiler settings + source set + library mappings + constructor args.
 
-## B) Standard JSON/manual verification
+## 5) Common mismatch causes
 
-If plugin path fails, use Solidity Standard JSON Input generated from the exact build and submit manually in Etherscan’s “Standard-Json-Input” mode, including library mappings.
+- Wrong compiler version.
+- Optimizer runs mismatch.
+- `viaIR` mismatch.
+- EVM version mismatch.
+- Metadata hash mismatch.
+- Wrong linked library addresses.
+- Wrong constructor args.
 
----
-
-## 5) Common verification failures and fixes
-
-- **Wrong compiler version**
-  - Symptom: bytecode mismatch.
-  - Fix: use `0.8.23` for Truffle deployments.
-
-- **Optimizer runs mismatch**
-  - Symptom: partial bytecode mismatch.
-  - Fix: optimizer enabled + runs `50`.
-
-- **viaIR mismatch**
-  - Symptom: major bytecode mismatch even with same solc.
-  - Fix: ensure `viaIR: true` matches deployment.
-
-- **Metadata hash mismatch**
-  - Symptom: tail-bytecode mismatch.
-  - Fix: compile with `metadata.bytecodeHash = none`.
-
-- **Wrong library addresses**
-  - Symptom: unresolved link references or mismatch.
-  - Fix: supply exact library name/address pairs from deployment.
-
-- **Wrong constructor arguments**
-  - Symptom: creation bytecode mismatch.
-  - Fix: ABI-encode constructor args exactly as deployed.
-
-- **Wrong EVM version**
-  - Symptom: mismatch despite same solc.
-  - Fix: set EVM to `london` (repo default unless overridden at deploy).
-
----
-
-## 6) Post-verification sanity check
+## 6) Post-verification check
 
 On Etherscan contract page:
-
-1. `Read Contract` tab should show named functions and outputs.
-2. `Write Contract` tab should expose typed parameter forms.
-3. Custom errors/events should decode properly in tx details.
-
-If tabs still look raw/minimal, verification likely used mismatched metadata/settings.
+1. Read tab shows typed outputs.
+2. Write tab shows named fields.
+3. Transaction details decode custom errors/events.

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "ui:abi": "node scripts/ui/export_abi.js",
     "ui:abi:check": "node scripts/ui/check_ui_abi.js",
     "merkle:proof": "node scripts/merkle/generate_merkle_proof.js",
-    "merkle:export": "node scripts/merkle/export_merkle_proofs.js"
+    "merkle:export": "node scripts/merkle/export_merkle_proofs.js",
+    "etherscan:prep": "node scripts/etherscan/cli.js",
+    "advisor:job": "node scripts/advisor/job_state_advisor.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.9.6"

--- a/scripts/advisor/job_state_advisor.js
+++ b/scripts/advisor/job_state_advisor.js
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+
+function readInput() {
+  const rawArg = process.argv[2];
+  if (rawArg) return JSON.parse(rawArg);
+  let data = "";
+  process.stdin.setEncoding("utf8");
+  process.stdin.on("data", (chunk) => { data += chunk; });
+  process.stdin.on("end", () => {
+    try {
+      const parsed = JSON.parse(data);
+      analyze(parsed);
+    } catch (e) {
+      console.error(`Invalid JSON input: ${e.message}`);
+      process.exit(1);
+    }
+  });
+  return null;
+}
+
+function t(x) { return BigInt(String(x)); }
+
+function analyze(i) {
+  const now = t(i.nowTs);
+  const core = i.jobCore || {};
+  const val = i.jobValidation || {};
+  const cfg = i.config || {};
+
+  const assignedAt = t(core.assignedAt || 0);
+  const duration = t(core.duration || 0);
+  const completionRequestedAt = t(val.completionRequestedAt || 0);
+  const disputedAt = t(val.disputedAt || 0);
+  const approvals = t(val.validatorApprovals || 0);
+  const disapprovals = t(val.validatorDisapprovals || 0);
+  const reviewPeriod = t(cfg.completionReviewPeriod || 604800);
+  const disputeReview = t(cfg.disputeReviewPeriod || 1209600);
+  const voteQuorum = t(cfg.voteQuorum || 3);
+
+  const totalVotes = approvals + disapprovals;
+  const assigned = core.assignedAgent && core.assignedAgent !== "0x0000000000000000000000000000000000000000";
+
+  const lines = [];
+  const actions = [];
+
+  if (core.completed) lines.push("State: COMPLETED (terminal)");
+  else if (core.expired) lines.push("State: EXPIRED (terminal)");
+  else if (core.disputed) lines.push("State: DISPUTED");
+  else if (!assigned) lines.push("State: OPEN (unassigned)");
+  else if (!val.completionRequested) lines.push("State: ASSIGNED_IN_PROGRESS");
+  else lines.push("State: COMPLETION_REQUESTED");
+
+  if (assigned && !val.completionRequested && !core.completed && !core.expired && !core.disputed) {
+    const expireAt = assignedAt + duration;
+    actions.push(`expireJob eligible after: ${expireAt.toString()} (now=${now.toString()})`);
+  }
+
+  if (val.completionRequested && !core.completed && !core.expired && !core.disputed) {
+    const reviewEnds = completionRequestedAt + reviewPeriod;
+    actions.push(`review window ends at: ${reviewEnds.toString()}`);
+    actions.push(`finalizeJob after review end: ${reviewEnds.toString()}`);
+    if (totalVotes < voteQuorum || approvals === disapprovals) {
+      actions.push("If finalized now (after review), outcome is dispute (under quorum or tie), unless total votes = 0 then agent-win path.");
+    } else if (approvals > disapprovals) {
+      actions.push("If finalized after review, expected outcome: agent win.");
+    } else {
+      actions.push("If finalized after review, expected outcome: employer refund.");
+    }
+    actions.push(`disputeJob latest time: ${reviewEnds.toString()} (must be <= this timestamp).`);
+  }
+
+  if (core.disputed) {
+    const staleAt = disputedAt + disputeReview;
+    actions.push(`resolveStaleDispute(owner) eligible after: ${staleAt.toString()}`);
+    actions.push("resolveDisputeWithCode(moderator): code 1=agent win, 2=employer refund, 0=no-op event.");
+  }
+
+  console.log("=== Offline Job State Advisor ===");
+  lines.forEach((l) => console.log(l));
+  console.log("\nValid actions / timing:");
+  if (!actions.length) console.log("- None (already terminal or missing fields)");
+  actions.forEach((a) => console.log(`- ${a}`));
+}
+
+const parsed = readInput();
+if (parsed) {
+  try {
+    analyze(parsed);
+  } catch (e) {
+    console.error(`Failed to analyze input: ${e.message}`);
+    process.exit(1);
+  }
+}

--- a/scripts/etherscan/cli.js
+++ b/scripts/etherscan/cli.js
@@ -1,0 +1,125 @@
+#!/usr/bin/env node
+/* eslint-disable no-console */
+function usage() {
+  console.log(`Usage:
+  node scripts/etherscan/cli.js --action <name> [options]
+
+Actions:
+  convert | approve | createJob | applyForJob | requestJobCompletion | validateJob | disapproveJob | resolveDisputeWithCode
+`);
+}
+const arg = (name, d) => {
+  const i = process.argv.indexOf(`--${name}`);
+  return i >= 0 && i + 1 < process.argv.length ? process.argv[i + 1] : d;
+};
+const need = (name) => {
+  const v = arg(name);
+  if (v === undefined) throw new Error(`Missing --${name}`);
+  return v;
+};
+const parseAmount = (human, decimals) => {
+  if (!/^\d+(\.\d+)?$/.test(human)) throw new Error(`Invalid --amount: ${human}`);
+  const [w, f = ""] = human.split(".");
+  if (f.length > decimals) throw new Error(`Too many decimals in amount. Max ${decimals}`);
+  const s = 10n ** BigInt(decimals);
+  return BigInt(w) * s + BigInt((f + "0".repeat(decimals)).slice(0, decimals));
+};
+const parseDuration = (v) => {
+  if (/^\d+$/.test(v)) return BigInt(v);
+  const m = v.match(/^(\d+)([smhdw])$/);
+  if (!m) throw new Error(`Invalid --duration: ${v}`);
+  const mult = { s: 1n, m: 60n, h: 3600n, d: 86400n, w: 604800n };
+  return BigInt(m[1]) * mult[m[2]];
+};
+const parseProof = (raw) => {
+  const p = JSON.parse(raw || "[]");
+  if (!Array.isArray(p)) throw new Error("--proof must be JSON array");
+  for (const x of p) if (!/^0x[0-9a-fA-F]{64}$/.test(x)) throw new Error(`Invalid proof item: ${x}`);
+  return p;
+};
+const checklist = (action) => {
+  console.log("\nPre-flight checklist:");
+  [
+    "Read paused() and settlementPaused() first.",
+    "Confirm AGI token balance and allowance.",
+    "Read getJobCore/getJobValidation for current job status.",
+    "Confirm all time windows are still open."
+  ].forEach((x) => console.log(`- [ ] ${x}`));
+  if (action === "resolveDisputeWithCode") console.log("- [ ] Moderator role required.");
+};
+const block = (title, data) => {
+  console.log(`\n=== ${title} ===`);
+  Object.entries(data).forEach(([k, v]) => console.log(`${k}: ${Array.isArray(v) ? JSON.stringify(v) : v}`));
+};
+
+(function main() {
+  try {
+    const action = arg("action");
+    if (!action) return usage();
+    const decimals = Number(arg("decimals", "18"));
+    const amount = arg("amount");
+    const duration = arg("duration");
+    const amountBase = amount ? parseAmount(amount, decimals).toString() : null;
+    const durSecs = duration ? parseDuration(duration).toString() : null;
+
+    if (action === "convert") {
+      return block("Conversion", {
+        decimals,
+        ...(amount ? { humanAmount: amount, baseUnits: amountBase } : {}),
+        ...(duration ? { durationInput: duration, durationSeconds: durSecs } : {})
+      });
+    }
+
+    if (action === "approve") {
+      checklist(action);
+      return block("Copy/paste into ERC20 approve(spender,amount)", {
+        spender: need("spender"),
+        amount: amountBase,
+        amountHuman: `${amount} @ ${decimals} decimals`
+      });
+    }
+
+    if (action === "createJob") {
+      checklist(action);
+      return block("Copy/paste into AGIJobManager.createJob", {
+        _jobSpecURI: need("jobSpecURI"),
+        _payout: amountBase,
+        _duration: durSecs,
+        _details: need("details")
+      });
+    }
+
+    if (["applyForJob", "validateJob", "disapproveJob"].includes(action)) {
+      checklist(action);
+      return block(`Copy/paste into AGIJobManager.${action}`, {
+        _jobId: need("jobId"),
+        subdomain: arg("subdomain", ""),
+        proof: parseProof(arg("proof", "[]"))
+      });
+    }
+
+    if (action === "requestJobCompletion") {
+      checklist(action);
+      return block("Copy/paste into AGIJobManager.requestJobCompletion", {
+        _jobId: need("jobId"),
+        _jobCompletionURI: need("jobCompletionURI")
+      });
+    }
+
+    if (action === "resolveDisputeWithCode") {
+      checklist(action);
+      const code = need("resolutionCode");
+      if (!["0", "1", "2"].includes(code)) throw new Error("resolutionCode must be 0, 1, or 2");
+      return block("Copy/paste into AGIJobManager.resolveDisputeWithCode", {
+        _jobId: need("jobId"),
+        resolutionCode: code,
+        reason: need("reason")
+      });
+    }
+
+    throw new Error(`Unknown action: ${action}`);
+  } catch (e) {
+    console.error(e.message);
+    process.exit(1);
+  }
+})();

--- a/scripts/merkle/export_merkle_proofs.js
+++ b/scripts/merkle/export_merkle_proofs.js
@@ -45,7 +45,7 @@ if (!Array.isArray(parsed) || parsed.length === 0) {
   process.exit(1);
 }
 
-const addresses = parsed.map(normalizeAddress);
+const addresses = [...new Set(parsed.map(normalizeAddress))].sort();
 const leaves = addresses.map(toLeaf);
 const tree = new MerkleTree(leaves, keccak256, { sortPairs: true, sortLeaves: true });
 
@@ -59,6 +59,9 @@ const output = {
   merkleOptions: { sortPairs: true, sortLeaves: true },
   root: tree.getHexRoot(),
   proofs,
+  etherscanProofs: Object.fromEntries(
+    Object.entries(proofs).map(([addr, proof]) => [addr, JSON.stringify(proof)])
+  )
 };
 
 if (outputPath) {


### PR DESCRIPTION
### Motivation
- Make AGIJobManager usable by non-technical users from Etherscan Read/Write tabs with copy/paste-ready inputs and clear runbooks. 
- Reduce owner/moderator friction by providing offline, deterministic tooling and standardized SOPs so operators can act with minimal manual reasoning.
- Preserve on-chain compatibility and bytecode discipline (no selector/signature changes, ABI-safe adjustments only to docs/tooling). 

### Description
- Documentation: rewrote and consolidated Etherscan-centric user/operator docs and runbooks, including `README.md` (quickstart, trust model, glossary), `docs/ETHERSCAN_GUIDE.md` (flagship Etherscan guide with role flows, checklist, timeline, failure matrix, TSV/JSON paste formats, ENS constraints), `docs/OWNER_RUNBOOK.md` (owner runbook, incident playbooks, withdrawal SOP), `docs/MODERATOR_RUNBOOK.md` (dispute triage, standardized reason format), `docs/VERIFY_ON_ETHERSCAN.md`, and `docs/FAQ.md`.
- Offline helper tooling: added `scripts/etherscan/cli.js` (CLI that produces copy/paste blocks and pre-flight checklists for common Write functions), `scripts/advisor/job_state_advisor.js` (offline job-state advisor that consumes pasted `getJobCore`/`getJobValidation` + timestamp), and enhanced `scripts/merkle/export_merkle_proofs.js` to dedupe/sort addresses and include `etherscanProofs` JSON strings directly pasteable into Etherscan `bytes32[]` inputs.
- Small repo metadata: added npm script aliases `etherscan:prep` and `advisor:job` in `package.json` and wired the new scripts into documentation examples; updated generated `docs/REFERENCE/VERSIONS.md` to satisfy docs integrity checks.
- Safety/compat: no Solidity API or selector changes were made (ENS selectors and calldata sizes preserved), no runtime bytecode-affecting changes to `contracts/AGIJobManager.sol` were performed, and the edits are documentation + tooling only to respect EIP-170 bytecode discipline.

### Testing
- Lint: ran `npm run lint` (Solhint warnings only, no errors). (passed with warnings)
- Build: ran `npm run build` (Truffle compile) and `npm run size` showing `AGIJobManager runtime bytecode: 24533` (below EIP-170 cap). (passed)
- Full test suite: ran `npm test` (Truffle + JS harness + repo checks) — test output: `351 passing` and contract/artifact size checks reported; ENS ABI/calldata compatibility tests remain present and pass. (passed)
- Docs integrity: ran `npm run docs:check` and regenerated `docs/REFERENCE/VERSIONS.md` via `npm run docs:gen` as required; `npm run docs:check` succeeded. (passed)
- Scripts smoke: ran `node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json` and received deterministic root + per-address proofs including `etherscanProofs`; ran `node scripts/etherscan/cli.js --action createJob ...` to verify paste output; ran `node scripts/advisor/job_state_advisor.js '{...}'` to verify advisor output. (passed)
- Known limitation: `forge test` was not executed in this environment because the `forge` binary is not installed here; this is an environment/tooling limitation and not a repo change. (skipped)

If you want, I can split any doc into smaller PRs, add more copy/paste examples for specific functions, or add minimal NatSpec comments to user-facing functions to improve Etherscan form labels while keeping ABI safety.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931a8aa3f883338c0a23bae8379eca)