### PR TITLE
fix: keep advisor sample completionRequestedAt within job duration

### DIFF
--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -1,76 +1,85 @@
 # AGIJobManager Etherscan Guide (Read/Write Contract)
 
-This guide is optimized for non-technical users using only:
-- wallet (e.g., MetaMask)
+This guide is written for non-technical users who only use:
+- a browser wallet (MetaMask or similar)
 - Etherscan `Read Contract` and `Write Contract`
 
 ## Choose your role
 - Employer: [Employer flow](#employer-flow)
 - Agent: [Agent flow](#agent-flow)
-- Validator: [validator-flow](#validator-flow)
+- Validator: [Validator flow](#validator-flow)
 - Moderator: [Moderator flow](#moderator-flow)
-- Owner/operator: [Owner/operator flow](#owneroperator-flow)
+- Owner/operator: [Owneroperator flow](#owneroperator-flow)
 
 ---
 
 ## Before you start
 
 ### Verification matters
-Use contracts with **verified source + ABI** on Etherscan. Without this, forms are hard to use and custom errors are not decoded clearly.
+Use the verified AGIJobManager contract on Etherscan. Verified source + ABI gives readable field names and decoded errors/events. If source is not verified, stop and use [`docs/VERIFY_ON_ETHERSCAN.md`](VERIFY_ON_ETHERSCAN.md).
 
 ### Units
-- Token amounts are `uint256` base units (usually 18 decimals):
-  - `1.5` tokens => `1500000000000000000`
-- Time is seconds:
-  - `12h` => `43200`
-  - `7d` => `604800`
+- Token amounts are `uint256` base units (usually 18 decimals).
+  - `1` token = `1000000000000000000`
+  - `1.5` tokens = `1500000000000000000`
+- Time values are in seconds.
+  - `12h` = `43200`
+  - `7d` = `604800`
 
-Use helper tools:
-- `node scripts/etherscan/prepare_inputs.js --action convert --amount 1.5 --duration 7d`
+Use the offline helper:
+```bash
+node scripts/etherscan/prepare_inputs.js --action convert --amount 1.5 --duration 7d
+```
 
 ### Safety checklist before any transaction
-Read these first:
-- `paused()`
-- `settlementPaused()`
-- `getJobCore(jobId)` and `getJobValidation(jobId)` for job actions
-- AGI token `balanceOf(yourAddress)`
-- AGI token `allowance(yourAddress, AGIJobManager)`
+1. Read `paused()`.
+2. Read `settlementPaused()`.
+3. For job-specific actions, read `getJobCore(jobId)` and `getJobValidation(jobId)`.
+4. On AGI token contract, read `balanceOf(yourAddress)`.
+5. On AGI token contract, read `allowance(yourAddress, AGIJobManagerAddress)`.
+6. Confirm all numeric inputs are base units / seconds.
 
-### Common failure modes
+### Common failure modes (custom errors)
 
 | Error / symptom | Likely cause | Fix |
 |---|---|---|
-| `NotAuthorized` | caller lacks role authorization | use additional allowlist, Merkle proof, or ENS auth route |
-| `SettlementPaused` | settlement switch enabled | wait for owner unpause or use only non-settlement reads |
-| `InvalidState` | wrong lifecycle stage | check `getJobCore` + timeline before retry |
-| `TransferFailed` | insufficient allowance/balance or non-standard token behavior | set allowance, verify balance, use exact-transfer ERC20 |
-| finalize opens dispute | tie/under-quorum outcome | moderator resolution required |
+| `NotAuthorized` | caller is not owner/moderator or fails role auth | use allowlist/Merkle/ENS route or correct signer |
+| `Blacklisted` | caller is blacklisted as agent/validator | contact owner/operator |
+| `SettlementPaused` | settlement lane is paused | wait for owner to unpause settlement |
+| `InvalidState` | action not valid in current job stage | check read cheat sheet + timeline first |
+| `JobNotFound` | wrong `jobId` | verify job ID in events/read calls |
+| `InvalidParameters` | malformed input (empty URI, bad code, bad config value) | correct parameters and retry |
+| `TransferFailed` | balance/allowance too low or token not strict-transfer compatible | fix allowance/balance; use standard ERC20 behavior |
+| `InsufficientWithdrawableBalance` | owner withdraw > `withdrawableAGI()` | lower amount |
+| `InsolventEscrowBalance` | unsafe owner action while escrow backing would be harmed | wait and reconcile escrow state |
+| `ConfigLocked` | identity configuration already locked | cannot change ENS/Merkle identity settings |
+| Finalize opens dispute | tie/under-quorum or contested outcome at finalize time | moderator must resolve dispute |
 
 ---
 
 ## Employer flow
 
-### 1) Approve escrow pull on AGI token
-Write function: `approve(spender, amount)` (on AGI ERC20)
+### 1) Approve escrow amount (AGI token contract)
+Write function: `approve(spender, amount)`
 
-Input meaning:
+Input fields:
 - `spender`: AGIJobManager contract address
 - `amount`: payout in base units
 
-Copy/paste example:
+Example:
 ```text
 spender: 0xYourAGIJobManager
-amount: 1200000000000000000000   // 1200 tokens at 18 decimals
+amount: 1200000000000000000000   // 1200 AGI at 18 decimals
 ```
 
 ### 2) Create job
 Write function: `createJob(jobSpecURI, payout, duration, details)`
 
-Input meaning:
-- `jobSpecURI`: metadata URI (ipfs/https)
-- `payout`: base-unit token amount
-- `duration`: seconds
-- `details`: short plain text summary
+Input fields:
+- `jobSpecURI` (string): URI to job metadata
+- `payout` (uint256): escrow amount in base units
+- `duration` (uint256): seconds until expiry window
+- `details` (string): human-readable summary
 
 Example:
 ```text
@@ -80,37 +89,110 @@ duration: 259200
 details: Translate legal packet EN->ES
 ```
 
-### 3) Cancel if unassigned
+### 3) Cancel job (when allowed)
 Write function: `cancelJob(jobId)`
+
+Input field:
+- `jobId` (uint256): target job ID
+
+Example:
+```text
+jobId: 42
+```
 
 ### 4) Finalize when eligible
 Write function: `finalizeJob(jobId)`
 
-### 5) Open dispute when needed
+Input field:
+- `jobId` (uint256): target job ID
+
+Example:
+```text
+jobId: 42
+```
+
+### 5) Dispute if needed
 Write function: `disputeJob(jobId)`
+
+Input field:
+- `jobId` (uint256): target job ID
+
+Example:
+```text
+jobId: 42
+```
 
 ---
 
 ## Agent flow
 
-### Authorization decision tree
-Use one route:
-1. owner allowlist (`additionalAgents`) OR
+### Authorization (3 routes)
+1. Owner additional allowlist (`addAdditionalAgent`) OR
 2. Merkle proof (`agentMerkleRoot`) OR
-3. ENS ownership under configured root node
+3. ENS subdomain ownership under configured root node
 
-### 1) Approve agent bond if required
-Write function on token: `approve(spender, amount)`
+### 1) Approve bond if required (AGI token contract)
+Write function: `approve(spender, amount)`
 
 ### 2) Apply to job
 Write function: `applyForJob(jobId, subdomain, proof)`
 
-Input meanings:
-- `jobId`: target job
-- `subdomain`: ENS label used for ENS auth path (or placeholder if using allowlist/merkle)
-- `proof`: bytes32[] merkle proof
+Input fields:
+- `jobId` (uint256): target job ID
+- `subdomain` (string): ENS label for ENS auth route (no dots)
+- `proof` (bytes32[]): Merkle proof array (use `[]` if not using Merkle route)
 
-Proof paste formats:
+Examples:
+```text
+jobId: 42
+subdomain: alice-agent
+proof: []
+```
+
+```text
+jobId: 42
+subdomain: alice-agent
+proof: ["0xaaa...", "0xbbb..."]
+```
+
+### 3) Request completion
+Write function: `requestJobCompletion(jobId, jobCompletionURI)`
+
+Input fields:
+- `jobId` (uint256)
+- `jobCompletionURI` (string): URI with deliverable evidence
+
+Example:
+```text
+jobId: 42
+jobCompletionURI: ipfs://bafy.../completion.v1.json
+```
+
+### 4) Dispute (optional)
+Write function: `disputeJob(jobId)`
+
+---
+
+## Validator flow
+
+### Authorization (3 routes)
+1. Owner additional allowlist (`addAdditionalValidator`) OR
+2. Merkle proof (`validatorMerkleRoot`) OR
+3. ENS subdomain ownership under configured root node
+
+### 1) Approve validator bond (AGI token contract)
+Write function: `approve(spender, amount)`
+
+### 2) Vote during review
+- Approve work: `validateJob(jobId, subdomain, proof)`
+- Disapprove work: `disapproveJob(jobId, subdomain, proof)`
+
+Input fields for both vote functions:
+- `jobId` (uint256)
+- `subdomain` (string)
+- `proof` (bytes32[])
+
+Proof format examples:
 ```text
 []
 ```
@@ -118,42 +200,9 @@ Proof paste formats:
 ["0xaaa...", "0xbbb..."]
 ```
 
-### 3) Submit completion
-Write function: `requestJobCompletion(jobId, jobCompletionURI)`
-
-Example URI:
-```text
-ipfs://bafy.../completion.v1.json
-```
-
-### 4) Optional dispute
-Write function: `disputeJob(jobId)`
-
----
-
-## Validator flow
-
-### Authorization decision tree
-Use one route:
-1. owner allowlist (`additionalValidators`) OR
-2. Merkle proof (`validatorMerkleRoot`) OR
-3. ENS ownership under configured root node
-
-### 1) Approve validator bond
-Token write function: `approve(spender, amount)`
-
-### 2) Vote
-- approve: `validateJob(jobId, subdomain, proof)`
-- reject: `disapproveJob(jobId, subdomain, proof)`
-
-Proof paste format:
-```text
-["0xaaa...", "0xbbb..."]
-```
-
 Outcome notes:
 - wrong-side validators can be slashed
-- correct-side validators can share rewards
+- correct-side validators can receive validation rewards
 
 ---
 
@@ -161,99 +210,155 @@ Outcome notes:
 
 Write function: `resolveDisputeWithCode(jobId, resolutionCode, reason)`
 
-Resolution code table:
-- `0` = NO_ACTION (dispute remains)
-- `1` = AGENT_WIN
-- `2` = EMPLOYER_WIN
+Input fields:
+- `jobId` (uint256)
+- `resolutionCode` (uint8)
+- `reason` (string)
 
-Standardized reason format (recommended):
+Resolution code table:
+- `0` = `NO_ACTION` (dispute remains unresolved)
+- `1` = `AGENT_WIN`
+- `2` = `EMPLOYER_WIN`
+
+Standardized reason format:
 ```text
-EVIDENCE:v1|summary:<one line>|links:<ipfs/case refs>|policy:<section>|moderator:<id>|ts:<unix>
+EVIDENCE:v1|summary:<one line>|facts:<facts>|links:<ipfs/urls>|policy:<section>|moderator:<id>|ts:<unix>
 ```
 
 ---
 
-## Owner/operator flow
+## Owneroperator flow
 
 ### Pause controls
-- intake only: `pause()` / `unpause()`
-- settlement toggle: `setSettlementPaused(true/false)`
-- full stop: `pauseAll()`
+- Intake pause: `pause()` / `unpause()`
+- Settlement pause: `setSettlementPaused(true|false)`
+- Full stop toggles: `pauseAll()` / `unpauseAll()`
 
 ### Governance/admin writes
-- allowlists: `addAdditionalAgent`, `addAdditionalValidator`
-- blacklists: `blacklistAgent`, `blacklistValidator`
-- moderators: `addModerator`, `removeModerator`
-- withdrawals: `withdrawableAGI()` (read) then `withdrawAGI(amount)`
-- ENS config: `setEnsJobPages`, `setUseEnsJobTokenURI`, `updateRootNodes`, `updateMerkleRoots`
-- lock identity config: `lockIdentityConfiguration()`
-- rescue/break-glass: `rescueERC20`, `rescueToken` (extreme caution)
+- Allowlist: `addAdditionalAgent`, `addAdditionalValidator`
+- Blacklist: `blacklistAgent`, `blacklistValidator`
+- Moderator set: `addModerator`, `removeModerator`
+- Withdrawals: read `withdrawableAGI()` then call `withdrawAGI(amount)`
+- ENS identity settings: `setEnsJobPages`, `setUseEnsJobTokenURI`, `updateEnsRegistry`, `updateNameWrapper`, `updateRootNodes`, `updateMerkleRoots`
+- Configuration lock: `lockIdentityConfiguration()`
+- Rescue (extreme caution): `rescueERC20`, `rescueToken`
 
 ---
 
 ## Time windows
 
 ```text
-assign --> request completion --> review window --> challenge window --> finalize OR dispute --> resolve
+assign
+  -> requestJobCompletion
+    -> review window (validator votes)
+      -> challenge window (if validator-approved path applies)
+        -> finalizeJob OR disputeJob
+          -> moderator resolveDisputeWithCode
 ```
 
-### Can I finalize now?
-Checklist:
-1. Read `getJobCore(jobId)`: `completionRequested == true`, `disputed == false`, not completed/expired/cancelled.
-2. Read `getJobValidation(jobId)` for vote counters/timing parameters.
-3. Compare `completionRequestedAt + completionReviewPeriod` and challenge period with current timestamp.
-4. If tied/under-quorum at review end, expect dispute path.
+### Can I finalize now? checklist
+1. `getJobCore(jobId)` must indicate:
+   - `completed == false`
+   - `disputed == false`
+   - `expired == false`
+2. `getJobValidation(jobId)` must indicate:
+   - `completionRequested == true`
+3. Calculate review end: `completionRequestedAt + completionReviewPeriod`.
+4. If validator-approved path is active, also enforce challenge window elapsed.
+5. Use strict elapsed logic: only act once current timestamp is **greater than** required threshold.
+6. If finalization still routes to dispute, use moderator flow.
 
 ---
 
 ## Read-contract cheat sheet
 
-- `getJobCore(jobId)`: canonical lifecycle fields (participants, payout, timestamps, flags).
-- `getJobValidation(jobId)`: review/dispute windows and vote counters/state.
-- `getJobSpecURI(jobId)`: original job metadata URI.
-- `getJobCompletionURI(jobId)`: submitted completion metadata URI.
-- `tokenURI(tokenId)`: final NFT metadata URI after completion.
+Use these reads to infer state and next action:
+
+- `getJobCore(jobId)` returns:
+  - employer, assignedAgent, payout, duration, assignedAt
+  - completed/disputed/expired flags
+  - agentPayoutPct
+- `getJobValidation(jobId)` returns:
+  - completionRequested
+  - validatorApprovals / validatorDisapprovals
+  - completionRequestedAt / disputedAt
+- `getJobSpecURI(jobId)` returns job spec URI.
+- `getJobCompletionURI(jobId)` returns completion evidence URI.
+- `tokenURI(tokenId)` returns NFT metadata URI (ENS-based when enabled).
+
+Interpretation shortcuts:
+- `assignedAgent == 0x000...0` => still open (not assigned).
+- `completionRequested == true` => review/dispute phase started.
+- `disputed == true` => only dispute resolution path remains.
+- `completed == true` or `expired == true` => terminal job state.
 
 ---
 
-## Authorization details (especially for Agent/Validator)
+## Authorization details (Agent and Validator)
 
-### Route 1: owner additional allowlist
-- Agent: `addAdditionalAgent(address)`
-- Validator: `addAdditionalValidator(address)`
-
-### Route 2: Merkle proof
-- leaf format: `keccak256(abi.encodePacked(address))`
-- proof pasted as Etherscan bytes32[]
-- offline generation script:
-  - `node scripts/merkle/export_merkle_proofs.js --input addresses.json`
-
-### Route 3: ENS subdomain ownership
-Subdomain label constraints:
-- lowercase ASCII
+### ENS label constraints
+For `subdomain` input used in ENS auth route:
+- lowercase ASCII only
 - length 1..63
-- `[a-z0-9-]` only
-- no dots
-- no leading/trailing dash
+- characters allowed: `[a-z0-9-]`
+- no dots (`.`)
+- no leading or trailing `-`
 
-Decision tree:
+### Which auth method are you using?
 ```text
-If owner allowlisted you -> use [] proof and proceed.
-Else if you have Merkle proof -> paste bytes32[] proof.
-Else if you own valid ENS subdomain under configured root -> use subdomain route.
-Else -> you are not authorized yet.
+Are you owner-allowlisted?
+  yes -> use that wallet, proof can be []
+  no  -> do you have Merkle proof from operator?
+          yes -> paste proof bytes32[] into Etherscan
+          no  -> do you control an allowed ENS subdomain under configured root?
+                  yes -> provide subdomain label in write call
+                  no  -> ask operator for allowlisting or updated Merkle root
+```
+
+### Merkle tooling
+Leaf format is fixed:
+- `keccak256(abi.encodePacked(address))`
+
+Generate root + proofs offline:
+```bash
+node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json
 ```
 
 ---
 
-## Offline helper scripts
+## Offline helper scripts (copy/paste friendly)
 
-- Merkle proofs: `node scripts/merkle/export_merkle_proofs.js --input addresses.json`
-- Etherscan input prep: `node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 3d`
-- Offline state advisor: `node scripts/advisor/state_advisor.js --input sample-job.json`
+### A) Merkle proof export
+```bash
+node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json --output merkle-proof-output.json
+```
 
-Advisor input note (copy from Read Contract outputs):
-- `getJobCore`: include `assignedAt`, `duration`, `completed`, `disputed`, `expired`, `employer`, `assignedAgent`.
-- `getJobValidation`: include `completionRequested`, `completionRequestedAt`, `disputedAt`, and (if available from your snapshot pipeline) `validatorApproved` + `validatorApprovedAt`.
-- also provide current timestamp and protocol windows (`completionReviewPeriod`, `disputeReviewPeriod`, `challengePeriodAfterApproval`) for accurate time-gated advice; if omitted, advisor suppresses dependent actions.
-- Time gates in advisor follow contract-style strict elapsed checks; for finalize/expire/stale resolution, current timestamp must be **strictly greater than** the reported threshold.
+### B) Etherscan input prep CLI
+```bash
+node scripts/etherscan/prepare_inputs.js --action approve --spender 0xYourAGIJobManager --amount 1200
+node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 3d --jobSpecURI ipfs://bafy.../job.json --details "Translate legal packet EN->ES"
+node scripts/etherscan/prepare_inputs.js --action apply --jobId 42 --subdomain alice-agent --proof "0xaaa...,0xbbb..."
+node scripts/etherscan/prepare_inputs.js --action request-completion --jobId 42 --jobCompletionURI ipfs://bafy.../completion.json
+node scripts/etherscan/prepare_inputs.js --action validate --jobId 42 --subdomain val-1 --proof "[]"
+node scripts/etherscan/prepare_inputs.js --action resolve-dispute --jobId 42 --code 1 --reason "EVIDENCE:v1|summary:milestones met|facts:...|links:ipfs://...|policy:ops-2.1|moderator:mod-07|ts:1736465000"
+```
+
+### C) Offline state advisor
+```bash
+node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json
+```
+
+Expected input schema (`--input` or `--json`):
+- `currentTimestamp`
+- `completionReviewPeriod`
+- `disputeReviewPeriod`
+- `challengePeriodAfterApproval`
+- `validatorApproved` (optional but recommended)
+- `validatorApprovedAt` (optional but recommended)
+- `getJobCore` object from Etherscan
+- `getJobValidation` object from Etherscan
+
+The advisor prints:
+- derived lifecycle state
+- valid actions now
+- earliest safe thresholds for finalize/expire/stale-dispute resolution

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,16 +1,16 @@
 # FAQ (Etherscan-first)
 
-## Why do I need approval before create/apply/vote/dispute?
+## Why do I need token approval before create/apply/vote/dispute?
 
-AGIJobManager pulls AGI with `transferFrom`, so allowance on the AGI token is required.
+AGIJobManager pulls AGI using `transferFrom`, so your wallet must grant allowance first.
 
 ## Should I use exact-amount approvals?
 
-For least privilege, yes: approve only the exact amount needed for escrow or bond, then raise if necessary.
+Yes for least privilege. Approve exact payout/bond amount when possible.
 
-## How do I paste `bytes32[]` proofs in Etherscan?
+## How do I paste `bytes32[]` proofs into Etherscan?
 
-Use one-line JSON array:
+Use a one-line JSON array:
 
 ```text
 []
@@ -20,21 +20,26 @@ Use one-line JSON array:
 ["0xabc...", "0xdef..."]
 ```
 
+You can generate proof arrays offline with:
+```bash
+node scripts/merkle/export_merkle_proofs.js --input addresses.json --output proofs.json
+```
+
 ## Why can `finalizeJob` open a dispute instead of settling?
 
-At review end, tie or under-quorum outcomes move to dispute flow by design.
+If finalization conditions indicate contested outcomes (for example under-quorum/tie paths), finalize can route to dispute resolution.
 
-## What if nobody votes?
+## What happens if nobody votes?
 
-At review-end timeout with no validator votes, contract follows deterministic finalize behavior (check `getJobValidation` + `finalizeJob` outcome path).
+Outcome is deterministic from contract logic and timing. Use `getJobValidation(jobId)` plus timing windows to evaluate whether finalize/dispute path is next.
 
 ## What is `paused` vs `settlementPaused`?
 
-- `paused`: intake pause controls (create/apply and related intake lanes)
-- `settlementPaused`: settlement/dispute/finalization lane pause
+- `paused`: intake lane controls.
+- `settlementPaused`: settlement/dispute/finalization lane controls.
 
-Operators can toggle independently for incident response.
+They are independent and can be toggled separately.
 
-## Why do fee-on-transfer/deflationary ERC20 tokens fail?
+## Why do fee-on-transfer or deflationary ERC20s fail?
 
-AGIJobManager accounting expects strict exact-transfer semantics. Fee-on-transfer or deflationary behavior can break invariants and revert with transfer/accounting errors.
+AGIJobManager accounting assumes strict transfer amounts. Tokens that burn/skim on transfer can violate accounting expectations and cause reverts (commonly `TransferFailed` or downstream state errors).

--- a/docs/VERIFY_ON_ETHERSCAN.md
+++ b/docs/VERIFY_ON_ETHERSCAN.md
@@ -2,39 +2,39 @@
 
 Etherscan Read/Write usability depends on successful source verification.
 
-## 1) Compiler settings used by this repo
+## 1) Compilation settings (must match deployment)
 
-From `truffle-config.js` (deployment path used by npm scripts):
-- solc: `0.8.23`
-- optimizer: enabled, `runs: 50`
-- `viaIR: true`
+From `truffle-config.js` deployment path:
+- compiler: `solc 0.8.23`
+- optimizer: enabled, `runs = 50`
+- `viaIR = true`
 - EVM version: `london`
 - metadata bytecode hash: `none`
 - revert strings: `strip`
 
-Foundry profile in `foundry.toml` exists for forge tests and differs (`solc 0.8.19`). Do not mix profiles when verifying Truffle deployments.
+Foundry settings in `foundry.toml` are for forge tests and are not the canonical truffle deployment profile.
 
-## 2) Build exactly
+## 2) Build exactly as CI/deploy path
 
 ```bash
 npm ci
 npm run build
 ```
 
-## 3) External library linking (required)
+## 3) Externally linked libraries
 
-AGIJobManager links external libraries. Provide exact deployed addresses for:
+AGIJobManager requires linked library addresses during verification. Supply exact deployed addresses for:
 - `UriUtils`
 - `TransferUtils`
 - `BondMath`
 - `ReputationMath`
 - `ENSOwnership`
 
-If library mapping is wrong, verification will fail.
+If any library mapping is wrong, bytecode mismatch is expected.
 
-## 4) Verification methods
+## 4) Verification options
 
-### A) Truffle plugin path
+### Option A: Truffle verify plugin
 
 ```bash
 ETHERSCAN_API_KEY=... \
@@ -43,23 +43,24 @@ MAINNET_RPC_URL=https://... \
 npx truffle run verify AGIJobManager --network mainnet
 ```
 
-### B) Standard JSON input
+### Option B: Etherscan Standard JSON input
 
-Use Etherscan Standard JSON mode with the same compiler settings and explicit library mapping.
+Use standard-json mode with the exact settings above and explicit library name -> address mapping.
 
-## 5) Troubleshooting mismatches
+## 5) Troubleshooting common mismatches
 
-- Wrong solc version (`0.8.23` expected for Truffle deployment)
-- Wrong optimizer runs (must be 50)
-- Wrong `viaIR` (must match deployment)
+- Wrong compiler version (must be `0.8.23` for truffle deployment)
+- Wrong optimizer run count (`50`)
+- Wrong `viaIR` flag
 - Wrong EVM version (`london`)
-- Metadata hash mode mismatch (`none` expected)
+- Wrong metadata hash mode (must be `none`)
 - Wrong constructor args
 - Wrong linked library addresses
+- Compiling with foundry profile then verifying truffle deployment artifacts
 
-## 6) Post-verify checks
+## 6) Post-verification checklist
 
-On Etherscan:
-1. `Read Contract` shows named methods.
-2. `Write Contract` shows typed fields.
-3. tx details decode custom errors/events cleanly.
+1. Etherscan `Read Contract` shows named methods.
+2. Etherscan `Write Contract` input fields are readable and typed.
+3. tx pages decode events and custom errors.
+4. Role-guide examples in [`docs/ETHERSCAN_GUIDE.md`](ETHERSCAN_GUIDE.md) now map to visible function signatures.

--- a/scripts/advisor/sample_job_state.json
+++ b/scripts/advisor/sample_job_state.json
@@ -1,0 +1,27 @@
+{
+  "jobId": 42,
+  "currentTimestamp": 1737000000,
+  "completionReviewPeriod": 86400,
+  "disputeReviewPeriod": 172800,
+  "challengePeriodAfterApproval": 43200,
+  "validatorApproved": false,
+  "validatorApprovedAt": 0,
+  "getJobCore": {
+    "employer": "0x1111111111111111111111111111111111111111",
+    "assignedAgent": "0x2222222222222222222222222222222222222222",
+    "payout": "1200000000000000000000",
+    "duration": 259200,
+    "assignedAt": 1736500000,
+    "completed": false,
+    "disputed": false,
+    "expired": false,
+    "agentPayoutPct": 80
+  },
+  "getJobValidation": {
+    "completionRequested": true,
+    "validatorApprovals": 2,
+    "validatorDisapprovals": 1,
+    "completionRequestedAt": 1736700000,
+    "disputedAt": 0
+  }
+}


### PR DESCRIPTION
### Motivation
- The advisor sample state in `scripts/advisor/sample_job_state.json` contained a `completionRequestedAt` timestamp outside the job's allowed request window (`assignedAt + duration`), producing an unreachable non-disputed state that could mislead operators or offline tooling.

### Description
- Adjusted `getJobValidation.completionRequestedAt` in `scripts/advisor/sample_job_state.json` from `1736800000` to `1736700000` so the sample satisfies `completionRequestedAt <= assignedAt + duration` and aligns with the contract check in `requestJobCompletion`.

### Testing
- Ran `node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json` and confirmed the advisor produced coherent derived state and finalize guidance with the corrected timestamps (succeeded). 
- Started `npm test` during validation and observed many Truffle/JS suites running and passing prior to an interrupted session, but the full `npm test` run was not completed in-session due to runtime/session constraints.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994ad10123c83338e73a932a51290f1)