### PR TITLE
Suppress overdue completion-request guidance in offline advisor and add Etherscan helper tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,412 +1,77 @@
-# AGIJobManager ALPHA v0
+# AGIJobManager
 
-[![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
-[![Solidity](https://img.shields.io/badge/solidity-0.8.19-363636.svg)](contracts/AGIJobManager.sol)
-[![Truffle](https://img.shields.io/badge/truffle-5.x-3fe0c5.svg)](https://trufflesuite.com/)
-[![CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml)
+AGIJobManager is an owner-operated on-chain job escrow and settlement contract for employer/agent workflows with validator voting and moderator dispute resolution.
 
-**AGIJobManager** is MONTREAL.AI’s on-chain enforcement layer for agent–employer workflows: validator-gated job escrow, payouts, dispute resolution, and reputation tracking, with ENS/Merkle role gating and ERC‑721 job NFT issuance. It is the *enforcement* half of a “Full‑Stack Trust Layer for AI Agents.”
+## Start here
 
-> **Status / Caution**: Experimental research software. Treat deployments as high-risk until you have performed independent security review, validated parameters, and ensured operational readiness. No public audit report is included in this repository.
+- Etherscan role guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
+- Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
+- Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
+- Verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
+- FAQ: [`docs/FAQ.md`](docs/FAQ.md)
 
+## Roles (plain language)
 
-## Start here (Etherscan-first)
+- **Employer**: funds jobs, assigns by accepting an applicant flow, can cancel before assignment, can finalize/dispute after completion request.
+- **Agent**: applies to jobs (allowlist/Merkle/ENS authorization), may post a bond, submits completion URI.
+- **Validator**: authorized voter that approves/disapproves completed work during review.
+- **Moderator**: resolves disputes with `resolveDisputeWithCode`.
+- **Owner**: configures risk parameters, pause controls, allowlists/blacklists/moderators, ENS wiring, and treasury withdrawal constrained by solvency.
 
-- **Etherscan user guide (all roles):** [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
-- **Owner/operator runbook:** [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
-- **Verification guide:** [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
+## Trust model (explicit)
 
-## Role overview (plain language)
+This system is **not trustless governance**. The owner is privileged and can:
+- pause/unpause intake (`pause`, `unpause`, `pauseAll`, `unpauseAll`),
+- pause/unpause settlement (`setSettlementPaused`),
+- change core risk and timing parameters,
+- manage allowlists, Merkle roots, and blacklists,
+- add/remove moderators,
+- change ENS/token identity configuration until `lockIdentityConfiguration()` is used,
+- withdraw only non-escrow AGI via `withdrawAGI` (bounded by `withdrawableAGI`).
 
-- **Employer**: funds jobs, hires agents, can cancel before assignment, can finalize/dispute after completion request.
-- **Agent**: applies to jobs (allowlist/Merkle/ENS-gated), posts bond when required, submits completion URI.
-- **Validator**: votes approve/disapprove during review window, posts per-vote bond, may earn rewards or be slashed.
-- **Moderator**: resolves active disputes with explicit outcome codes.
-- **Owner**: operates risk controls (pause switches, parameters, allowlists, moderators, ENS wiring, treasury withdrawal of non-escrow funds).
+Users should assume an operator-managed escrow model with transparent on-chain controls.
 
-## Trust model (one paragraph)
+## One-screen quickstart (Etherscan)
 
-AGIJobManager is intentionally **owner-operated** rather than trustless: owner and moderators have meaningful operational authority. The owner can pause/unpause intake, pause settlement, adjust core risk parameters (quorum, thresholds, review windows, bond/slash parameters), manage allowlists/blacklists and moderators, manage ENS identity wiring, and withdraw only treasury surplus that remains after escrow and bond locks. Users should treat this as a business-operated escrow system with transparent on-chain controls, not a decentralized court.
+1. On AGI token contract: `approve(AGIJobManager, amount)`.
+2. Employer: `createJob(jobSpecURI, payout, duration, details)`.
+3. Agent: `applyForJob(jobId, subdomain, proof)`.
+4. Agent: `requestJobCompletion(jobId, jobCompletionURI)`.
+5. Validators: `validateJob` / `disapproveJob` during review period.
+6. Employer: `finalizeJob(jobId)` when eligible; if contested, `disputeJob(jobId)` and moderator resolves.
 
-## Quick glossary
+## Glossary (Etherscan terms)
 
-- **jobId**: numeric identifier for each job.
-- **payout**: escrowed AGI amount for a job (token base units).
-- **duration**: work window in seconds from assignment.
-- **completion review period**: validator voting window after completion request.
-- **dispute review period**: stale-dispute timeout before owner can resolve stale disputes.
-- **quorum**: minimum total validator votes considered sufficient participation.
-- **bond**: AGI amount staked by agents/validators/dispute initiator.
-- **slashing**: penalty reducing bond for incorrect validator side.
+- **jobId**: numeric job identifier.
+- **payout**: escrowed amount in token base units.
+- **duration**: job duration in seconds.
+- **review window**: completion voting period after completion request.
+- **quorum**: minimum total validator participation threshold.
+- **bond**: staked token amount for agent/validator/dispute initiation.
+- **slashing**: bond penalty for wrong-side outcomes.
 
-
-## At a glance
-
-**What it is**
-- **Job escrow & settlement engine**: employer-funded jobs, agent assignment, validator approvals/disapprovals (thresholded), moderator dispute resolution, payouts/refunds.
-- **Reputation mapping**: on-chain reputation updates for agents and validators derived from job outcomes.
-- **Job NFT issuance**: mints an ERC‑721 “job NFT” on completion for the employer.
-- **Trust gating**: role eligibility enforced via explicit allowlists, Merkle proofs, and ENS/NameWrapper/Resolver ownership checks.
-
-**What it is NOT**
-- **Not an on-chain ERC‑8004 implementation**: ERC‑8004 is consumed off-chain; this repo does not integrate it on-chain.
-- **Not a generalized identity or reputation registry**: only contract-local reputation mappings and ENS/Merkle gating are provided.
-- **Not a generalized NFT marketplace**: this contract does not embed a marketplace; NFTs trade externally via standard ERC‑721 approvals and transfers.
-- **Not a decentralized court or DAO**: moderators and the owner have significant authority; validator membership remains permissioned even with bonded voting.
-
-## Important trust notes
-- **Owner-operated**: the owner can pause/unpause, tune parameters, and manage allowlists/blacklists.
-- **Escrow invariant**: the owner can withdraw **treasury only** (AGI balance minus `lockedEscrow`, `lockedAgentBonds`, `lockedValidatorBonds`, and `lockedDisputeBonds`) and only while paused; escrowed funds and bonds are not withdrawable.
-- **Pause semantics**: new activity is blocked, but completion requests and settlement exits remain available.
-- **Identity wiring lock**: `lockIdentityConfiguration()` permanently freezes token/ENS/root-node wiring, while leaving operational controls intact.
-- **Validator incentives**: validators post a bond per vote (capped at payout), earn rewards when their vote matches the final outcome, and are slashed when they are wrong.
-- **Agent incentives**: agents post a payout‑proportional bond (minimum floor, capped at payout) at apply time; bonds are returned on agent wins and fully slashed to employers on employer wins/expiry.
-- **Reputation**: reputation increases with payout size and job duration (delayed completion requests do not increase scores).
-
-### Platform retained revenue (agent wins)
-When a job settles in favor of the agent, any remainder after the agent payout and validator budget (caused by integer division rounding or intentional headroom) is **retained by the platform**. This retained amount stays in the contract and becomes owner‑withdrawable **only while paused** via `withdrawAGI()`, subject to the `withdrawableAGI()` escrow‑solvency checks.
-
-**Trust model summary**: owner‑operated escrow; escrow protected by `lockedEscrow`; owner withdraws only non‑escrow funds under defined conditions.
-
-## Incentives & game theory
-AGIJobManager is optimized for a **business‑run escrow** with a **permissioned validator club** and a **trusted moderator/owner backstop**—not a trustless court.
-“Optimal” here means **liveness**, **priced deviations**, **predictable validator turnout**, and **cheap operations** under that explicit trust model.
-Validators opt‑in **per job** by voting within `completionReviewPeriod`; disputes freeze voting and rely on moderators.
-For the full incentive map, deviation strategies, and parameter playbooks, see
-[`docs/game-theory.md`](docs/game-theory.md).
-Validators should review the 10‑minute workflow in [`docs/validators.md`](docs/validators.md);
-operators should review parameter‑tuning and off‑chain governance before production use.
-
-## NFT trading
-
-AGI Jobs are standard ERC‑721 NFTs. They can be traded on OpenSea and other marketplaces using normal approvals and transfers. This contract does not implement an internal marketplace.
-
-## Documentation
-
-Start with the documentation index: [`docs/00_INDEX.md`](docs/00_INDEX.md).
-
-Documentation hub: [`docs/README.md`](docs/README.md).
-
-Institutional docs set (generated + curated) for contracts, operations, security, testing, deployment, and integrations:
-- [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
-- [`docs/CONTRACTS/AGIJobManager.md`](docs/CONTRACTS/AGIJobManager.md)
-- [`docs/OPERATIONS/RUNBOOK.md`](docs/OPERATIONS/RUNBOOK.md)
-- [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
-- [`docs/REFERENCE/CONTRACT_INTERFACE.md`](docs/REFERENCE/CONTRACT_INTERFACE.md)
-
-Documentation graphics are text-only Mermaid/SVG assets. Freshness is enforced through deterministic generators (`npm run docs:gen`) and CI validation (`npm run docs:check`). Binary-file additions are blocked by policy and CI (`node scripts/check-no-binaries.mjs`).
-
-Core operator/integrator/auditor docs:
-
-ENS integration docs:
-- [`docs/INTEGRATIONS/ENS.md`](docs/INTEGRATIONS/ENS.md)
-- [`docs/INTEGRATIONS/ENS_ROBUSTNESS.md`](docs/INTEGRATIONS/ENS_ROBUSTNESS.md)
-- [`docs/INTEGRATIONS/ENS_USE_CASE.md`](docs/INTEGRATIONS/ENS_USE_CASE.md)
-- [`docs/REFERENCE/ENS_REFERENCE.md`](docs/REFERENCE/ENS_REFERENCE.md) *(generated)*
-
-- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md)
-- [`docs/PROTOCOL_FLOW.md`](docs/PROTOCOL_FLOW.md)
-- [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
-- [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
-- [`docs/ENS_INTEGRATION.md`](docs/ENS_INTEGRATION.md)
-- [`docs/SECURITY_MODEL.md`](docs/SECURITY_MODEL.md)
-- [`docs/TROUBLESHOOTING.md`](docs/TROUBLESHOOTING.md)
-- [`docs/GLOSSARY.md`](docs/GLOSSARY.md)
-- [`docs/REPOSITORY_INVENTORY.md`](docs/REPOSITORY_INVENTORY.md)
-
-## Quickstart
+## Tooling and CI entrypoints
 
 ```bash
-npm ci  # deterministic install from package-lock.json
+npm ci
 npm run build
-npm run test
-```
-
-Additional checks used in CI:
-
-```bash
+npm test
 npm run lint
 npm run size
 ```
 
-## Testing
+`npm test` runs: Truffle compile/tests, additional Node tests, and contract size guards.
 
-- Testing runbook and deterministic guidance: [`docs/TESTING.md`](docs/TESTING.md)
-- Risk-based coverage matrix and regression policy: [`docs/TEST_PLAN.md`](docs/TEST_PLAN.md)
-- Diagram-first architecture of test harness and failure modes: [`docs/ARCHITECTURE_TESTS.md`](docs/ARCHITECTURE_TESTS.md)
 
-## Architecture + illustrations
+## Documentation
 
-### Job lifecycle (state machine)
-```mermaid
-stateDiagram-v2
-    [*] --> Open: createJob
-    Open --> InProgress: applyForJob
-    InProgress --> CompletionRequested: requestJobCompletion
+- Main docs index: [`docs/README.md`](docs/README.md)
+- Quintessential end-to-end walkthrough: [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
 
-    CompletionRequested --> ApprovalWindow: validateJob (approval threshold)
-    ApprovalWindow --> Completed: finalizeJob (after challenge window)
-    CompletionRequested --> Completed: finalizeJob (timeout, no validator activity)
-    CompletionRequested --> Refunded: finalizeJob (timeout, employer win)
-
-    CompletionRequested --> Disputed: disapproveJob (disapproval threshold)
-    CompletionRequested --> Disputed: disputeJob (manual)
-
-    Disputed --> Completed: resolveDisputeWithCode(AGENT_WIN)
-    Disputed --> Refunded: resolveDisputeWithCode(EMPLOYER_WIN)
-    Disputed --> Completed: resolveStaleDispute (owner, timeout)
-
-    InProgress --> Expired: expireJob (timeout, no completion request)
-
-    Open --> Deleted: cancelJob (employer)
-    Open --> Deleted: delistJob (owner)
-```
-*Note:* `validateJob`/`disapproveJob` require `completionRequested` to be true; validators can only act after the agent submits completion metadata. `resolveDispute` with a non‑canonical resolution string maps to `NO_ACTION` and leaves the dispute active. Agent‑win dispute resolution requires a prior completion request so settlement always has completion metadata; agents may submit completion even if a dispute is already open, including after the nominal duration has elapsed or while paused for dispute recovery. `Deleted` corresponds to cancelled/delisted jobs where the job struct is cleared (`employer == address(0)`).
-
-**Settlement invariant (payout + NFT)**: the agent can only be paid and the completion NFT can only be minted after a completion request is recorded on-chain **and** a non-empty, valid completion metadata URI is stored. Moderators/owners cannot award an agent win without that completion request, and the job NFT always points to the completion metadata (not the job spec).
-
-**Dispute lane policy**
-- Disputes can only be initiated after completion is requested (`completionRequested == true`).
-- Once disputed, validator voting is frozen; approvals/disapprovals no longer progress settlement.
-- Settlement while disputed happens only via moderator resolution or owner stale‑dispute resolution (pause optional, after the dispute review window).
-
-### Full‑stack trust layer (signaling → enforcement)
-```mermaid
-flowchart LR
-    subgraph Off-chain signaling
-        A[Agents, Validators, Observers] --> B[ERC-8004 signals]
-        B --> C[Indexers / Rankers]
-        C --> D[Policy decisions<br/>allowlists, trust tiers]
-    end
-
-    D -->|Merkle roots & allowlists| E[AGIJobManager contract]
-    E <-->|ENS + NameWrapper + Resolver| F[ENS contracts]
-    E --> G[Escrow, payouts,<br/>reputation, job NFTs]
-```
-
-## Roles & permissions
-
-| Role | Capabilities | Trust considerations |
-| --- | --- | --- |
-| **Owner** | Pause/unpause, set parameters, manage allowlists/blacklists, add moderators and AGI types, withdraw surplus ERC‑20 (balance minus locked escrow + bonds). | Highly privileged. Compromise or misuse can override operational safety. |
-| **Moderator** | Resolve disputes via `resolveDispute`. | Central dispute authority; outcomes depend on moderator integrity. |
-| **Employer** | Create jobs, fund escrow, cancel pre-assignment, dispute jobs, receive job NFTs. | Funds are custodied by contract until resolution. |
-| **Agent** | Apply for jobs, request completion, earn payouts and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
-| **Validator** | Approve/disapprove jobs, earn payout share and reputation. | Eligibility gated by allowlists/Merkle/ENS. |
-
-## Deploy & Ops
-
-- Deployment sequence: [`docs/DEPLOY_RUNBOOK.md`](docs/DEPLOY_RUNBOOK.md)
-- Day-2 operations and incident playbooks: [`docs/OPERATIONS.md`](docs/OPERATIONS.md)
-- Configuration reference for owner-settable knobs: [`docs/CONFIGURATION.md`](docs/CONFIGURATION.md)
-- Mainnet institutional runbook (deploy + incident + diagrams): [`docs/MAINNET_OPERATIONS.md`](docs/MAINNET_OPERATIONS.md)
-
-### Mainnet token assumptions (production)
-
-- AGIALPHA token address: `0xa61a3b3a130a9c20768eebf97e21515a6046a1fa`.
-- The system expects exact-transfer ERC20 semantics (no fee-on-transfer/rebase behavior).
-- AGIALPHA token-level pause must remain unpaused for normal operation.
-- ENS integration is intentionally best-effort; core escrow/settlement correctness does not depend on ENS success.
-
-### Dependency pinning note
-
-- `@openzeppelin/contracts` is pinned to `4.9.6` to keep v4 import paths and Ownable constructor behavior stable across deterministic builds.
-
-**Compiler note**: `AGIJobManager.sol` declares `pragma solidity ^0.8.19`, while the Truffle compiler is pinned to `0.8.23` in `truffle-config.js`. `viaIR` remains **disabled** to keep runtime bytecode under the EIP‑170 cap; the large job getter is kept internal and covered by targeted read‑model getters, keeping the legacy pipeline stable.
-
-## Contract documentation
-
-Detailed contract documentation lives in `docs/`:
-
-- [Configure-once operations guide](docs/CONFIGURE_ONCE.md)
-- [Configure-once deployment profile](docs/DEPLOYMENT_PROFILE.md)
-- [Deployment checklist](docs/deployment-checklist.md)
-- [Minimal governance operations](docs/minimal-governance.md)
-- [Minimal governance model](docs/GOVERNANCE.md)
-- [AGI Jobs one-pager (canonical narrative)](docs/AGI_JOBS_ONE_PAGER.md)
-- [AGIJobManager overview](docs/AGIJobManager.md)
-- [AGIJobManager interface reference](docs/AGIJobManager_Interface.md)
-- [Contract read API (job getters)](docs/contract-read-api.md)
-- [Bytecode size & job getters](docs/bytecode-and-getters.md)
-- [AGIJobManager operator guide](docs/AGIJobManager_Operator_Guide.md)
-- [AGIJobManager security considerations](docs/AGIJobManager_Security.md)
-- [Identity lock & treasury pause semantics](docs/identity-lock-and-treasury.md)
-- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
-- [Security policy](SECURITY.md)
-
-## Mainnet bytecode size (EIP-170)
-
-Ethereum mainnet enforces a **24,576-byte** runtime bytecode cap (Spurious Dragon / EIP‑170). Always check the deployed runtime size before deploying:
+Documentation maintenance commands:
 
 ```bash
-node -e "const a=require('./build/contracts/AGIJobManager.json'); const b=(a.deployedBytecode||'').replace(/^0x/,''); console.log('AGIJobManager deployedBytecode bytes:', b.length/2)"
+npm run docs:gen
+npm run docs:check
+npm run check:no-binaries  # check-no-binaries
 ```
-
-The mainnet deployment settings that keep `AGIJobManager` under the limit are:
-- Optimizer: enabled
-- `optimizer.runs`: **50** (pinned in `truffle-config.js`)
-- `viaIR`: **false** by default
-- `metadata.bytecodeHash`: **none**
-- `debug.revertStrings`: **strip**
-- `solc` version: **0.8.23** (pinned in `truffle-config.js`)
-- `evmVersion`: **london** (or the target chain default)
-
-To check runtime sizes locally after compilation:
-```bash
-node scripts/check-contract-sizes.js
-```
-
-To enforce a deterministic size gate on deployable contracts:
-```bash
-node scripts/check-bytecode-size.js
-```
-
-## Web UI (GitHub Pages)
-
-- Canonical UI path in-repo: [`docs/ui/agijobmanager.html`](docs/ui/agijobmanager.html)
-- Usage guide: [`docs/ui/README.md`](docs/ui/README.md)
-- Expected Pages URL pattern: `https://<org>.github.io/<repo>/ui/agijobmanager.html`
-- GitHub Pages setup: Settings → Pages → Source “Deploy from branch” → Branch `main` → Folder `/docs`.
-- The contract address is user-configurable and must be provided until the new mainnet deployment is finalized.
-- Contract address override: query param `?contract=0x...` or the UI **Save address** button (stored in `localStorage`).
-
-## ERC‑8004 integration (control plane ↔ execution plane)
-See [`docs/ERC8004.md`](docs/ERC8004.md) and [`docs/erc8004/README.md`](docs/erc8004/README.md) for the mapping spec, threat model, and adapter notes. Quick export example:
-
-```bash
-AGIJOBMANAGER_ADDRESS=0xYourContract \
-ERC8004_IDENTITY_REGISTRY=0xIdentityRegistry \
-ERC8004_REPUTATION_REGISTRY=0xReputationRegistry \
-FROM_BLOCK=0 \
-TO_BLOCK=latest \
-OUT_DIR=integrations/erc8004/out \
-truffle exec scripts/erc8004/export_feedback.js --network sepolia
-```
-
-Local dev chain (Ganache):
-```bash
-npx ganache -p 8545
-npx truffle migrate --network development
-```
-
-## Deployment & verification (Truffle)
-
-`truffle-config.js` is the source of truth for networks and env vars. A full guide lives in [`docs/Deployment.md`](docs/Deployment.md).
-
-**Environment setup**
-- Copy `.env.example` → `.env` (keep it local):
-  ```bash
-  cp .env.example .env
-  ```
-- `.env.example` lists every variable read by `truffle-config.js`, with optional defaults.
-
-**Required (Sepolia / Mainnet)**
-- `PRIVATE_KEYS`: comma-separated private keys.
-- RPC configuration, one of:
-  - `SEPOLIA_RPC_URL` / `MAINNET_RPC_URL`, or
-  - `ALCHEMY_KEY` / `ALCHEMY_KEY_MAIN`, or
-  - `INFURA_KEY`.
-
-**Verification**
-- `ETHERSCAN_API_KEY` for `truffle-plugin-verify`.
-
-**Optional tuning**
-- Gas & confirmations: `SEPOLIA_GAS`, `MAINNET_GAS`, `SEPOLIA_GAS_PRICE_GWEI`, `MAINNET_GAS_PRICE_GWEI`, `SEPOLIA_CONFIRMATIONS`, `MAINNET_CONFIRMATIONS`, `SEPOLIA_TIMEOUT_BLOCKS`, `MAINNET_TIMEOUT_BLOCKS`.
-- Provider polling: `RPC_POLLING_INTERVAL_MS`.
-- EVM version override: `SOLC_EVM_VERSION` (defaults to `london`).
-- Compiler settings are pinned in `truffle-config.js` (solc `0.8.23`, runs `50`, `evmVersion` `london`).
-- Local chain: `GANACHE_MNEMONIC`.
-
-**Network notes**
-- `test` uses an in-process Ganache provider for deterministic `truffle test` runs.
-- `development`/Ganache typically needs no env vars.
-- `sepolia` needs `ALCHEMY_KEY` (or `SEPOLIA_RPC_URL`) + `PRIVATE_KEYS`.
-- `mainnet` needs `ALCHEMY_KEY_MAIN` (or `MAINNET_RPC_URL`) + `PRIVATE_KEYS`.
-- `PRIVATE_KEYS` format: comma-separated, no spaces, keep it local.
-
-> **Deployment caution**: `migrations/2_deploy_contracts.js` reads constructor parameters from environment variables. Ensure token/ENS/NameWrapper/root nodes/Merkle roots are set correctly before any production deployment.
-
-## Security considerations
-
-- **Centralization risk**: the owner can change critical parameters and withdraw surplus AGI (balance minus `lockedEscrow`) while paused; moderators can resolve disputes.
-- **Eligibility gating**: ENS registry/NameWrapper/root nodes are intended to be configured before any job exists and then locked; Merkle roots remain configurable for allowlist updates.
-- **Token compatibility**: ERC‑20 `transfer`/`transferFrom` may return `true`/`false` **or** return no data; calls that revert or return `false` are treated as failures. Fee‑on‑transfer, rebasing, and other balance‑mutating tokens are **not supported**; escrow deposits enforce exact amounts received.
-- **Validator trust**: validators are allowlisted; no slashing or decentralization guarantees.
-- **Duration enforcement**: only `requestJobCompletion` enforces the job duration; validators can still approve/disapprove after a deadline **once completion is requested** unless off‑chain policies intervene.
-- **Dispute resolution codes**: moderators should use `resolveDisputeWithCode(jobId, code, reason)` with `code = 0 (NO_ACTION)`, `1 (AGENT_WIN)`, or `2 (EMPLOYER_WIN)`. The `reason` is freeform and does not control settlement. The legacy string-based `resolveDispute` is deprecated; non‑canonical strings map to `NO_ACTION` and keep the dispute active.
-- **Agent payout snapshot**: the agent payout percentage is snapshotted at `applyForJob` and used at completion; later NFT transfers do **not** change payout for that job. Agents must have a nonzero AGI‑type payout tier at apply time (0% tiers cannot accept jobs), and `additionalAgents` only bypass identity checks (not payout eligibility).
-
-## Pause behavior
-
-Pause is an incident-response safety control. When paused, **new activity** is blocked (job creation, applications, validation/disputes), but safe exits remain available. Assigned agents can still call `requestJobCompletion`, and settlement exits (`cancelJob`, `expireJob`, `finalizeJob`) still work when their normal predicates are satisfied. Resume operations by unpausing once the issue is resolved.
-
-See [`docs/Security.md`](docs/Security.md) for a detailed threat model and known limitations.
-
-## Ecosystem links
-
-- **Repository**: https://github.com/MontrealAI/AGIJobManager
-- **Etherscan (deployment-specific)**: https://etherscan.io/address/<contract-address>
-- **OpenSea (job NFTs, deployment-specific)**: https://opensea.io/assets/ethereum/<contract-address>
-- **ERC‑8004 specification**: https://eips.ethereum.org/EIPS/eip-8004
-- **ERC‑8004 deck (framing)**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0/blob/main/docs/presentation/MONTREALAI_x_ERC8004_v0.pdf
-- **ERC‑8004 deck (repo copy)**: [`presentations/MONTREALAI_x_ERC8004_v0.pdf`](presentations/MONTREALAI_x_ERC8004_v0.pdf)
-- **Institutional overview (repo PDF)**: [`presentations/AGI_Eth_Institutional_v0.pdf`](presentations/AGI_Eth_Institutional_v0.pdf)
-- **AGI‑Alpha‑Agent reference repo**: https://github.com/MontrealAI/AGI-Alpha-Agent-v0
-- **ENS docs**: https://docs.ens.domains/
-- **ENS NameWrapper**: https://docs.ens.domains/ens-improvement-proposals/ensip-10-namewrapper
-- **OpenZeppelin Contracts**: https://docs.openzeppelin.com/contracts/4.x/
-- **Truffle**: https://trufflesuite.com/docs/truffle/
-
-## Documentation index
-
-Start here:
-- [`docs/README.md`](docs/README.md)
-- [Mainnet deployment & security overview](docs/mainnet-deployment-and-security-overview.md)
-- [Security policy](SECURITY.md)
-- **Non‑technical user guides**: [`docs/user-guide/README.md`](docs/user-guide/README.md)
-- [`docs/AGIJobManager.md`](docs/AGIJobManager.md)
-- [`docs/ParameterSafety.md`](docs/ParameterSafety.md)
-- [`docs/ops/parameter-safety.md`](docs/ops/parameter-safety.md)
-- [`docs/Deployment.md`](docs/Deployment.md)
-- [`docs/Security.md`](docs/Security.md)
-- [`docs/Testing.md`](docs/Testing.md)
-- [`docs/ERC8004.md`](docs/ERC8004.md)
-- [`docs/Interface.md`](docs/Interface.md)
-  - To regenerate from ABI: `npm run build` then `npm run docs:interface`.
-- **ERC‑8004 integration (control plane ↔ execution plane)**: [`docs/erc8004/README.md`](docs/erc8004/README.md)
-- **AGI.Eth Namespace (alpha)**:
-  - User guide: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA.md)
-  - Quickstart: [`docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md`](docs/namespace/AGI_ETH_NAMESPACE_ALPHA_QUICKSTART.md)
-  - Identity gating appendix: [`docs/namespace/ENS_IDENTITY_GATING.md`](docs/namespace/ENS_IDENTITY_GATING.md)
-  - FAQ: [`docs/namespace/FAQ.md`](docs/namespace/FAQ.md)
-
-## UI / Sovereign Ops Console
-
-[![UI CI](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ui.yml/badge.svg)](https://github.com/MontrealAI/AGIJobManager/actions/workflows/ui.yml)
-
-A standalone institutional Next.js UI lives in [`ui/`](./ui) with deterministic demo fixtures, read-only-first navigation, and simulation-first transaction safety.
-
-### Quick start
-```bash
-cd ui
-npm ci
-NEXT_PUBLIC_DEMO_MODE=1 npm run dev
-```
-
-### Documentation
-- [docs/ui/README.md](./docs/ui/README.md)
-- [Architecture](./docs/ui/ARCHITECTURE.md)
-- [Job lifecycle](./docs/ui/JOB_LIFECYCLE.md)
-- [Ops runbook](./docs/ui/OPS_RUNBOOK.md)
-- [Security model](./docs/ui/SECURITY_MODEL.md)
-- [Design system](./docs/ui/DESIGN_SYSTEM.md)
-- [Demo mode](./docs/ui/DEMO.md)
-- [Testing](./docs/ui/TESTING.md)
-- [Contract interface](./docs/ui/CONTRACT_INTERFACE.md)
-- [Pinned versions](./docs/ui/VERSIONS.md)
-
-### Text-only graphics (no binary screenshots)
-![Sovereign palette](./docs/ui/assets/palette.svg)
-![UI wireframe](./docs/ui/assets/ui-wireframe.svg)
-
-Security highlights: read-only mode without wallet, simulation-first write paths, URI allowlisting, strict security headers, and CI-enforced no-binaries checks (`npm run check:no-binaries`).

--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -1,354 +1,259 @@
 # AGIJobManager Etherscan Guide (Read/Write Contract)
 
-This guide is for users who only want to use **Etherscan + wallet** (no CLI required).
+This guide is optimized for non-technical users using only:
+- wallet (e.g., MetaMask)
+- Etherscan `Read Contract` and `Write Contract`
 
-## Before you start (everyone)
-
-1. Open the deployed contract page on Etherscan.
-2. Confirm the contract is **verified** so the ABI-backed forms appear under **Read Contract** and **Write Contract**.
-3. Connect your wallet in **Write Contract**.
-
-### Units you must use
-
-- `payout`, `bond`, and token amounts are in the AGI token's **smallest units** (like wei for ETH).
-  - Example: if token has 18 decimals, `1 token = 1000000000000000000`.
-- `duration`, `completionReviewPeriod`, `disputeReviewPeriod`, and challenge windows are **seconds**.
-  - 1 hour = `3600`
-  - 1 day = `86400`
-
-### Pre-flight checklist (always do this)
-
-Under **Read Contract**, check:
-
-- `paused()` must be `false` for intake actions (`createJob`, `applyForJob`).
-- `settlementPaused()` must be `false` for settlement actions (`requestJobCompletion`, `validateJob`, `finalizeJob`, `disputeJob`, moderator resolution).
-- Your token balance (`balanceOf`) is enough.
-- Your allowance (`allowance(owner, spender)`) is enough for AGIJobManager to pull tokens via `transferFrom`.
-
-`spender` = AGIJobManager contract address.
+## Choose your role
+- Employer: [Employer flow](#employer-flow)
+- Agent: [Agent flow](#agent-flow)
+- Validator: [validator-flow](#validator-flow)
+- Moderator: [Moderator flow](#moderator-flow)
+- Owner/operator: [Owner/operator flow](#owneroperator-flow)
 
 ---
 
-## Choose your role
+## Before you start
+
+### Verification matters
+Use contracts with **verified source + ABI** on Etherscan. Without this, forms are hard to use and custom errors are not decoded clearly.
+
+### Units
+- Token amounts are `uint256` base units (usually 18 decimals):
+  - `1.5` tokens => `1500000000000000000`
+- Time is seconds:
+  - `12h` => `43200`
+  - `7d` => `604800`
+
+Use helper tools:
+- `node scripts/etherscan/prepare_inputs.js --action convert --amount 1.5 --duration 7d`
+
+### Safety checklist before any transaction
+Read these first:
+- `paused()`
+- `settlementPaused()`
+- `getJobCore(jobId)` and `getJobValidation(jobId)` for job actions
+- AGI token `balanceOf(yourAddress)`
+- AGI token `allowance(yourAddress, AGIJobManager)`
+
+### Common failure modes
+
+| Error / symptom | Likely cause | Fix |
+|---|---|---|
+| `NotAuthorized` | caller lacks role authorization | use additional allowlist, Merkle proof, or ENS auth route |
+| `SettlementPaused` | settlement switch enabled | wait for owner unpause or use only non-settlement reads |
+| `InvalidState` | wrong lifecycle stage | check `getJobCore` + timeline before retry |
+| `TransferFailed` | insufficient allowance/balance or non-standard token behavior | set allowance, verify balance, use exact-transfer ERC20 |
+| finalize opens dispute | tie/under-quorum outcome | moderator resolution required |
+
+---
 
 ## Employer flow
 
-### 1) Approve AGI allowance
+### 1) Approve escrow pull on AGI token
+Write function: `approve(spender, amount)` (on AGI ERC20)
 
-On the AGI ERC-20 token contract (Write tab):
-- `approve(spender, amount)`
-  - `spender`: AGIJobManager address
-  - `amount`: payout in base units
+Input meaning:
+- `spender`: AGIJobManager contract address
+- `amount`: payout in base units
 
-Example:
-- Human: 1,200 AGI
-- Base units (18 decimals): `1200000000000000000000`
+Copy/paste example:
+```text
+spender: 0xYourAGIJobManager
+amount: 1200000000000000000000   // 1200 tokens at 18 decimals
+```
 
 ### 2) Create job
+Write function: `createJob(jobSpecURI, payout, duration, details)`
 
-On AGIJobManager (Write tab):
-- `createJob(jobSpecURI, payout, duration, details)`
+Input meaning:
+- `jobSpecURI`: metadata URI (ipfs/https)
+- `payout`: base-unit token amount
+- `duration`: seconds
+- `details`: short plain text summary
 
-Example inputs:
-- `jobSpecURI`: `ipfs://bafybeigdyrzt.../jobSpec.v1.json`
-- `payout`: `1200000000000000000000`
-- `duration`: `259200` (3 days)
-- `details`: `Spanish-to-English legal translation, 40 pages`
+Example:
+```text
+jobSpecURI: ipfs://bafy.../job-spec.v1.json
+payout: 1200000000000000000000
+duration: 259200
+details: Translate legal packet EN->ES
+```
 
-### 3) Optional cancel (before assignment only)
+### 3) Cancel if unassigned
+Write function: `cancelJob(jobId)`
 
-- `cancelJob(jobId)`
-- Reverts with `InvalidState` after an agent is assigned.
+### 4) Finalize when eligible
+Write function: `finalizeJob(jobId)`
 
-### 4) Finalize after completion request / voting windows
-
-- `finalizeJob(jobId)`
-- If validators approved early and challenge period passed, finalization can succeed before full review window.
-- If review window ends with tie/under-quorum, this call can create a dispute instead of settling.
-
-### 5) Raise dispute if needed
-
-- `disputeJob(jobId)`
-- Employer or assigned agent can call during review period after completion is requested.
-- Requires dispute bond transfer (approve first if needed).
-
-### 6) `delistJob(jobId)` meaning
-
-- `delistJob(jobId)` is **owner-only** emergency/admin cancellation for unassigned jobs.
-- Employers should normally use `cancelJob`.
-
-### 7) Events to track in Etherscan logs
-
-- `JobCreated` → job posted
-- `JobApplied` → agent assigned
-- `JobCompletionRequested` → completion submitted
-- `JobDisputed` → dispute opened
-- `JobCompleted` → settled agent-win path
-- `JobExpired` → expired and refunded to employer
-
-### If employer actions revert
-
-- `NotAuthorized`: wrong caller (not employer for employer-only action).
-- `InvalidState`: wrong lifecycle stage (e.g., cancel after assignment; finalize too early).
-- `SettlementPaused`: settlement actions paused.
-- `TransferFailed`: allowance/balance/token behavior problem.
+### 5) Open dispute when needed
+Write function: `disputeJob(jobId)`
 
 ---
 
 ## Agent flow
 
-### Agent authorization decision tree
+### Authorization decision tree
+Use one route:
+1. owner allowlist (`additionalAgents`) OR
+2. Merkle proof (`agentMerkleRoot`) OR
+3. ENS ownership under configured root node
 
-An agent can pass authorization if **any one** is true:
+### 1) Approve agent bond if required
+Write function on token: `approve(spender, amount)`
 
-1. `additionalAgents(agentAddress) == true` (owner allowlist), or
-2. Agent is in current agent Merkle root with valid proof, or
-3. ENS ownership path validates for the submitted subdomain.
+### 2) Apply to job
+Write function: `applyForJob(jobId, subdomain, proof)`
 
-If none pass, `applyForJob` reverts `NotAuthorized`.
+Input meanings:
+- `jobId`: target job
+- `subdomain`: ENS label used for ENS auth path (or placeholder if using allowlist/merkle)
+- `proof`: bytes32[] merkle proof
 
-### 1) Approve AGI for agent bond (if bond > 0)
-
-- On AGI token: `approve(AGIJobManager, amount)`.
-
-### 2) Apply to a job
-
-- `applyForJob(jobId, subdomain, proof)`
-
-Examples:
-- `jobId`: `42`
-- `subdomain`: `alice-agent`
-- `proof` (Etherscan bytes32[]):
-  - `[]` (if allowlisted directly and not using Merkle)
-  - `[
-    "0x2b5d5b6f8c6f5f7a4fcb89de0d4045ce2f4b56e09a1ce3b7f7a1738ac9f2d103",
-    "0x8f26f0de0efecf7c54a8b44e8d5f8d0617f0af6f94fd5f4d1f4f208f01877d71"
-  ]`
+Proof paste formats:
+```text
+[]
+```
+```text
+["0xaaa...", "0xbbb..."]
+```
 
 ### 3) Submit completion
+Write function: `requestJobCompletion(jobId, jobCompletionURI)`
 
-- `requestJobCompletion(jobId, jobCompletionURI)`
+Example URI:
+```text
+ipfs://bafy.../completion.v1.json
+```
 
-Example:
-- `jobCompletionURI`: `ipfs://bafybeibf.../jobCompletion.v1.json`
-
-### 4) Dispute (if needed)
-
-- `disputeJob(jobId)` during review period.
-
-### If agent actions revert
-
-- `NotAuthorized`: authorization path failed or wrong caller.
-- `Blacklisted`: address is blacklisted.
-- `IneligibleAgentPayout`: agent lacks required AGI type eligibility.
-- `InvalidState`: already assigned/completed/disputed/out-of-window.
-- `TransferFailed`: missing allowance or token transfer failure.
+### 4) Optional dispute
+Write function: `disputeJob(jobId)`
 
 ---
 
 ## Validator flow
 
-### Validator authorization decision tree
+### Authorization decision tree
+Use one route:
+1. owner allowlist (`additionalValidators`) OR
+2. Merkle proof (`validatorMerkleRoot`) OR
+3. ENS ownership under configured root node
 
-Validator can vote if **any one** is true:
+### 1) Approve validator bond
+Token write function: `approve(spender, amount)`
 
-1. `additionalValidators(validatorAddress) == true`, or
-2. Included in validator Merkle root with valid proof, or
-3. ENS ownership path validates for submitted subdomain.
+### 2) Vote
+- approve: `validateJob(jobId, subdomain, proof)`
+- reject: `disapproveJob(jobId, subdomain, proof)`
 
-### 1) Approve AGI for validator bond
+Proof paste format:
+```text
+["0xaaa...", "0xbbb..."]
+```
 
-- On AGI token: `approve(AGIJobManager, amount)`.
-
-### 2) Cast vote
-
-- Approve outcome: `validateJob(jobId, subdomain, proof)`
-- Reject outcome: `disapproveJob(jobId, subdomain, proof)`
-
-Proof format for Etherscan:
-
-`["0xabc...","0xdef..."]`
-
-### 3) Practical voting checklist
-
-Vote only when:
-- `completionRequested == true`
-- current time <= `completionRequestedAt + completionReviewPeriod`
-- you have not already voted
-
-Avoid voting when:
-- dispute already active (`disputed == true`)
-- review window passed
-
-Gas note:
-- first validator vote initializes per-job validator bond amount and may cost more gas.
-
-### Slashing (high-level)
-
-- Validators post a bond per vote.
-- Validators on the incorrect side can be partially slashed by `validatorSlashBps`.
-- Correct-side validators share reward pool + slashed amounts.
-
-### How votes affect finalization
-
-- Early approve path: enough approvals sets `validatorApproved`; finalize allowed after challenge period.
-- At review end:
-  - no votes → deterministic agent-win settlement,
-  - tie or under quorum → dispute is opened,
-  - majority approvals → agent-win,
-  - majority disapprovals → employer refund path.
-
-### If validator actions revert
-
-- `NotAuthorized` / `Blacklisted` / `InvalidState` / `TransferFailed`.
-- `ValidatorLimitReached` if max validators per job reached.
+Outcome notes:
+- wrong-side validators can be slashed
+- correct-side validators can share rewards
 
 ---
 
 ## Moderator flow
 
-### Resolve dispute
+Write function: `resolveDisputeWithCode(jobId, resolutionCode, reason)`
 
-- `resolveDisputeWithCode(jobId, resolutionCode, reason)`
+Resolution code table:
+- `0` = NO_ACTION (dispute remains)
+- `1` = AGENT_WIN
+- `2` = EMPLOYER_WIN
 
-`resolutionCode` values:
-- `0` = log-only no-op (emits event, dispute remains active)
-- `1` = resolve in favor of agent (`_completeJob` path)
-- `2` = resolve in favor of employer (`_refundEmployer` path)
-
-Reason examples:
-- `"Evidence confirms milestone delivered; agent prevails"`
-- `"Major spec mismatch; employer refunded"`
-
-`reason` is emitted in `DisputeResolvedWithCode` and visible on-chain.
+Standardized reason format (recommended):
+```text
+EVIDENCE:v1|summary:<one line>|links:<ipfs/case refs>|policy:<section>|moderator:<id>|ts:<unix>
+```
 
 ---
 
 ## Owner/operator flow
 
 ### Pause controls
+- intake only: `pause()` / `unpause()`
+- settlement toggle: `setSettlementPaused(true/false)`
+- full stop: `pauseAll()`
 
-- `pause` / `unpause` (aka intake pause helpers exist too)
-- `setSettlementPaused(bool)` controls settlement actions and also gates calls that require `whenSettlementNotPaused` (including `createJob`/`applyForJob`).
-
-Plain English:
-- `pause=true` blocks new intake actions.
-- `settlementPaused=true` blocks settlement/dispute/finalization paths.
-
-### Treasury withdrawal (safe sequence)
-
-1. `pause()` (required for `withdrawAGI`).
-2. `withdrawableAGI()` (Read) to get max safe amount.
-3. `withdrawAGI(amount)` with `amount <= withdrawableAGI`.
-
-### Manage allowlists / roots
-
-- `updateMerkleRoots(validatorRoot, agentRoot)`
-- `addAdditionalAgent` / `removeAdditionalAgent`
-- `addAdditionalValidator` / `removeAdditionalValidator`
-
-### Moderators / blacklists
-
-- `addModerator` / `removeModerator`
-- `blacklistAgent(address, status)`
-- `blacklistValidator(address, status)`
-
-### ENS configuration
-
-- `setEnsJobPages(address)`
-- `setUseEnsJobTokenURI(bool)`
-- `lockIdentityConfiguration()` (irreversible lock of identity wiring controls)
-
-### Rescue functions (extreme caution)
-
-- `rescueERC20(token, to, amount)`
-- `rescueToken(token, data)`
-- `rescueETH(amount)`
-
-These are emergency tools; misuse can break trust with users. Use formal runbook and sign-off.
+### Governance/admin writes
+- allowlists: `addAdditionalAgent`, `addAdditionalValidator`
+- blacklists: `blacklistAgent`, `blacklistValidator`
+- moderators: `addModerator`, `removeModerator`
+- withdrawals: `withdrawableAGI()` (read) then `withdrawAGI(amount)`
+- ENS config: `setEnsJobPages`, `setUseEnsJobTokenURI`, `updateRootNodes`, `updateMerkleRoots`
+- lock identity config: `lockIdentityConfiguration()`
+- rescue/break-glass: `rescueERC20`, `rescueToken` (extreme caution)
 
 ---
 
-## Time windows and finalization timeline
+## Time windows
 
 ```text
-assignedAt -------------------- assignedAt + duration
-    |                                   |
-    |<----- agent can work ------------>| (after this, expire path possible if no completion request)
-
-completionRequestedAt ---------------- completionRequestedAt + completionReviewPeriod
-         |                                        |
-         |<----- validators can vote ------------>| finalize may settle or open dispute
-
-validatorApprovedAt ----- validatorApprovedAt + challengePeriodAfterApproval
-         |                               |
-         |<-- early finalize blocked -->| after this, early finalize can settle if approvals > disapprovals
+assign --> request completion --> review window --> challenge window --> finalize OR dispute --> resolve
 ```
 
-### “Can I call finalize now?” checklist
-
-1. `completionRequested == true`?
-2. If `validatorApproved == true`, has `challengePeriodAfterApproval` elapsed?
-3. If not early path, has `completionReviewPeriod` elapsed?
-4. If tie/under-quorum, expect dispute creation on finalize.
-
-If unsure: you can still call `finalizeJob(jobId)`; if too early, it reverts `InvalidState`.
+### Can I finalize now?
+Checklist:
+1. Read `getJobCore(jobId)`: `completionRequested == true`, `disputed == false`, not completed/expired/cancelled.
+2. Read `getJobValidation(jobId)` for vote counters/timing parameters.
+3. Compare `completionRequestedAt + completionReviewPeriod` and challenge period with current timestamp.
+4. If tied/under-quorum at review end, expect dispute path.
 
 ---
 
-## Read Contract cheat sheet
+## Read-contract cheat sheet
 
-- `getJobCore(jobId)`
-  - employer, assignedAgent, payout, duration, assignedAt, completed, disputed, expired, agentPayoutPct.
-- `getJobValidation(jobId)`
-  - completionRequested, validatorApprovals, validatorDisapprovals, completionRequestedAt, disputedAt.
-- `getJobSpecURI(jobId)`
-  - original job spec URI.
-- `getJobCompletionURI(jobId)`
-  - submitted completion URI.
-- `tokenURI(tokenId)`
-  - completion NFT metadata URI.
-
-State inference examples:
-- `assignedAgent == 0x000...0` and `completed == false` → unassigned/open.
-- `completionRequested == true` and `disputed == false` → in validator review.
-- `completed == true` → settled and NFT minted.
-- `expired == true` → expired path executed.
+- `getJobCore(jobId)`: canonical lifecycle fields (participants, payout, timestamps, flags).
+- `getJobValidation(jobId)`: review/dispute windows and vote counters/state.
+- `getJobSpecURI(jobId)`: original job metadata URI.
+- `getJobCompletionURI(jobId)`: submitted completion metadata URI.
+- `tokenURI(tokenId)`: final NFT metadata URI after completion.
 
 ---
 
-## Revert/error decoding for Etherscan users
+## Authorization details (especially for Agent/Validator)
 
-Common custom errors and likely fixes:
+### Route 1: owner additional allowlist
+- Agent: `addAdditionalAgent(address)`
+- Validator: `addAdditionalValidator(address)`
 
-- `NotAuthorized`
-  - Caller is wrong role or proof/ENS/allowlist authorization failed.
-- `Blacklisted`
-  - Address is owner-blacklisted.
-- `InvalidParameters`
-  - Bad input value/format (zero or too large period, invalid resolution code, invalid URI length, etc.).
-- `InvalidState`
-  - Right function, wrong timing/lifecycle stage.
-- `SettlementPaused`
-  - settlement toggled off by owner.
-- `TransferFailed`
-  - allowance/balance missing, or token transfer behavior incompatible.
-- `ValidatorLimitReached`
-  - max validators for this job already reached.
-- `InsufficientWithdrawableBalance` / `InsolventEscrowBalance`
-  - attempted treasury withdrawal exceeds safe withdrawable amount.
+### Route 2: Merkle proof
+- leaf format: `keccak256(abi.encodePacked(address))`
+- proof pasted as Etherscan bytes32[]
+- offline generation script:
+  - `node scripts/merkle/export_merkle_proofs.js --input addresses.json`
 
-Tip: Etherscan shows custom error names only if ABI is verified and matched to deployed bytecode.
+### Route 3: ENS subdomain ownership
+Subdomain label constraints:
+- lowercase ASCII
+- length 1..63
+- `[a-z0-9-]` only
+- no dots
+- no leading/trailing dash
+
+Decision tree:
+```text
+If owner allowlisted you -> use [] proof and proceed.
+Else if you have Merkle proof -> paste bytes32[] proof.
+Else if you own valid ENS subdomain under configured root -> use subdomain route.
+Else -> you are not authorized yet.
+```
 
 ---
 
-## Merkle proof helper (offline)
+## Offline helper scripts
 
-Use repo helper script (no RPC calls):
+- Merkle proofs: `node scripts/merkle/export_merkle_proofs.js --input addresses.json`
+- Etherscan input prep: `node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 3d`
+- Offline state advisor: `node scripts/advisor/state_advisor.js --input sample-job.json`
 
-- Single address proof:
-  - `node scripts/merkle/generate_merkle_proof.js --input scripts/merkle/sample_addresses.json --address 0x...`
-- Full map (root + proofs for all addresses):
-  - `node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json --output proofs.json`
-
-`proofs.json` output is directly copy/pasteable into Etherscan bytes32[] fields.
+Advisor input note (copy from Read Contract outputs):
+- `getJobCore`: include `assignedAt`, `duration`, `completed`, `disputed`, `expired`, `employer`, `assignedAgent`.
+- `getJobValidation`: include `completionRequested`, `completionRequestedAt`, `disputedAt`, and (if available from your snapshot pipeline) `validatorApproved` + `validatorApprovedAt`.
+- also provide current timestamp and protocol windows (`completionReviewPeriod`, `disputeReviewPeriod`, `challengePeriodAfterApproval`) for accurate time-gated advice; if omitted, advisor suppresses dependent actions.
+- Time gates in advisor follow contract-style strict elapsed checks; for finalize/expire/stale resolution, current timestamp must be **strictly greater than** the reported threshold.

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,67 +1,40 @@
-# AGIJobManager FAQ (Etherscan-focused)
+# FAQ (Etherscan-first)
 
-## Why do I need to approve first?
+## Why do I need approval before create/apply/vote/dispute?
 
-AGIJobManager uses ERC-20 `transferFrom` for escrow and bonds. The contract cannot pull your tokens unless you grant allowance first on the AGI token contract (`approve(spender, amount)`).
+AGIJobManager pulls AGI with `transferFrom`, so allowance on the AGI token is required.
 
-## How do I paste a `bytes32[]` proof into Etherscan?
+## Should I use exact-amount approvals?
 
-Use JSON-array syntax in a single input box:
+For least privilege, yes: approve only the exact amount needed for escrow or bond, then raise if necessary.
+
+## How do I paste `bytes32[]` proofs in Etherscan?
+
+Use one-line JSON array:
 
 ```text
-["0xabc...","0xdef..."]
+[]
 ```
 
-Notes:
-- include quotes around each 32-byte hex value,
-- include `0x` prefix,
-- for empty proof use `[]`.
+```text
+["0xabc...", "0xdef..."]
+```
 
-## Why did `finalizeJob` create a dispute instead of paying out?
+## Why can `finalizeJob` open a dispute instead of settling?
 
-At review-window end, `finalizeJob` opens a dispute when votes are tied or total votes are below quorum. This is expected behavior to avoid low-participation settlement.
+At review end, tie or under-quorum outcomes move to dispute flow by design.
 
-## What happens if nobody votes?
+## What if nobody votes?
 
-If no validator votes are cast and review window ends, `finalizeJob` settles deterministically in the agent-win path (non-dispute).
+At review-end timeout with no validator votes, contract follows deterministic finalize behavior (check `getJobValidation` + `finalizeJob` outcome path).
 
-## What does `paused` vs `settlementPaused` mean?
+## What is `paused` vs `settlementPaused`?
 
-- `paused`: intake-side pause (new create/apply activity blocked). Voting remains possible unless settlement is also paused.
-- `settlementPaused`: settlement/dispute/finalization paths blocked, and functions using `whenSettlementNotPaused` (including `createJob`/`applyForJob`) are blocked.
+- `paused`: intake pause controls (create/apply and related intake lanes)
+- `settlementPaused`: settlement/dispute/finalization lane pause
 
-Operators can use them separately for incident control.
+Operators can toggle independently for incident response.
 
-## Why does my ERC-20 transfer revert?
+## Why do fee-on-transfer/deflationary ERC20 tokens fail?
 
-Common causes:
-- insufficient wallet balance,
-- insufficient allowance,
-- token is fee-on-transfer/rebasing/non-standard and fails exact-transfer assumptions,
-- token-level pause or restrictions.
-
-AGIJobManager expects exact-transfer semantics; fee-on-transfer behavior can break accounting and revert.
-
-## Which addresses are authorized as agent/validator?
-
-Authorization succeeds if any of these pass:
-1. direct additional allowlist mapping,
-2. Merkle proof against current root,
-3. ENS ownership path.
-
-If all fail, calls revert `NotAuthorized`.
-
-## What does `resolutionCode` mean in moderator dispute resolution?
-
-For `resolveDisputeWithCode(jobId, resolutionCode, reason)`:
-- `0`: no-op (event only; dispute remains active),
-- `1`: agent-win resolution,
-- `2`: employer-win resolution.
-
-## Can owner withdraw escrowed user funds?
-
-Owner withdrawal is constrained by solvency checks. `withdrawAGI` is limited to `withdrawableAGI()` and only callable while paused. Locked escrow and bond balances are excluded from withdrawable amount.
-
-## Why are numbers so large in Etherscan input fields?
-
-Amounts are raw token base units (`uint256`). Convert human amount by token decimals. With 18 decimals, `1` token equals `1000000000000000000`.
+AGIJobManager accounting expects strict exact-transfer semantics. Fee-on-transfer or deflationary behavior can break invariants and revert with transfer/accounting errors.

--- a/docs/MODERATOR_RUNBOOK.md
+++ b/docs/MODERATOR_RUNBOOK.md
@@ -1,0 +1,55 @@
+# MODERATOR_RUNBOOK
+
+## 1) Dispute triage decision tree
+
+```text
+Is dispute active?
+  no  -> stop (no moderator action)
+  yes -> gather evidence bundle
+         |
+         v
+Do facts clearly support one side under policy?
+  no  -> code 0 (NO_ACTION) with reason and escalation note
+  yes -> choose code 1 (AGENT_WIN) or 2 (EMPLOYER_WIN)
+```
+
+## 2) Resolution matrix
+
+| Condition | Suggested code |
+|---|---|
+| completion evidence valid + obligations met | `1` (AGENT_WIN) |
+| completion invalid/absent + employer claim supported | `2` (EMPLOYER_WIN) |
+| insufficient/conflicting evidence | `0` (NO_ACTION) |
+
+## 3) SOP: `resolveDisputeWithCode(jobId, code, reason)`
+
+### Minimum evidence checklist
+- `getJobCore(jobId)` snapshot
+- `getJobValidation(jobId)` snapshot
+- `getJobSpecURI(jobId)` and (if present) `getJobCompletionURI(jobId)`
+- dispute claim summary from both parties
+- any off-chain artifacts referenced by URI/hash
+
+### Reason format (standardize)
+
+```text
+EVIDENCE:v1|summary:<one line>|facts:<key facts>|links:<refs>|policy:<section>|moderator:<id>|ts:<unix>
+```
+
+Examples:
+- `EVIDENCE:v1|summary:milestones met|facts:delivery+acceptance logs match|links:ipfs://...|policy:ops-2.1|moderator:mod-07|ts:1736465000`
+- `EVIDENCE:v1|summary:missing deliverable|facts:completion URI invalid|links:ipfs://...|policy:ops-2.3|moderator:mod-03|ts:1736465200`
+
+### Consistency rules
+- Use the same evidence threshold for similar cases.
+- If uncertain, prefer code `0` and request more evidence.
+- Never resolve based on private side-channel claims without verifiable references.
+
+## 4) Etherscan-only workflow
+
+1. Read `getJobCore(jobId)`.
+2. Read `getJobValidation(jobId)`.
+3. Read `getJobSpecURI(jobId)` and `getJobCompletionURI(jobId)`.
+4. Confirm dispute is active.
+5. Write `resolveDisputeWithCode(jobId, code, reason)`.
+6. Save tx hash in moderator case log.

--- a/docs/REFERENCE/VERSIONS.md
+++ b/docs/REFERENCE/VERSIONS.md
@@ -1,7 +1,7 @@
 # Versions Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `04498d330052`.
-- Source snapshot fingerprint: `04498d330052`.
+- Generated at (deterministic source fingerprint): `9a8995adf63e`.
+- Source snapshot fingerprint: `9a8995adf63e`.
 - Generation mode: deterministic from repository source files.
 
 ## Toolchain snapshot

--- a/package.json
+++ b/package.json
@@ -18,7 +18,9 @@
     "ui:abi": "node scripts/ui/export_abi.js",
     "ui:abi:check": "node scripts/ui/check_ui_abi.js",
     "merkle:proof": "node scripts/merkle/generate_merkle_proof.js",
-    "merkle:export": "node scripts/merkle/export_merkle_proofs.js"
+    "merkle:export": "node scripts/merkle/export_merkle_proofs.js",
+    "etherscan:prep": "node scripts/etherscan/prepare_inputs.js",
+    "advisor:job": "node scripts/advisor/state_advisor.js"
   },
   "dependencies": {
     "@openzeppelin/contracts": "4.9.6"

--- a/scripts/advisor/state_advisor.js
+++ b/scripts/advisor/state_advisor.js
@@ -1,0 +1,174 @@
+#!/usr/bin/env node
+
+const fs = require('fs');
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg.startsWith('--')) {
+      const k = arg.slice(2);
+      const v = argv[i + 1];
+      if (!v || v.startsWith('--')) {
+        out[k] = true;
+      } else {
+        out[k] = v;
+        i += 1;
+      }
+    }
+  }
+  return out;
+}
+
+function hasValue(v) {
+  return !(v === undefined || v === null || v === '');
+}
+
+function toBig(v, fallback = 0n) {
+  if (!hasValue(v)) return fallback;
+  return BigInt(String(v));
+}
+
+function toBigOrNull(v) {
+  if (!hasValue(v)) return null;
+  return BigInt(String(v));
+}
+
+function bool(v) {
+  return v === true || v === 'true' || v === 1 || v === '1';
+}
+
+function loadInput(args) {
+  if (args.input) return JSON.parse(fs.readFileSync(args.input, 'utf8'));
+  if (args.json) return JSON.parse(args.json);
+  throw new Error('Provide --input <file.json> or --json <json-string>');
+}
+
+function main() {
+  const args = parseArgs(process.argv);
+  const data = loadInput(args);
+
+  const now = toBig(data.currentTimestamp);
+  const core = data.getJobCore || {};
+  const val = data.getJobValidation || {};
+
+  const jobId = core.jobId ?? data.jobId ?? '?';
+  const completionRequested = bool(val.completionRequested ?? core.completionRequested);
+  const disputed = bool(core.disputed ?? val.disputed);
+  const completed = bool(core.completed);
+  const expired = bool(core.expired);
+
+  const employer = core.employer || '0x0000000000000000000000000000000000000000';
+  const assignedAgent = core.assignedAgent || core.agent || '0x0000000000000000000000000000000000000000';
+
+  const duration = toBig(core.duration);
+  const assignedAt = toBig(core.assignedAt);
+  const completionRequestedAt = toBig(val.completionRequestedAt ?? core.completionRequestedAt);
+  const disputedAt = toBig(val.disputedAt ?? core.disputedAt);
+  const validatorApproved = (val.validatorApproved ?? data.validatorApproved ?? core.validatorApproved);
+
+
+  // Global protocol-level windows and validator approval timestamp may be provided by user input.
+  const completionReviewPeriod = toBigOrNull(data.completionReviewPeriod ?? val.completionReviewPeriod);
+  const disputeReviewPeriod = toBigOrNull(data.disputeReviewPeriod ?? val.disputeReviewPeriod);
+  const challengeWindow = toBigOrNull(data.challengePeriodAfterApproval ?? val.challengeWindow ?? val.validatorChallengeWindow);
+  const validatorApprovedAt = toBigOrNull(data.validatorApprovedAt ?? val.validatorApprovedAt ?? core.validatorApprovedAt);
+
+  const reviewEndsAt = (completionRequestedAt > 0n && completionReviewPeriod !== null)
+    ? completionRequestedAt + completionReviewPeriod
+    : null;
+  const challengeEndsAt = (validatorApprovedAt !== null && validatorApprovedAt > 0n && challengeWindow !== null)
+    ? validatorApprovedAt + challengeWindow
+    : null;
+  const staleDisputeAt = (disputedAt > 0n && disputeReviewPeriod !== null)
+    ? disputedAt + disputeReviewPeriod
+    : null;
+  const expireAt = assignedAt > 0n ? assignedAt + duration : null;
+
+  let state = 'OPEN';
+  if (employer === '0x0000000000000000000000000000000000000000') state = 'CANCELLED_OR_DELISTED';
+  else if (expired) state = 'EXPIRED';
+  else if (completed) state = 'COMPLETED';
+  else if (disputed) state = 'DISPUTED';
+  else if (completionRequested) state = 'COMPLETION_REQUESTED';
+  else if (assignedAt > 0n || (assignedAgent && assignedAgent !== '0x0000000000000000000000000000000000000000')) state = 'IN_PROGRESS';
+
+  const actions = [];
+  if (state === 'OPEN') actions.push('applyForJob (eligible agent)');
+  if (state === 'OPEN') actions.push('cancelJob (employer)');
+  if (state === 'IN_PROGRESS') {
+    if (expireAt === null || now <= expireAt) {
+      actions.push('requestJobCompletion (assigned agent)');
+    }
+    if (expireAt !== null && now > expireAt) actions.push('expireJob (available once assignedAt + duration has elapsed)');
+  }
+  if (state === 'COMPLETION_REQUESTED') {
+    if (reviewEndsAt !== null && now <= reviewEndsAt) actions.push('validateJob/disapproveJob (eligible validators)');
+    if (reviewEndsAt !== null && now <= reviewEndsAt) actions.push('disputeJob (employer or assigned agent, if within allowed window)');
+
+    // finalizeJob requires review window elapsed and, when validator-approved path is active,
+    // challenge period elapsed from validatorApprovedAt.
+    const validatorApprovedKnown = validatorApproved === true || validatorApproved === false || validatorApproved === 'true' || validatorApproved === 'false' || validatorApproved === 1 || validatorApproved === 0;
+    const validatorApprovedBool = bool(validatorApproved);
+    const reviewElapsed = reviewEndsAt !== null && now > reviewEndsAt;
+    const challengeElapsed = challengeEndsAt !== null && now > challengeEndsAt;
+
+    if (reviewElapsed) {
+      if (validatorApprovedKnown) {
+        if (!validatorApprovedBool || challengeElapsed) {
+          actions.push('finalizeJob (may settle or open dispute depending on votes/quorum)');
+        }
+      } else if (challengeEndsAt !== null) {
+        if (challengeElapsed) {
+          actions.push('finalizeJob (may settle or open dispute depending on votes/quorum)');
+        }
+      }
+    }
+  }
+  if (state === 'DISPUTED') {
+    actions.push('resolveDisputeWithCode (moderator)');
+    if (staleDisputeAt !== null && now > staleDisputeAt) actions.push('resolveStaleDispute (owner)');
+  }
+
+  console.log(`Job ${jobId} advisory (offline)`);
+  console.log(`- Derived state: ${state}`);
+  console.log(`- now: ${now}`);
+  if (expireAt !== null) console.log(`- expireAt (assignedAt + duration): ${expireAt}`);
+  if (reviewEndsAt !== null) console.log(`- reviewEndsAt: ${reviewEndsAt}`);
+  if (challengeEndsAt !== null) {
+    console.log(`- challengeEndsAt (validatorApprovedAt + challengePeriodAfterApproval): ${challengeEndsAt}`);
+  }
+  if (staleDisputeAt !== null) console.log(`- staleDisputeAt (disputedAt + disputeReviewPeriod): ${staleDisputeAt}`);
+
+  const missingTiming = [];
+  if (completionReviewPeriod === null) missingTiming.push('completionReviewPeriod');
+  if (disputeReviewPeriod === null) missingTiming.push('disputeReviewPeriod');
+  if (challengeWindow === null) missingTiming.push('challengePeriodAfterApproval');
+  if (missingTiming.length > 0) {
+    console.log(`- Warning: missing timing inputs (${missingTiming.join(', ')}); advisor suppresses dependent time-gated actions.`);
+  }
+  if (!hasValue(validatorApproved) && challengeWindow !== null) {
+    console.log('- Warning: validatorApproved is unknown; finalize advice is conservatively suppressed unless challenge-gate state is provably satisfied from provided inputs.');
+  }
+
+  if (state === 'IN_PROGRESS' && expireAt !== null && now > expireAt) {
+    console.log('- Note: requestJobCompletion is suppressed because now is past assignedAt + duration for a non-disputed job.');
+  }
+  console.log('- Valid actions now:');
+  if (actions.length === 0) console.log('  - none (terminal state or missing timing inputs)');
+  for (const a of actions) console.log(`  - ${a}`);
+
+  if (state === 'COMPLETION_REQUESTED' && reviewEndsAt !== null) {
+    const finalizeGate = challengeEndsAt === null || reviewEndsAt > challengeEndsAt ? reviewEndsAt : challengeEndsAt;
+    console.log(`- Earliest conservative finalize threshold (must be strictly greater than this): ${finalizeGate}`);
+    console.log('- Note: finalize is only suggested when challenge-gate status is known-safe (or explicitly not validator-approved).');
+  }
+  if (state === 'IN_PROGRESS' && expireAt !== null) {
+    console.log(`- Earliest expire threshold (must be strictly greater than this): ${expireAt}`);
+  }
+  if (state === 'DISPUTED' && staleDisputeAt !== null) {
+    console.log(`- Earliest stale-dispute owner threshold (must be strictly greater than this): ${staleDisputeAt}`);
+  }
+}
+
+main();

--- a/scripts/etherscan/prepare_inputs.js
+++ b/scripts/etherscan/prepare_inputs.js
@@ -1,0 +1,155 @@
+#!/usr/bin/env node
+
+function parseArgs(argv) {
+  const out = {};
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (!arg.startsWith('--')) continue;
+    const key = arg.slice(2);
+    const next = argv[i + 1];
+    if (!next || next.startsWith('--')) {
+      out[key] = true;
+      continue;
+    }
+    out[key] = next;
+    i += 1;
+  }
+  return out;
+}
+
+function parseAmountToBaseUnits(input, decimals) {
+  const text = String(input).trim();
+  if (!/^\d+(\.\d+)?$/.test(text)) throw new Error(`Invalid amount: ${input}`);
+  const [whole, frac = ''] = text.split('.');
+  if (frac.length > decimals) {
+    throw new Error(`Too many decimal places for decimals=${decimals}: ${input}`);
+  }
+  const paddedFrac = (frac + '0'.repeat(decimals)).slice(0, decimals);
+  const base = `${whole}${paddedFrac}`.replace(/^0+/, '') || '0';
+  return base;
+}
+
+function parseDurationToSeconds(input) {
+  const text = String(input).trim().toLowerCase();
+  if (/^\d+$/.test(text)) return BigInt(text).toString();
+  const match = text.match(/^(\d+)([smhdw])$/);
+  if (!match) {
+    throw new Error(`Invalid duration: ${input}. Use forms like 3600, 12h, 7d`);
+  }
+  const value = BigInt(match[1]);
+  const unit = match[2];
+  const scale = {
+    s: 1n,
+    m: 60n,
+    h: 3600n,
+    d: 86400n,
+    w: 604800n,
+  }[unit];
+  return (value * scale).toString();
+}
+
+function printBlock(title, lines) {
+  console.log(`\n=== ${title} ===`);
+  for (const line of lines) console.log(line);
+}
+
+function checklist(action) {
+  const common = [
+    '- Read: paused() and settlementPaused()',
+    '- Read: job state (getJobCore/getJobValidation) if action is job-specific',
+    '- Check wallet AGI balance and ERC20 allowance',
+    '- Confirm you are using token base units and seconds',
+  ];
+  if (action === 'create-job') common.push('- Confirm intake is not paused');
+  if (action === 'finalize') common.push('- Confirm review/challenge windows are elapsed or early-approval criteria met');
+  if (action === 'resolve-dispute') common.push('- Confirm disputed=true and your address is a moderator/owner');
+  return common;
+}
+
+function asProofArray(input) {
+  if (!input) return '[]';
+  if (input.trim().startsWith('[')) return input;
+  return JSON.stringify(input.split(',').map((x) => x.trim()).filter(Boolean));
+}
+
+function run() {
+  const args = parseArgs(process.argv);
+  const action = args.action || 'help';
+  const decimals = Number(args.decimals || '18');
+
+  if (action === 'help' || args.help) {
+    console.log('Usage: node scripts/etherscan/prepare_inputs.js --action <action> [options]');
+    console.log('Actions: convert, approve, create-job, apply, request-completion, validate, disapprove, resolve-dispute, finalize');
+    process.exit(0);
+  }
+
+  if (action === 'convert') {
+    const amount = args.amount || '0';
+    const duration = args.duration || '0';
+    printBlock('Conversions', [
+      `amount(${amount}) with decimals=${decimals} => ${parseAmountToBaseUnits(amount, decimals)}`,
+      `duration(${duration}) => ${parseDurationToSeconds(duration)}`,
+    ]);
+  }
+
+  if (action === 'approve') {
+    const spender = args.spender || '<AGIJobManagerAddress>';
+    const amountHuman = args.amount || '0';
+    const amountBase = parseAmountToBaseUnits(amountHuman, decimals);
+    printBlock('Copy/paste into Etherscan: ERC20 approve(spender, amount)', [
+      `spender: ${spender}`,
+      `amount: ${amountBase}  // ${amountHuman} tokens @ ${decimals} decimals`,
+    ]);
+  }
+
+  if (action === 'create-job') {
+    const payoutHuman = args.payout || '0';
+    const payoutBase = parseAmountToBaseUnits(payoutHuman, decimals);
+    const durationSeconds = parseDurationToSeconds(args.duration || '0');
+    printBlock('Copy/paste into Etherscan: createJob(jobSpecURI, payout, duration, details)', [
+      `jobSpecURI: ${args.jobSpecURI || 'ipfs://<job-spec.json>'}`,
+      `payout: ${payoutBase}  // ${payoutHuman} tokens`,
+      `duration: ${durationSeconds}  // from ${args.duration || '0'}`,
+      `details: ${args.details || 'short plain-language job summary'}`,
+    ]);
+  }
+
+  if (action === 'apply') {
+    printBlock('Copy/paste into Etherscan: applyForJob(jobId, subdomain, proof)', [
+      `jobId: ${args.jobId || '0'}`,
+      `subdomain: ${args.subdomain || 'alice-agent'}`,
+      `proof: ${asProofArray(args.proof)}`,
+    ]);
+  }
+
+  if (action === 'request-completion') {
+    printBlock('Copy/paste into Etherscan: requestJobCompletion(jobId, jobCompletionURI)', [
+      `jobId: ${args.jobId || '0'}`,
+      `jobCompletionURI: ${args.jobCompletionURI || 'ipfs://<job-completion.json>'}`,
+    ]);
+  }
+
+  if (action === 'validate' || action === 'disapprove') {
+    printBlock(`Copy/paste into Etherscan: ${action === 'validate' ? 'validateJob' : 'disapproveJob'}(jobId, subdomain, proof)`, [
+      `jobId: ${args.jobId || '0'}`,
+      `subdomain: ${args.subdomain || 'validator-1'}`,
+      `proof: ${asProofArray(args.proof)}`,
+    ]);
+  }
+
+  if (action === 'resolve-dispute') {
+    printBlock('Copy/paste into Etherscan: resolveDisputeWithCode(jobId, resolutionCode, reason)', [
+      `jobId: ${args.jobId || '0'}`,
+      `resolutionCode: ${args.code || '1'}  // 0=NO_ACTION, 1=AGENT_WIN, 2=EMPLOYER_WIN`,
+      `reason: ${args.reason || 'EVIDENCE:v1|summary:...|links:...|moderator:...|ts:...'} `,
+    ]);
+  }
+
+  if (action === 'finalize') {
+    printBlock('Copy/paste into Etherscan: finalizeJob(jobId)', [`jobId: ${args.jobId || '0'}`]);
+  }
+
+  printBlock(`Pre-flight checklist for action=${action}`, checklist(action));
+}
+
+run();

--- a/scripts/merkle/export_merkle_proofs.js
+++ b/scripts/merkle/export_merkle_proofs.js
@@ -50,8 +50,11 @@ const leaves = addresses.map(toLeaf);
 const tree = new MerkleTree(leaves, keccak256, { sortPairs: true, sortLeaves: true });
 
 const proofs = {};
+const etherscanProofArrays = {};
 for (const address of addresses) {
-  proofs[address] = tree.getHexProof(toLeaf(address));
+  const proof = tree.getHexProof(toLeaf(address));
+  proofs[address] = proof;
+  etherscanProofArrays[address] = JSON.stringify(proof);
 }
 
 const output = {
@@ -59,6 +62,7 @@ const output = {
   merkleOptions: { sortPairs: true, sortLeaves: true },
   root: tree.getHexRoot(),
   proofs,
+  etherscanProofArrays,
 };
 
 if (outputPath) {


### PR DESCRIPTION
### Motivation
- Prevent the offline advisor from recommending `requestJobCompletion` for in-progress jobs that are already past `assignedAt + duration`, which on-chain would revert unless the job is disputed. 
- Improve operator ergonomics for Etherscan workflows by providing input-prep helpers and clearer docs for advisor inputs (timing and `validatorApproved` state). 
- Expose a conservative advisor message when time/approval inputs are missing so users are not misled into sending transactions that will fail.

### Description
- Updated `scripts/advisor/state_advisor.js` to only suggest `requestJobCompletion` for `IN_PROGRESS` when `now <= assignedAt + duration`, keep `expireJob` guidance for overdue jobs, and print an explicit note when completion guidance is suppressed. 
- Added an Etherscan input prep helper `scripts/etherscan/prepare_inputs.js` and an `advisor:job` npm script in `package.json` for easier local usage. 
- Enhanced `scripts/merkle/export_merkle_proofs.js` to emit copy/pasteable Etherscan proof arrays and added several documentation changes and new runbooks (`docs/ETHERSCAN_GUIDE.md`, `docs/FAQ.md`, `docs/MODERATOR_RUNBOOK.md`, `docs/OWNER_RUNBOOK.md`, `docs/VERIFY_ON_ETHERSCAN.md`, `docs/REFERENCE/VERSIONS.md`, and `README.md`) to document advisor inputs and Etherscan guidance. 
- No Solidity, ABI, or runtime contract changes; this is a script/docs/tooling-only change.

### Testing
- Ran `npm run docs:check`, which succeeded. 
- Ran the full JS/Truffle test suite via `npm test`, which completed successfully (`351 passing`). 
- Exercised the modified advisor with a repro input via `node scripts/advisor/state_advisor.js --input /tmp/advisor_overdue.json` and verified the suppressed `requestJobCompletion` recommendation and the added explanatory note. 
- Attempted `forge test` but it could not be executed in this environment (`bash: command not found: forge`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69931a8aa3f883338c0a23bae8379eca)