### PR TITLE
Assign unique migration index for legacy snapshot deploy path and add snapshot tooling and guards

### DIFF
--- a/docs/MAINNET_MIGRATION_FROM_LEGACY.md
+++ b/docs/MAINNET_MIGRATION_FROM_LEGACY.md
@@ -1,0 +1,78 @@
+# Mainnet migration from legacy AGIJobManager
+
+## Prerequisites
+
+- `MAINNET_RPC_URL` (read-only RPC for snapshot, funded deploy RPC for migration)
+- `ETHERSCAN_API_KEY` (required for Etherscan V2 API lookups)
+- `PRIVATE_KEYS` for the deployer account
+- `CONFIRM_MAINNET_DEPLOY=1` for mainnet execution
+
+## 1) Generate a deterministic snapshot
+
+Pin an explicit block:
+
+```bash
+MAINNET_RPC_URL=https://eth.llamarpc.com \
+ETHERSCAN_API_KEY=... \
+node scripts/snapshotLegacyMainnetConfig.js --block 24471342
+```
+
+Output file:
+
+- `migrations/snapshots/legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json`
+
+Review checklist:
+
+- addresses (`owner`, `agiToken`, `ensRegistry`, `nameWrapper`)
+- roots and merkle roots
+- numeric risk params
+- booleans (`paused`, `settlementPaused`, `lockIdentityConfig`, `useEnsJobTokenURI`)
+- dynamic sets (`moderators`, `additional*`, blacklist sets)
+- AGI type list and payout percentages
+
+## 2) Dry-run on a fork (recommended)
+
+If you have a local mainnet fork endpoint:
+
+```bash
+MAINNET_RPC_URL=http://127.0.0.1:8545 \
+PRIVATE_KEYS=<deployer_pk> \
+CONFIRM_MAINNET_DEPLOY=1 \
+truffle migrate --network mainnet --f 3 --to 3
+```
+
+## 3) Mainnet migration
+
+```bash
+MAINNET_RPC_URL=https://<your-mainnet-rpc> \
+PRIVATE_KEYS=<deployer_pk> \
+CONFIRM_MAINNET_DEPLOY=1 \
+truffle migrate --network mainnet --f 3 --to 3
+```
+
+Optional owner override:
+
+```bash
+NEW_OWNER=0x... truffle migrate --network mainnet --f 3 --to 3
+```
+
+## 4) Post-deploy verification checklist
+
+In Etherscan **Read Contract** for the new deployment:
+
+- constructor wiring: `agiToken`, `ens`, `nameWrapper`, roots, merkle roots
+- thresholds and core params
+- AGI types (`agiTypes(0..n)`)
+- moderators/additionals/blacklists where applicable
+- pause/settlement pause/identity lock flags
+- final owner address
+
+## 5) Etherscan verification with linked libraries
+
+Use repo-native Truffle verification (`truffle-plugin-verify`) after deployment:
+
+```bash
+ETHERSCAN_API_KEY=... truffle run verify AGIJobManager --network mainnet
+```
+
+Ensure library addresses printed by migration match link references in the verified metadata.

--- a/migrations/3_deploy_agijobmanager_from_legacy_snapshot.js
+++ b/migrations/3_deploy_agijobmanager_from_legacy_snapshot.js
@@ -1,0 +1,185 @@
+const path = require('path');
+const AGIJobManager = artifacts.require('AGIJobManager');
+const BondMath = artifacts.require('BondMath');
+const ENSOwnership = artifacts.require('ENSOwnership');
+const ReputationMath = artifacts.require('ReputationMath');
+const TransferUtils = artifacts.require('TransferUtils');
+const UriUtils = artifacts.require('UriUtils');
+
+const SNAPSHOT = require(path.join(__dirname, 'snapshots', 'legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json'));
+
+function assertEq(label, actual, expected) {
+  if (String(actual).toLowerCase() !== String(expected).toLowerCase()) {
+    throw new Error(`Assertion failed for ${label}: actual=${actual} expected=${expected}`);
+  }
+}
+
+function isSnapshotReplayComplete(snapshot) {
+  const provenance = snapshot.provenance || {};
+  if (provenance.replayComplete === false) return false;
+
+  const note = String(provenance.note || '').toLowerCase();
+  const derivedBy = String(provenance.derivedBy || '').toLowerCase();
+
+  if (note.includes('unavailable') || note.includes('must be reviewed') || note.includes('incomplete')) {
+    return false;
+  }
+  if (!derivedBy.includes('transaction input replay')) {
+    return false;
+  }
+
+  return true;
+}
+
+module.exports = async function (deployer, network, accounts) {
+  if (network === 'development' || network === 'test') {
+    return;
+  }
+
+  const chainId = Number(await web3.eth.getChainId());
+  if (chainId !== Number(SNAPSHOT.chainId)) {
+    throw new Error(`Snapshot chainId mismatch: connected=${chainId} snapshot=${SNAPSHOT.chainId}`);
+  }
+  if (chainId === 1 && process.env.CONFIRM_MAINNET_DEPLOY !== '1') {
+    throw new Error('Refusing mainnet deployment without CONFIRM_MAINNET_DEPLOY=1');
+  }
+
+  if (!isSnapshotReplayComplete(SNAPSHOT)) {
+    throw new Error('Snapshot provenance indicates incomplete replay-derived state. Regenerate and commit a fully replayed snapshot before running migration.');
+  }
+
+  await deployer.deploy(BondMath);
+  await deployer.deploy(ENSOwnership);
+  await deployer.deploy(ReputationMath);
+  await deployer.deploy(TransferUtils);
+  await deployer.deploy(UriUtils);
+
+  await deployer.link(BondMath, AGIJobManager);
+  await deployer.link(ENSOwnership, AGIJobManager);
+  await deployer.link(ReputationMath, AGIJobManager);
+  await deployer.link(TransferUtils, AGIJobManager);
+  await deployer.link(UriUtils, AGIJobManager);
+
+  if (/__\$[a-f0-9]{34}\$__/i.test(AGIJobManager.bytecode)) {
+    throw new Error('Unresolved library link references remain in AGIJobManager.bytecode');
+  }
+
+  await deployer.deploy(
+    AGIJobManager,
+    SNAPSHOT.addresses.agiToken,
+    SNAPSHOT.baseIpfsUrl,
+    [SNAPSHOT.addresses.ensRegistry, SNAPSHOT.addresses.nameWrapper],
+    [
+      SNAPSHOT.roots.clubRootNode,
+      SNAPSHOT.roots.agentRootNode,
+      SNAPSHOT.roots.alphaClubRootNode,
+      SNAPSHOT.roots.alphaAgentRootNode
+    ],
+    [SNAPSHOT.merkleRoots.validatorMerkleRoot, SNAPSHOT.merkleRoots.agentMerkleRoot]
+  );
+
+  const manager = await AGIJobManager.deployed();
+  const owner = accounts[0];
+
+  if (SNAPSHOT.numericParams.validationRewardPercentage) {
+    await manager.setValidationRewardPercentage(SNAPSHOT.numericParams.validationRewardPercentage, { from: owner });
+  }
+  if (SNAPSHOT.numericParams.requiredValidatorApprovals) {
+    await manager.setRequiredValidatorApprovals(SNAPSHOT.numericParams.requiredValidatorApprovals, { from: owner });
+  }
+  if (SNAPSHOT.numericParams.requiredValidatorDisapprovals) {
+    await manager.setRequiredValidatorDisapprovals(SNAPSHOT.numericParams.requiredValidatorDisapprovals, { from: owner });
+  }
+  if (SNAPSHOT.numericParams.premiumReputationThreshold) {
+    await manager.setPremiumReputationThreshold(SNAPSHOT.numericParams.premiumReputationThreshold, { from: owner });
+  }
+  if (SNAPSHOT.numericParams.maxJobPayout) {
+    await manager.setMaxJobPayout(SNAPSHOT.numericParams.maxJobPayout, { from: owner });
+  }
+  if (SNAPSHOT.numericParams.jobDurationLimit) {
+    await manager.setJobDurationLimit(SNAPSHOT.numericParams.jobDurationLimit, { from: owner });
+  }
+
+  if (SNAPSHOT.addresses.ensJobPages && SNAPSHOT.addresses.ensJobPages !== '0x0000000000000000000000000000000000000000') {
+    await manager.setEnsJobPages(SNAPSHOT.addresses.ensJobPages, { from: owner });
+  }
+  if (typeof SNAPSHOT.booleans.useEnsJobTokenURI === 'boolean') {
+    await manager.setUseEnsJobTokenURI(SNAPSHOT.booleans.useEnsJobTokenURI, { from: owner });
+  }
+
+  for (const row of SNAPSHOT.dynamicSets.moderators) {
+    await manager.addModerator(row.address, { from: owner });
+  }
+  for (const row of SNAPSHOT.dynamicSets.additionalAgents) {
+    await manager.addAdditionalAgent(row.address, { from: owner });
+  }
+  for (const row of SNAPSHOT.dynamicSets.additionalValidators) {
+    await manager.addAdditionalValidator(row.address, { from: owner });
+  }
+  for (const row of SNAPSHOT.dynamicSets.blacklistedAgents) {
+    await manager.blacklistAgent(row.address, true, { from: owner });
+  }
+  for (const row of SNAPSHOT.dynamicSets.blacklistedValidators) {
+    await manager.blacklistValidator(row.address, true, { from: owner });
+  }
+
+  for (const row of SNAPSHOT.agiTypes) {
+    if (Number(row.payoutPercentage) > 0) {
+      try {
+        await manager.addAGIType(row.nftAddress, row.payoutPercentage, { from: owner });
+      } catch (err) {
+        throw new Error(`addAGIType failed for ${row.nftAddress}: ${err.message}`);
+      }
+    }
+  }
+
+  for (const row of SNAPSHOT.agiTypes) {
+    if (!row.enabled) {
+      try {
+        await manager.disableAGIType(row.nftAddress, { from: owner });
+      } catch (err) {
+        throw new Error(`disableAGIType failed for ${row.nftAddress}. Snapshot must provide a restorable pre-disable AGI type for disabled entries: ${err.message}`);
+      }
+    }
+  }
+
+  if (SNAPSHOT.booleans.paused) {
+    await manager.pauseIntake({ from: owner });
+  }
+  if (SNAPSHOT.booleans.settlementPaused) {
+    await manager.setSettlementPaused(true, { from: owner });
+  }
+  if (SNAPSHOT.booleans.lockIdentityConfig) {
+    await manager.lockIdentityConfiguration({ from: owner });
+  }
+
+  const finalOwner = process.env.NEW_OWNER || SNAPSHOT.addresses.owner;
+  await manager.transferOwnership(finalOwner, { from: owner });
+
+  assertEq('agiToken', await manager.agiToken(), SNAPSHOT.addresses.agiToken);
+  assertEq('ens', await manager.ens(), SNAPSHOT.addresses.ensRegistry);
+  assertEq('nameWrapper', await manager.nameWrapper(), SNAPSHOT.addresses.nameWrapper);
+  assertEq('clubRootNode', await manager.clubRootNode(), SNAPSHOT.roots.clubRootNode);
+  assertEq('agentRootNode', await manager.agentRootNode(), SNAPSHOT.roots.agentRootNode);
+  assertEq('alphaClubRootNode', await manager.alphaClubRootNode(), SNAPSHOT.roots.alphaClubRootNode);
+  assertEq('alphaAgentRootNode', await manager.alphaAgentRootNode(), SNAPSHOT.roots.alphaAgentRootNode);
+  assertEq('validatorMerkleRoot', await manager.validatorMerkleRoot(), SNAPSHOT.merkleRoots.validatorMerkleRoot);
+  assertEq('agentMerkleRoot', await manager.agentMerkleRoot(), SNAPSHOT.merkleRoots.agentMerkleRoot);
+  assertEq('requiredValidatorApprovals', await manager.requiredValidatorApprovals(), SNAPSHOT.numericParams.requiredValidatorApprovals);
+  assertEq('requiredValidatorDisapprovals', await manager.requiredValidatorDisapprovals(), SNAPSHOT.numericParams.requiredValidatorDisapprovals);
+  assertEq('premiumReputationThreshold', await manager.premiumReputationThreshold(), SNAPSHOT.numericParams.premiumReputationThreshold);
+  assertEq('validationRewardPercentage', await manager.validationRewardPercentage(), SNAPSHOT.numericParams.validationRewardPercentage);
+  assertEq('maxJobPayout', await manager.maxJobPayout(), SNAPSHOT.numericParams.maxJobPayout);
+  assertEq('jobDurationLimit', await manager.jobDurationLimit(), SNAPSHOT.numericParams.jobDurationLimit);
+  assertEq('paused', await manager.paused(), SNAPSHOT.booleans.paused);
+  assertEq('settlementPaused', await manager.settlementPaused(), SNAPSHOT.booleans.settlementPaused);
+
+  console.log('Deployed libraries:');
+  console.log(`- BondMath: ${BondMath.address}`);
+  console.log(`- ENSOwnership: ${ENSOwnership.address}`);
+  console.log(`- ReputationMath: ${ReputationMath.address}`);
+  console.log(`- TransferUtils: ${TransferUtils.address}`);
+  console.log(`- UriUtils: ${UriUtils.address}`);
+  console.log(`AGIJobManager deployed at: ${manager.address}`);
+  console.log('All assertions passed.');
+};

--- a/migrations/snapshots/legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json
+++ b/migrations/snapshots/legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json
@@ -1,0 +1,93 @@
+{
+  "schemaVersion": "1.0.0",
+  "generatedAt": "2026-02-16T00:00:00.000Z",
+  "legacyAddress": "0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477",
+  "chainId": 1,
+  "blockNumber": 24471342,
+  "blockTimestamp": "1771268519",
+  "source": {
+    "etherscan": {
+      "proxy": "0"
+    },
+    "proxyDetection": {
+      "isProxy": false,
+      "implementationFromEip1967Slot": "0x0000000000000000000000000000000000000000"
+    }
+  },
+  "addresses": {
+    "owner": "0xD76ad27A1BcF8652e7e46be603fA742FD1c10A99",
+    "agiToken": "0xF0780F43b86c13B3D0681b1Cf6dAEB1499E7f14D",
+    "ensRegistry": "0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e",
+    "nameWrapper": "0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401",
+    "ensJobPages": "0x0000000000000000000000000000000000000000"
+  },
+  "baseIpfsUrl": "https://ipfs.io/ipfs/",
+  "roots": {
+    "clubRootNode": "0x39eb848f88bdfb0a6371096249dd451f56859dfe2cd3ddeab1e26d5bb68ede16",
+    "agentRootNode": "0x2c9c6189b2e92da4d0407e9deb38ff6870729ad063af7e8576cb7b7898c88e2d",
+    "alphaClubRootNode": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
+    "alphaAgentRootNode": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e",
+    "derived": [
+      {
+        "name": "alpha.club.agi.eth",
+        "value": "0x6487f659ec6f3fbd424b18b685728450d2559e4d68768393f9c689b2b6e5405e",
+        "derived": true
+      },
+      {
+        "name": "alpha.agent.agi.eth",
+        "value": "0xc74b6c5e8a0d97ed1fe28755da7d06a84593b4de92f6582327bc40f41d6c2d5e",
+        "derived": true
+      }
+    ]
+  },
+  "merkleRoots": {
+    "validatorMerkleRoot": "0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b",
+    "agentMerkleRoot": "0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b"
+  },
+  "booleans": {
+    "paused": false,
+    "settlementPaused": false,
+    "lockIdentityConfig": false,
+    "useEnsJobTokenURI": false
+  },
+  "numericParams": {
+    "requiredValidatorApprovals": "8",
+    "requiredValidatorDisapprovals": "10",
+    "premiumReputationThreshold": "10000",
+    "validationRewardPercentage": "8",
+    "maxJobPayout": "8888888800000000000000000",
+    "jobDurationLimit": "10000000"
+  },
+  "dynamicSets": {
+    "moderators": [],
+    "additionalAgents": [],
+    "additionalValidators": [],
+    "blacklistedAgents": [],
+    "blacklistedValidators": []
+  },
+  "agiTypes": [
+    {
+      "nftAddress": "0x1C11AE902e70e20B775c43B60f8EcB1ac17168B2",
+      "payoutPercentage": "80",
+      "enabled": true,
+      "source": {
+        "method": "eth_call",
+        "index": 0
+      }
+    },
+    {
+      "nftAddress": "0x76521F2AACC4EDFC58c837CBe8358ec7D18A4EFB",
+      "payoutPercentage": "80",
+      "enabled": true,
+      "source": {
+        "method": "eth_call",
+        "index": 1
+      }
+    }
+  ],
+  "provenance": {
+    "replayComplete": false,
+    "derivedBy": "eth_call + constructor metadata",
+    "note": "Dynamic set replay unavailable without complete tx history API key; fields left empty and must be reviewed before mainnet deployment."
+  }
+}

--- a/scripts/snapshotLegacyMainnetConfig.js
+++ b/scripts/snapshotLegacyMainnetConfig.js
@@ -1,0 +1,243 @@
+#!/usr/bin/env node
+const fs = require('fs');
+const path = require('path');
+const { execFileSync } = require('child_process');
+const Web3 = require('web3');
+
+const web3 = new Web3();
+const LEGACY_ADDRESS = '0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477';
+const SNAPSHOT_PATH = path.join(__dirname, '..', 'migrations', 'snapshots', 'legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json');
+const ETHERSCAN_V2 = 'https://api.etherscan.io/v2/api';
+const EIP1967_IMPLEMENTATION_SLOT = '0x360894A13BA1A3210667C828492DB98DCA3E2076CC3735A920A3CA505D382BBC';
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const parsed = { block: 'latest' };
+  for (let i = 0; i < args.length; i += 1) {
+    if (args[i] === '--block') parsed.block = args[i + 1];
+  }
+  return parsed;
+}
+
+function runCurl(url, extra = []) {
+  return execFileSync('curl', ['-sS', '--max-time', '30', '-L', '-A', 'Mozilla/5.0', ...extra, url], { encoding: 'utf8' });
+}
+
+function runJsonRpc(rpcUrl, method, params = []) {
+  const payload = JSON.stringify({ jsonrpc: '2.0', id: 1, method, params });
+  const out = execFileSync('curl', ['-sS', '--max-time', '30', '-H', 'content-type: application/json', '--data', payload, rpcUrl], { encoding: 'utf8' });
+  const parsed = JSON.parse(out);
+  if (parsed.error) throw new Error(`RPC ${method} failed: ${parsed.error.message}`);
+  return parsed.result;
+}
+
+function toHexBlock(blockNumberOrLatest) {
+  if (blockNumberOrLatest === 'latest') return 'latest';
+  return `0x${Number(blockNumberOrLatest).toString(16)}`;
+}
+
+function checksum(address) {
+  if (!address) return null;
+  if (/^0x0{40}$/i.test(address)) return '0x0000000000000000000000000000000000000000';
+  return web3.utils.toChecksumAddress(address);
+}
+
+function getEtherscanSource(address, apiKey) {
+  if (apiKey) {
+    const url = `${ETHERSCAN_V2}?chainid=1&module=contract&action=getsourcecode&address=${address}&apikey=${apiKey}`;
+    const parsed = JSON.parse(runCurl(url));
+    if (parsed.status === '1' && parsed.result && parsed.result[0]) return parsed.result[0];
+  }
+  const html = runCurl(`https://etherscan.io/address/${address}#code`);
+  const abiMatch = html.match(/id='js-copytextarea2'[^>]*>(\[.*?\])<\/pre>/s);
+  const ctorMatch = html.match(/Constructor Arguments[\s\S]*?<pre[^>]*>([0-9a-fA-F]+)<br>/s);
+  if (!abiMatch) throw new Error('Failed to fetch ABI from Etherscan (API+HTML failed).');
+  return {
+    ContractName: 'AGIJobManager', CompilerVersion: 'unknown', OptimizationUsed: 'unknown', Runs: 'unknown',
+    Proxy: '0', Implementation: '', ABI: abiMatch[1], ConstructorArguments: ctorMatch ? ctorMatch[1] : ''
+  };
+}
+
+function getTxHashes(address, apiKey) {
+  if (!apiKey) {
+    throw new Error('ETHERSCAN_API_KEY is required for complete tx replay. HTML scraping is intentionally disabled because it cannot guarantee full history pagination.');
+  }
+
+  const all = [];
+  const offset = 10000;
+  for (let page = 1; page <= 100; page += 1) {
+    const url = `${ETHERSCAN_V2}?chainid=1&module=account&action=txlist&address=${address}&startblock=0&endblock=99999999&page=${page}&offset=${offset}&sort=asc&apikey=${apiKey}`;
+    const parsed = JSON.parse(runCurl(url));
+    if (parsed.status !== '1') {
+      throw new Error(`Etherscan txlist pagination failed at page ${page}: ${parsed.message || 'unknown'} / ${parsed.result || 'n/a'}`);
+    }
+    all.push(...parsed.result.map((x) => x.hash.toLowerCase()));
+    if (parsed.result.length < offset) {
+      return [...new Set(all)];
+    }
+  }
+
+  throw new Error('Etherscan txlist pagination exceeded safety bound; refusing partial replay.');
+}
+
+function encodeCall(abiEntry, args = []) {
+  return web3.eth.abi.encodeFunctionCall(abiEntry, args);
+}
+
+function decodeOutput(abiEntry, raw) {
+  const outputs = abiEntry.outputs || [];
+  if (outputs.length === 0) return null;
+  const decoded = web3.eth.abi.decodeParameters(outputs, raw);
+  if (outputs.length === 1) return decoded[0];
+  return decoded;
+}
+
+function callAt(rpcUrl, address, abiEntry, args, blockTag) {
+  const data = encodeCall(abiEntry, args);
+  const raw = runJsonRpc(rpcUrl, 'eth_call', [{ to: address, data }, blockTag]);
+  return decodeOutput(abiEntry, raw);
+}
+
+function namehash(name) {
+  let node = '0x' + '00'.repeat(32);
+  for (const label of name.split('.').reverse()) {
+    node = web3.utils.keccak256(node + web3.utils.keccak256(label).slice(2));
+  }
+  return node;
+}
+
+function str(v) { return String(v); }
+
+async function main() {
+  const { block } = parseArgs();
+  const rpcUrl = process.env.MAINNET_RPC_URL || 'https://eth.llamarpc.com';
+  const apiKey = process.env.ETHERSCAN_API_KEY || '';
+
+  const chainIdHex = runJsonRpc(rpcUrl, 'eth_chainId', []);
+  const chainId = Number(chainIdHex);
+  if (chainId !== 1) throw new Error(`Expected chainId=1 got ${chainId}`);
+
+  const blockTag = block === 'latest' ? 'latest' : toHexBlock(block);
+  const blockInfo = runJsonRpc(rpcUrl, 'eth_getBlockByNumber', [blockTag, false]);
+  if (!blockInfo) throw new Error(`Cannot fetch block ${blockTag}`);
+  const blockNumber = Number(blockInfo.number);
+
+  const source = getEtherscanSource(LEGACY_ADDRESS, apiKey);
+  const abi = JSON.parse(source.ABI);
+  const fnByName = new Map(abi.filter((x) => x.type === 'function').map((x) => [x.name, x]));
+  const fnBySig = new Map(abi.filter((x) => x.type === 'function').map((x) => [web3.eth.abi.encodeFunctionSignature(x), x]));
+
+  const implStorage = runJsonRpc(rpcUrl, 'eth_getStorageAt', [LEGACY_ADDRESS, EIP1967_IMPLEMENTATION_SLOT, toHexBlock(blockNumber)]);
+  const implAddress = checksum(`0x${implStorage.slice(-40)}`);
+
+  const calls = {};
+  const getters = ['owner','agiToken','ens','nameWrapper','clubRootNode','agentRootNode','validatorMerkleRoot','agentMerkleRoot','paused','settlementPaused','lockIdentityConfig','ensJobPages','useEnsJobTokenURI','requiredValidatorApprovals','requiredValidatorDisapprovals','voteQuorum','premiumReputationThreshold','validationRewardPercentage','maxJobPayout','jobDurationLimit','completionReviewPeriod','disputeReviewPeriod','validatorBondBps','validatorBondMin','validatorBondMax','validatorSlashBps','challengePeriodAfterApproval','agentBond','agentBondBps','agentBondMin','agentBondMax'];
+  for (const g of getters) {
+    const fn = fnByName.get(g);
+    if (!fn) continue;
+    calls[g] = callAt(rpcUrl, LEGACY_ADDRESS, fn, [], toHexBlock(blockNumber));
+  }
+
+  const agiTypesOnchain = [];
+  const agiTypesFn = fnByName.get('agiTypes');
+  if (agiTypesFn) {
+    for (let i = 0; i < 64; i += 1) {
+      try {
+        const decoded = callAt(rpcUrl, LEGACY_ADDRESS, agiTypesFn, [String(i)], toHexBlock(blockNumber));
+        const nft = checksum(decoded.nftAddress || decoded[0]);
+        const pct = str(decoded.payoutPercentage || decoded[1]);
+        if (!nft || /^0x0{40}$/i.test(nft)) break;
+        agiTypesOnchain.push({ nftAddress: nft, payoutPercentage: pct, enabled: Number(pct) > 0, source: { method: 'eth_call', index: i } });
+      } catch (_e) { break; }
+    }
+  }
+
+  const txHashes = getTxHashes(LEGACY_ADDRESS, apiKey);
+  const mutations = [];
+  const tracked = new Set(['addModerator','removeModerator','addAdditionalAgent','removeAdditionalAgent','addAdditionalValidator','removeAdditionalValidator','blacklistAgent','blacklistValidator','addAGIType','disableAGIType','setBaseIpfsUrl']);
+
+  for (const hash of txHashes) {
+    const tx = runJsonRpc(rpcUrl, 'eth_getTransactionByHash', [hash]);
+    if (!tx || !tx.to || tx.to.toLowerCase() !== LEGACY_ADDRESS.toLowerCase() || !tx.input || tx.input.length < 10) continue;
+    const receipt = runJsonRpc(rpcUrl, 'eth_getTransactionReceipt', [hash]);
+    if (!receipt || receipt.status !== '0x1' || Number(receipt.blockNumber) > blockNumber) continue;
+    const fn = fnBySig.get(tx.input.slice(0, 10));
+    if (!fn || !tracked.has(fn.name)) continue;
+    const decoded = web3.eth.abi.decodeParameters(fn.inputs, tx.input.slice(10));
+    mutations.push({ hash, blockNumber: Number(receipt.blockNumber), transactionIndex: Number(receipt.transactionIndex), functionName: fn.name, args: fn.inputs.map((i, idx) => decoded[idx]) });
+  }
+  mutations.sort((a,b)=>(a.blockNumber-b.blockNumber)||(a.transactionIndex-b.transactionIndex));
+
+  const maps = { moderators:new Map(), additionalAgents:new Map(), additionalValidators:new Map(), blacklistedAgents:new Map(), blacklistedValidators:new Map() };
+  const agiMap = new Map(); const agiOrder = []; let baseIpfsUrl = null;
+  const put = (map, addr, enabled, src)=>map.set(checksum(addr),{enabled,source:src});
+
+  for (const m of mutations) {
+    const src = { method:'tx_input_replay', txHash:m.hash, blockNumber:m.blockNumber, transactionIndex:m.transactionIndex };
+    const [a0,a1] = m.args;
+    if (m.functionName==='addModerator') put(maps.moderators,a0,true,src);
+    if (m.functionName==='removeModerator') put(maps.moderators,a0,false,src);
+    if (m.functionName==='addAdditionalAgent') put(maps.additionalAgents,a0,true,src);
+    if (m.functionName==='removeAdditionalAgent') put(maps.additionalAgents,a0,false,src);
+    if (m.functionName==='addAdditionalValidator') put(maps.additionalValidators,a0,true,src);
+    if (m.functionName==='removeAdditionalValidator') put(maps.additionalValidators,a0,false,src);
+    if (m.functionName==='blacklistAgent') put(maps.blacklistedAgents,a0,Boolean(a1),src);
+    if (m.functionName==='blacklistValidator') put(maps.blacklistedValidators,a0,Boolean(a1),src);
+    if (m.functionName==='setBaseIpfsUrl') baseIpfsUrl = a0;
+    if (m.functionName==='addAGIType') {
+      const nft = checksum(a0); const pct = str(a1);
+      if (!agiMap.has(nft)) agiOrder.push(nft);
+      agiMap.set(nft,{nftAddress:nft,payoutPercentage:pct,enabled:Number(pct)>0,source:src});
+    }
+    if (m.functionName==='disableAGIType') {
+      const nft = checksum(a0);
+      if (!agiMap.has(nft)) agiOrder.push(nft);
+      agiMap.set(nft,{nftAddress:nft,payoutPercentage:'0',enabled:false,source:src});
+    }
+  }
+
+  if (!baseIpfsUrl && source.ConstructorArguments) {
+    const ctor = abi.find((x)=>x.type==='constructor');
+    if (ctor) {
+      const decoded = web3.eth.abi.decodeParameters(ctor.inputs, `0x${source.ConstructorArguments}`);
+      const strIdx = ctor.inputs.findIndex((x)=>x.type==='string');
+      if (strIdx >= 0) baseIpfsUrl = decoded[strIdx];
+    }
+  }
+
+  const agiTypes = agiTypesOnchain;
+
+  const snapshot = {
+    schemaVersion:'1.0.0',generatedAt:new Date().toISOString(),legacyAddress:checksum(LEGACY_ADDRESS),chainId,
+    blockNumber,blockTimestamp:str(Number(blockInfo.timestamp)),
+    source:{etherscan:{contractName:source.ContractName,compilerVersion:source.CompilerVersion,optimizationUsed:source.OptimizationUsed,runs:source.Runs,proxy:source.Proxy,implementationFromMetadata:source.Implementation?checksum(source.Implementation):null},proxyDetection:{isProxy:source.Proxy==='1'||!/^0x0{40}$/i.test(implAddress),implementationFromEip1967Slot:implAddress}},
+    addresses:{owner:checksum(calls.owner),agiToken:checksum(calls.agiToken),ensRegistry:checksum(calls.ens),nameWrapper:checksum(calls.nameWrapper),ensJobPages:checksum(calls.ensJobPages||'0x0000000000000000000000000000000000000000')},
+    baseIpfsUrl,
+    roots:{clubRootNode:calls.clubRootNode,agentRootNode:calls.agentRootNode,alphaClubRootNode:namehash('alpha.club.agi.eth'),alphaAgentRootNode:namehash('alpha.agent.agi.eth'),derived:[{name:'alpha.club.agi.eth',value:namehash('alpha.club.agi.eth'),derived:true},{name:'alpha.agent.agi.eth',value:namehash('alpha.agent.agi.eth'),derived:true}]},
+    merkleRoots:{validatorMerkleRoot:calls.validatorMerkleRoot,agentMerkleRoot:calls.agentMerkleRoot},
+    booleans:{paused:Boolean(calls.paused),settlementPaused:Boolean(calls.settlementPaused),lockIdentityConfig:Boolean(calls.lockIdentityConfig),useEnsJobTokenURI:Boolean(calls.useEnsJobTokenURI)},
+    numericParams:Object.fromEntries(Object.entries(calls).filter(([k])=>!['owner','agiToken','ens','nameWrapper','clubRootNode','agentRootNode','validatorMerkleRoot','agentMerkleRoot','paused','settlementPaused','lockIdentityConfig','ensJobPages','useEnsJobTokenURI'].includes(k)).map(([k,v])=>[k,str(v)])),
+    dynamicSets:{
+      moderators:[...maps.moderators.entries()].filter(([,v])=>v.enabled).map(([address,v])=>({address,source:v.source})),
+      additionalAgents:[...maps.additionalAgents.entries()].filter(([,v])=>v.enabled).map(([address,v])=>({address,source:v.source})),
+      additionalValidators:[...maps.additionalValidators.entries()].filter(([,v])=>v.enabled).map(([address,v])=>({address,source:v.source})),
+      blacklistedAgents:[...maps.blacklistedAgents.entries()].filter(([,v])=>v.enabled).map(([address,v])=>({address,source:v.source})),
+      blacklistedValidators:[...maps.blacklistedValidators.entries()].filter(([,v])=>v.enabled).map(([address,v])=>({address,source:v.source}))
+    },
+    agiTypes,
+    provenance:{derivedBy:'eth_call + transaction input replay',txCountConsidered:txHashes.length,mutationCount:mutations.length,note:'AGI types are sourced from on-chain agiTypes(index) reads; replay data is used for non-enumerable sets only.'}
+  };
+
+  fs.mkdirSync(path.dirname(SNAPSHOT_PATH),{recursive:true});
+  fs.writeFileSync(SNAPSHOT_PATH,`${JSON.stringify(snapshot,null,2)}\n`);
+
+  console.log('Legacy snapshot summary');
+  console.log(`- chainId: ${chainId}`);
+  console.log(`- blockNumber: ${blockNumber}`);
+  console.log(`- owner: ${snapshot.addresses.owner}`);
+  console.log(`- agiToken: ${snapshot.addresses.agiToken}`);
+  console.log(`- counts: moderators=${snapshot.dynamicSets.moderators.length} additionalAgents=${snapshot.dynamicSets.additionalAgents.length} additionalValidators=${snapshot.dynamicSets.additionalValidators.length} blacklistedAgents=${snapshot.dynamicSets.blacklistedAgents.length} blacklistedValidators=${snapshot.dynamicSets.blacklistedValidators.length} agiTypes=${snapshot.agiTypes.length}`);
+  console.log(`- wrote snapshot: ${SNAPSHOT_PATH}`);
+}
+
+main().catch((err)=>{ console.error(`Snapshot failed: ${err.message}`); process.exit(1); });


### PR DESCRIPTION
### Motivation

- Prevent ambiguous Truffle migration ranges by removing the index collision between the legacy-snapshot deployment and the existing `2_deploy_contracts.js` migration. 
- Ensure operators cannot accidentally deploy from an incompletely-replayed snapshot by adding provenance checks and requiring explicit mainnet confirmation. 
- Provide a reproducible snapshot generator so maintainers can produce and inspect the snapshot used by the migration.

### Description

- Renamed the legacy snapshot migration to `migrations/3_deploy_agijobmanager_from_legacy_snapshot.js` and updated runbook commands in `docs/MAINNET_MIGRATION_FROM_LEGACY.md` to use `--f 3 --to 3` so Truffle range selection is unambiguous. 
- Added a preflight `isSnapshotReplayComplete(snapshot)` check in the migration that rejects snapshots whose provenance indicates incomplete replay and added a guard that requires `CONFIRM_MAINNET_DEPLOY=1` for `chainId===1` runs. 
- Added `migrations/snapshots/legacy.mainnet.0x0178B6baD606aaF908f72135B8eC32Fc1D5bA477.json` (snapshot with provenance showing replay incomplete) and a `scripts/snapshotLegacyMainnetConfig.js` utility that fetches on-chain state and (when possible) replays transactions via Etherscan to produce a deterministic snapshot file. 
- The migration deploys and links library contracts, deploys `AGIJobManager` with snapshot-derived constructor args, restores numeric/boolean parameters, applies dynamic sets and AGI types (with error wrapping for failing restores), applies pause/lock flags, transfers ownership (honoring `NEW_OWNER`), and performs final assertions against the snapshot.

### Testing

- Ran a syntax check on the migration with `node -c migrations/3_deploy_agijobmanager_from_legacy_snapshot.js`, which returned without syntax errors. 
- Ran a syntax check on the snapshot generator with `node -c scripts/snapshotLegacyMainnetConfig.js`, which returned without syntax errors. 
- Built the project with `npm run build` (Truffle compile), which completed successfully though compilation emitted a contract-size warning for a test harness; build succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6993655398e08333bf49fbe00919209a)