### PR TITLE
Improve Etherscan UX docs and harden offline Merkle proof export

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,21 @@ npm run size
 
 `npm test` runs: Truffle compile/tests, additional Node tests, and contract size guards.
 
+## Offline helper tooling (Etherscan-first)
+
+- Merkle root + proof export (paste-ready `bytes32[]`):
+  ```bash
+  node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json --output proofs.json
+  ```
+- Etherscan write-input preparation + unit conversion:
+  ```bash
+  node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 7d --jobSpecURI ipfs://bafy.../job.json --details "Translate legal packet EN->ES"
+  ```
+- Offline state advisor (no RPC required):
+  ```bash
+  node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json
+  ```
+
 
 ## Documentation
 

--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -9,7 +9,7 @@ This guide is written for non-technical users who only use:
 - Agent: [Agent flow](#agent-flow)
 - Validator: [Validator flow](#validator-flow)
 - Moderator: [Moderator flow](#moderator-flow)
-- Owner/operator: [Owneroperator flow](#owneroperator-flow)
+- Owner/operator: [Owner/operator flow](#owneroperator-flow)
 
 ---
 
@@ -227,7 +227,7 @@ EVIDENCE:v1|summary:<one line>|facts:<facts>|links:<ipfs/urls>|policy:<section>|
 
 ---
 
-## Owneroperator flow
+## Owner/operator flow
 
 ### Pause controls
 - Intake pause: `pause()` / `unpause()`
@@ -335,7 +335,7 @@ Are you owner-allowlisted?
 Leaf format is fixed:
 - `keccak256(abi.encodePacked(address))`
 
-Generate root + proofs offline:
+Generate root + proofs offline (deterministic ordering, duplicate-address guard):
 ```bash
 node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json
 ```

--- a/scripts/merkle/export_merkle_proofs.js
+++ b/scripts/merkle/export_merkle_proofs.js
@@ -46,12 +46,17 @@ if (!Array.isArray(parsed) || parsed.length === 0) {
 }
 
 const addresses = parsed.map(normalizeAddress);
-const leaves = addresses.map(toLeaf);
+const uniqueAddresses = [...new Set(addresses)].sort();
+if (uniqueAddresses.length !== addresses.length) {
+  console.error("Input contains duplicate addresses. Please provide unique addresses only.");
+  process.exit(1);
+}
+const leaves = uniqueAddresses.map(toLeaf);
 const tree = new MerkleTree(leaves, keccak256, { sortPairs: true, sortLeaves: true });
 
 const proofs = {};
 const etherscanProofArrays = {};
-for (const address of addresses) {
+for (const address of uniqueAddresses) {
   const proof = tree.getHexProof(toLeaf(address));
   proofs[address] = proof;
   etherscanProofArrays[address] = JSON.stringify(proof);


### PR DESCRIPTION
### Motivation
- Make the Etherscan Read/Write experience reliable and copy/paste friendly for non‑technical users and reduce operator error with small, offline-first helpers and clearer guidance.
- Keep changes minimal and non-invasive to on‑chain behavior, selectors, and bytecode discipline.

### Description
- Add an “Offline helper tooling (Etherscan‑first)” section to `README.md` with copy/paste commands for Merkle proof export, Etherscan input preparation, and the offline state advisor so operators find tooling from the repo entrypoint.
- Fix Owner/operator labeling/navigation and explicitly call out deterministic/duplicate‑safe Merkle tooling in `docs/ETHERSCAN_GUIDE.md` for clearer role flows and operator expectations.
- Harden `scripts/merkle/export_merkle_proofs.js` to normalize addresses to lowercase, reject duplicate inputs, and use a deterministic sorted unique list before building the Merkle tree and producing paste‑ready `bytes32[]` proofs.

### Testing
- `npm run build` completed successfully.
- `npx truffle test --network test test/ensAbiCompatibility.test.js` passed (ENS selector and calldata‑length assertions included) indicating selector/calldata invariants remain intact.
- `npm run size` completed successfully and reported AGIJobManager runtime bytecode size as `24533` bytes (within EIP‑170 limit).
- `npm run lint` ran to completion with warnings only (no errors).
- `node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json` produced root and paste‑ready proofs successfully.
- `node scripts/etherscan/prepare_inputs.js --action create-job ...` and `node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json` produced expected copy/paste outputs.
- Full `npm test` (the repo entrypoint) could not be completed in this environment due to prolonged `truffle compile --all` runs; targeted ENS ABI compatibility tests and tooling smoke tests were run and passed, and `forge` tests were skipped because `forge` is not present in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994eacff0788333809611bd41baec88)