### PR TITLE
docs: Etherscan-first role guides, owner/moderator runbooks, and verification guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AGIJobManager
 
-AGIJobManager is an owner-operated on-chain job escrow and settlement contract for employer/agent workflows with validator voting and moderator dispute resolution.
+AGIJobManager is an owner-operated on-chain job escrow contract with validator voting and moderator dispute resolution. It is designed so users can operate directly from Etherscan (`Read Contract` / `Write Contract`) with a browser wallet.
 
 ## Start here
 
-- Etherscan role guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
+- Etherscan step-by-step guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
 - Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
 - Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
 - Verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
@@ -12,43 +12,44 @@ AGIJobManager is an owner-operated on-chain job escrow and settlement contract f
 
 ## Roles (plain language)
 
-- **Employer**: funds jobs, assigns by accepting an applicant flow, can cancel before assignment, can finalize/dispute after completion request.
-- **Agent**: applies to jobs (allowlist/Merkle/ENS authorization), may post a bond, submits completion URI.
-- **Validator**: authorized voter that approves/disapproves completed work during review.
-- **Moderator**: resolves disputes with `resolveDisputeWithCode`.
-- **Owner**: configures risk parameters, pause controls, allowlists/blacklists/moderators, ENS wiring, and treasury withdrawal constrained by solvency.
+- **Employer**: funds jobs, creates jobs, can cancel before assignment, and finalizes/disputes after completion request.
+- **Agent**: authorized worker who applies, may post a bond, and submits completion evidence.
+- **Validator**: authorized reviewer who votes approve/disapprove during review.
+- **Moderator**: resolves active disputes with `resolveDisputeWithCode`.
+- **Owner**: system operator with privileged controls and treasury authority bounded by on-chain solvency checks.
 
-## Trust model (explicit)
+## Explicit trust model
 
-This system is **not trustless governance**. The owner is privileged and can:
+This protocol is **operator-managed, not trustless governance**. The owner can:
 - pause/unpause intake (`pause`, `unpause`, `pauseAll`, `unpauseAll`),
 - pause/unpause settlement (`setSettlementPaused`),
-- change core risk and timing parameters,
-- manage allowlists, Merkle roots, and blacklists,
-- add/remove moderators,
-- change ENS/token identity configuration until `lockIdentityConfiguration()` is used,
-- withdraw only non-escrow AGI via `withdrawAGI` (bounded by `withdrawableAGI`).
+- change core risk/timing params,
+- manage allowlists, Merkle roots, blacklists, moderators,
+- configure ENS integration and tokenURI routing,
+- lock identity config permanently (`lockIdentityConfiguration`),
+- withdraw only non-escrow AGI via `withdrawAGI` constrained by `withdrawableAGI`.
 
-Users should assume an operator-managed escrow model with transparent on-chain controls.
+Users should assume an actively operated escrow system and always read current config in Etherscan before transacting.
 
-## One-screen quickstart (Etherscan)
+## One-screen quickstart (Etherscan only)
 
-1. On AGI token contract: `approve(AGIJobManager, amount)`.
+1. AGI token contract: `approve(AGIJobManager, amount)`.
 2. Employer: `createJob(jobSpecURI, payout, duration, details)`.
 3. Agent: `applyForJob(jobId, subdomain, proof)`.
 4. Agent: `requestJobCompletion(jobId, jobCompletionURI)`.
-5. Validators: `validateJob` / `disapproveJob` during review period.
-6. Employer: `finalizeJob(jobId)` when eligible; if contested, `disputeJob(jobId)` and moderator resolves.
+5. Validators: `validateJob` / `disapproveJob`.
+6. Employer: `finalizeJob(jobId)` when eligible.
+7. If contested: `disputeJob(jobId)` then moderator `resolveDisputeWithCode`.
 
-## Glossary (Etherscan terms)
+## Tiny glossary (Etherscan labels)
 
 - **jobId**: numeric job identifier.
-- **payout**: escrowed amount in token base units.
-- **duration**: job duration in seconds.
-- **review window**: completion voting period after completion request.
-- **quorum**: minimum total validator participation threshold.
-- **bond**: staked token amount for agent/validator/dispute initiation.
-- **slashing**: bond penalty for wrong-side outcomes.
+- **payout**: escrowed token amount in base units.
+- **duration**: seconds allowed from assignment to completion request.
+- **review window**: `completionReviewPeriod` after completion request.
+- **quorum**: minimum validator participation (`voteQuorum`).
+- **bonds**: staked AGI (agent/validator/dispute).
+- **slashing**: bond penalty applied to wrong-side participants.
 
 ## Tooling and CI entrypoints
 
@@ -58,20 +59,7 @@ npm run build
 npm test
 npm run lint
 npm run size
+npm run forge:test
 ```
 
-`npm test` runs: Truffle compile/tests, additional Node tests, and contract size guards.
-
-
-## Documentation
-
-- Main docs index: [`docs/README.md`](docs/README.md)
-- Quintessential end-to-end walkthrough: [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
-
-Documentation maintenance commands:
-
-```bash
-npm run docs:gen
-npm run docs:check
-npm run check:no-binaries  # check-no-binaries
-```
+`npm test` is the canonical repository entrypoint and runs Truffle compile/tests, additional Node tests, and contract size checks.

--- a/docs/MODERATOR_RUNBOOK.md
+++ b/docs/MODERATOR_RUNBOOK.md
@@ -1,55 +1,61 @@
 # MODERATOR_RUNBOOK
 
+Consistency-first dispute operations for `resolveDisputeWithCode`.
+
 ## 1) Dispute triage decision tree
 
 ```text
-Is dispute active?
-  no  -> stop (no moderator action)
-  yes -> gather evidence bundle
-         |
-         v
-Do facts clearly support one side under policy?
-  no  -> code 0 (NO_ACTION) with reason and escalation note
-  yes -> choose code 1 (AGENT_WIN) or 2 (EMPLOYER_WIN)
+Is job currently disputed?
+  no  -> stop (no action)
+  yes -> gather minimum evidence set
+            |
+            v
+Is evidence sufficient and internally consistent?
+  no  -> resolutionCode 0 (NO_ACTION), request more evidence
+  yes -> which side is supported by evidence/policy?
+            |                     |
+            |                     +--> employer supported -> code 2 (EMPLOYER_WIN)
+            +--> agent supported  -> code 1 (AGENT_WIN)
 ```
 
 ## 2) Resolution matrix
 
-| Condition | Suggested code |
-|---|---|
-| completion evidence valid + obligations met | `1` (AGENT_WIN) |
-| completion invalid/absent + employer claim supported | `2` (EMPLOYER_WIN) |
-| insufficient/conflicting evidence | `0` (NO_ACTION) |
+| Situation | Code | Expected effect |
+|---|---:|---|
+| Evidence incomplete/conflicting | 0 | Dispute stays active |
+| Agent fulfilled scoped deliverables | 1 | Agent-win settlement path |
+| Employer claim is substantiated (non-delivery/non-compliance) | 2 | Employer refund path |
 
-## 3) SOP: `resolveDisputeWithCode(jobId, code, reason)`
+## 3) SOP for `resolveDisputeWithCode(jobId, resolutionCode, reason)`
 
-### Minimum evidence checklist
-- `getJobCore(jobId)` snapshot
-- `getJobValidation(jobId)` snapshot
-- `getJobSpecURI(jobId)` and (if present) `getJobCompletionURI(jobId)`
-- dispute claim summary from both parties
-- any off-chain artifacts referenced by URI/hash
+### Minimum evidence checklist (required)
+- Snapshot of `getJobCore(jobId)`.
+- Snapshot of `getJobValidation(jobId)`.
+- `getJobSpecURI(jobId)` and `getJobCompletionURI(jobId)` (if set).
+- Parties’ claims and timestamps.
+- Artifact references (hashes/URIs) used in decision.
 
-### Reason format (standardize)
+### Required reason-string format
 
 ```text
-EVIDENCE:v1|summary:<one line>|facts:<key facts>|links:<refs>|policy:<section>|moderator:<id>|ts:<unix>
+EVIDENCE:v1|summary:<one-line>|facts:<fact-list>|links:<uri-list>|policy:<section>|moderator:<id>|ts:<unix>
 ```
 
 Examples:
-- `EVIDENCE:v1|summary:milestones met|facts:delivery+acceptance logs match|links:ipfs://...|policy:ops-2.1|moderator:mod-07|ts:1736465000`
-- `EVIDENCE:v1|summary:missing deliverable|facts:completion URI invalid|links:ipfs://...|policy:ops-2.3|moderator:mod-03|ts:1736465200`
+- `EVIDENCE:v1|summary:scope complete|facts:spec-v1 hash matched + deliverables present|links:ipfs://...|policy:mod-2.1|moderator:mod-07|ts:1736465000`
+- `EVIDENCE:v1|summary:missing milestone|facts:no evidence for milestone-2|links:ipfs://...|policy:mod-2.3|moderator:mod-03|ts:1736465200`
 
 ### Consistency rules
-- Use the same evidence threshold for similar cases.
-- If uncertain, prefer code `0` and request more evidence.
-- Never resolve based on private side-channel claims without verifiable references.
+- Apply same threshold across similar cases.
+- If uncertain, default to code `0` and request additional evidence.
+- Never resolve from unverifiable private claims.
+- Always archive tx hash + reason string with case ID.
 
 ## 4) Etherscan-only workflow
 
-1. Read `getJobCore(jobId)`.
-2. Read `getJobValidation(jobId)`.
-3. Read `getJobSpecURI(jobId)` and `getJobCompletionURI(jobId)`.
-4. Confirm dispute is active.
-5. Write `resolveDisputeWithCode(jobId, code, reason)`.
-6. Save tx hash in moderator case log.
+1. In `Read Contract`: call `getJobCore(jobId)`.
+2. In `Read Contract`: call `getJobValidation(jobId)`.
+3. In `Read Contract`: call `getJobSpecURI(jobId)` and `getJobCompletionURI(jobId)`.
+4. Confirm `disputed` is active and timeline is coherent.
+5. In `Write Contract`: call `resolveDisputeWithCode(jobId, resolutionCode, reason)`.
+6. Save transaction hash in moderation log.

--- a/docs/OWNER_RUNBOOK.md
+++ b/docs/OWNER_RUNBOOK.md
@@ -1,76 +1,111 @@
 # OWNER_RUNBOOK
 
-## 1) Deployment checklist
+Low-touch operator guide for AGIJobManager.
 
-1. Compile with repo settings (`npm run build`).
-2. Deploy external libraries required by AGIJobManager:
-   - UriUtils
-   - TransferUtils
-   - BondMath
-   - ReputationMath
-   - ENSOwnership
-3. Link libraries exactly in deployment artifacts.
-4. Deploy AGIJobManager with intended constructor config.
-5. Verify on Etherscan with exact compiler/optimizer/viaIR settings and library addresses.
-6. Confirm Read/Write tabs render all expected functions.
+## 1) Deployment checklist (including external libs + verification)
 
-## 2) Recommended safe defaults and staged rollout
+1. Build exactly with repo defaults (`npm ci`, `npm run build`).
+2. Deploy/link external libraries exactly as deployment scripts expect.
+3. Record deployed addresses for AGIJobManager and linked libraries.
+4. Verify on Etherscan using the exact compiler/optimizer settings in [`docs/VERIFY_ON_ETHERSCAN.md`](VERIFY_ON_ETHERSCAN.md).
+5. Confirm Etherscan shows readable `Read Contract` and `Write Contract` tabs.
+6. Run post-deploy smoke checks:
+   - `paused() == false` (unless launch freeze plan says otherwise)
+   - `settlementPaused() == false`
+   - correct token, ENS registry/wrapper/job pages addresses
+   - root nodes + Merkle roots set as intended
 
-- Start with conservative payout limits and duration limits.
-- Start with higher validator quorum/thresholds and small allowlists.
-- Keep `useEnsJobTokenURI` disabled until ENSJobPages path is validated.
-- Phase rollout: internal pilot -> controlled allowlist -> broader onboarding.
+## 2) Recommended safe defaults + staged rollout
 
-## 3) Incident playbooks
+### Stage 0 (dry-run)
+- Keep intake paused.
+- Configure roots, Merkle roots, moderators.
+- Test end-to-end on a small controlled address set.
 
-### A) Stop intake (keep settlement open)
-1. `pause()` (or `pauseIntake()`).
-2. Keep `setSettlementPaused(false)`.
-3. Communicate “no new jobs/applications, settlement continues.”
+### Stage 1 (limited production)
+- Unpause intake for a small allowlisted cohort.
+- Keep conservative risk params (payout caps, duration limits, quorum thresholds).
+- Monitor create/apply/completion/dispute path daily.
 
-### B) Stop settlement (freeze completion/dispute lane)
-1. `setSettlementPaused(true)`.
-2. Keep intake policy explicit (optionally still paused).
-3. Investigate and publish operator notice.
+### Stage 2 (generalized)
+- Expand allowlist scope or ENS routes.
+- Increase limits gradually after observed stability.
+- Keep incident playbooks ready and documented.
+
+## 3) Incident playbooks (exact sequences)
+
+### A) “Stop intake” only (new jobs/applications)
+1. Call `pause()` (or `pauseIntake()`).
+2. Keep `settlementPaused = false` so existing jobs can still settle.
+3. Announce scope: no new intake, settlement still open.
+
+### B) “Stop settlement” only
+1. Call `setSettlementPaused(true)`.
+2. Optionally keep intake open if incident is settlement-specific.
+3. Announce affected functions (finalize/dispute/settle lanes).
 
 ### C) Full stop
-1. `pauseAll()`.
+1. Call `pauseAll()`.
 2. Verify `paused() == true` and `settlementPaused() == true`.
-3. Run reconciliation before any withdrawals/parameter changes.
+3. Publish incident note with next review time.
 
-## 4) Revenue withdrawal safety
+### D) Controlled recovery
+1. Reverse only the affected lane first (`setSettlementPaused(false)` or `unpause()`).
+2. Observe before full reopen.
+3. Restore fully with `unpauseAll()` when safe.
 
-Use only while paused and settlement not paused constraints are met by contract guards.
+## 4) Safe treasury withdrawals without escrow risk
+
+Never use raw token balance as withdrawable amount.
 
 Checklist:
 1. Read `withdrawableAGI()`.
-2. Ensure requested amount <= `withdrawableAGI()`.
-3. Confirm incident state and solvency rationale are documented.
-4. Call `withdrawAGI(amount)`.
+2. Ensure planned amount is `<= withdrawableAGI()`.
+3. Confirm incident state allows withdrawal (`whenPaused` and settlement not paused requirements apply to AGI path).
+4. Execute `withdrawAGI(amount)`.
+5. Archive tx hash and rationale.
 
-Never assume gross token balance is withdrawable; locked escrow/bonds are excluded by contract accounting.
+## 5) Allowlist governance + Merkle root rotation
 
-## 5) Allowlist governance + Merkle rotation
-
-Rotation process:
-1. Build new allowlist JSON offline.
-2. Generate root/proofs with `scripts/merkle/export_merkle_proofs.js`.
-3. Announce effective time and migration window.
-4. Apply `updateMerkleRoots(validatorRoot, agentRoot)`.
-5. Re-publish per-address proofs for users.
+1. Prepare new address set offline.
+2. Generate root/proofs offline:
+   ```bash
+   node scripts/merkle/export_merkle_proofs.js --input addresses.json --output proofs.json
+   ```
+3. Communicate cutover time + proof distribution instructions.
+4. Call `updateMerkleRoots(newValidatorRoot, newAgentRoot)`.
+5. Publish proofs as Etherscan-ready bytes32[] arrays.
+6. Keep previous list/version for audit trail.
 
 ## 6) ENS operations
 
-- Configure ENS integrations: `setEnsJobPages`, `updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`.
-- Enable ENS-backed tokenURI only when tested: `setUseEnsJobTokenURI(true)`.
-- `lockIdentityConfiguration()` permanently freezes identity config setters.
+- Configure ENS integration addresses:
+  - `updateEnsRegistry(address)`
+  - `updateNameWrapper(address)`
+  - `setEnsJobPages(address)`
+- Configure roots:
+  - `updateRootNodes(clubRoot, agentRoot, alphaClubRoot, alphaAgentRoot)`
+- Toggle ENS tokenURI path:
+  - `setUseEnsJobTokenURI(bool)`
+- Permanent lock:
+  - `lockIdentityConfiguration()` prevents further identity config mutation.
 
-## 7) High-risk actions (special approval required)
+## 7) High-risk actions (change-control mandatory)
 
-- `rescueERC20`
-- `rescueToken`
+Require ticket + peer review + post-change validation:
+- `rescueToken`, `rescueERC20`, `rescueETH`
 - `lockIdentityConfiguration`
-- identity setters (`updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`, `updateMerkleRoots`, `setEnsJobPages`)
-- economic setters while escrow is empty (quorum/threshold/bond/time params)
+- identity setters (`updateEnsRegistry`, `updateNameWrapper`, `setEnsJobPages`, `updateRootNodes`, `updateMerkleRoots`)
+- economic setters (bond/quorum/timing/limit parameters)
 
-Require change ticket, rationale, and post-change verification notes.
+## 8) Minimal recurring ops cadence
+
+Daily:
+- review paused flags
+- review unresolved disputes
+- check unexpected blacklists/allowlist changes
+
+Weekly:
+- parameter drift review
+- Merkle list freshness review
+- runbook drill for intake/settlement pause scenarios


### PR DESCRIPTION
### Motivation
- Make AGIJobManager genuinely usable by non-technical users from Etherscan `Read Contract` / `Write Contract` and give owners/moderators low-touch, auditable runbooks. 
- Preserve all on-chain ABI/selector/behavior invariants (ENS selectors/calldata constraints and bytecode discipline) while improving offline-first operator tooling and copy/paste UX. 
- Prefer documentation and small offline helpers to editing Solidity to avoid any ABI or bytecode risk.

### Description
- Reworked the top-level `README.md` to be an Etherscan-first entrypoint with a one-screen quickstart, explicit roles, trust model, and a tiny glossary for Etherscan form labels. 
- Rewrote `docs/ETHERSCAN_GUIDE.md` into a flagship, role-based, copy/paste-ready guide that includes verification notes, unit conversions, safety checklists, common failure-mode mappings, exact Write-function field explanations and Etherscan pasteable examples (including `bytes32[]` proof formatting), ENS label constraints and an authorization decision tree. 
- Rewrote `docs/OWNER_RUNBOOK.md`, `docs/MODERATOR_RUNBOOK.md`, `docs/VERIFY_ON_ETHERSCAN.md`, and `docs/FAQ.md` to provide autonomous operator runbooks, a deterministic moderator SOP for `resolveDisputeWithCode`, exact verification/compiler settings and troubleshooting, and direct Etherscan-focused FAQ answers. 
- Pointed to and documented existing offline helper scripts (`scripts/merkle/*`, `scripts/etherscan/prepare_inputs.js`, `scripts/advisor/state_advisor.js`) with copy/paste invocation examples so operators/users can produce Etherscan-ready inputs without RPC access; no new dependencies or Solidity changes were introduced.

### Testing
- `npm ci` completed successfully (dependency install succeeded). 
- `npm run lint` (Solhint) ran successfully and returned only pre-existing warnings (no new errors). 
- Offline helper scripts executed successfully: `node scripts/merkle/export_merkle_proofs.js`, `node scripts/etherscan/prepare_inputs.js`, and `node scripts/advisor/state_advisor.js` produced expected outputs. 
- `npm run build` / `npm test` could not be completed here because `truffle compile` hung in this environment, and `forge` is not available locally (`forge` not found), so full CI test-suite/Foundry tests were not run; these remain blocking items to run in CI or a developer machine and are documented as known limitations.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ad10123c83338e73a932a51290f1)