### PR TITLE
test(security): add deterministic ENS ownership auth regression coverage

### DIFF
--- a/SECURITY_VERIFICATION_REPORT.md
+++ b/SECURITY_VERIFICATION_REPORT.md
@@ -6,7 +6,7 @@
 - ENS integration contracts and assembly call compatibility assumptions
 
 ## Tooling Versions
-- Foundry: `forge --version`
+- Foundry: `forge 1.5.1-stable (b0a9dd9ceda36f63e2326ce530c10e6916f4b8a2)`
 - Solidity compiler: `0.8.19` (from `foundry.toml`)
 - Slither: `0.10.4`
 - Echidna: not included (Foundry handler invariants already cover the multi-step state machine with deterministic CI runtime)
@@ -29,6 +29,9 @@ npm run slither
 ## Added Verification Coverage
 
 ### Unit / Regression (Foundry)
+- Deterministic ENS ownership authorization path with strict label enforcement:
+  - valid resolver-backed subdomain authorizes apply flow
+  - invalid labels (e.g. containing dots) revert via strict ENS label validation
 - ENS selector and calldata compatibility checks assert:
   - `handleHook(uint8,uint256)` selector = `0x1f76f7a2`, calldata length `0x44`
   - `jobEnsURI(uint256)` selector = `0x751809b4`, calldata length `0x24`


### PR DESCRIPTION
### Motivation

- Close a deterministic verification gap around ENS-based authorization by exercising the resolver-backed ownership path and strict ENS label validation in the Foundry security suite.
- Ensure ENS integration assumptions (selectors/calldata) and label rules are explicitly regression-tested without touching production contract storage or signatures.

### Description

- Add a deterministic unit regression `test_ENSOwnershipPathAndStrictLabelValidation` to `forge-test/unit/AGIJobManagerSecurityVerification.t.sol` that wires `MockENSRegistry`, `MockNameWrapper`, and `MockResolver` to assert resolver-backed subdomain authorization allows `applyForJob` and that malformed labels (e.g. containing `.`) revert via `EnsLabelUtils` validation.
- Import and use test-only ENS mocks (`MockENSRegistry`, `MockNameWrapper`, `MockResolver`) and create a temporary test `AGIJobManagerHarness` instance to exercise the ENS resolver path end-to-end in a deterministic offline environment.
- Update `SECURITY_VERIFICATION_REPORT.md` to pin the concrete Foundry tool version used and to document the new ENS ownership and strict label-validation coverage.
- No production contract code or storage layout was modified; all changes are test-only and concentrate verification coverage in `forge-test` and docs.

### Testing

- Ran `FOUNDRY_PROFILE=ci forge build` and `FOUNDRY_PROFILE=ci forge test` for unit, fuzz and invariant suites, and the new ENS regression test, with all suites passing (unit/fuzz/invariants passed in CI-profile runs).
- Ran Slither via `npm run slither` (which runs `./scripts/security/run-slither.sh`) with Slither `0.10.4`, and the analyzer returned no actionable findings ("0 result(s) found").
- Environment/tooling used during verification: `forge 1.5.1-stable`, `solc 0.8.19`, and `slither 0.10.4`, and reproduction commands are recorded in `SECURITY_VERIFICATION_REPORT.md`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994fa5dae2883339c577f6d75bd1897)