### PR TITLE
docs: polish institutional README badge presentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,8 @@
 # AGIJobManager
 
-[![CI][ci-badge]][ci-url] [![Slither][slither-badge]][slither-url] [![License][license-badge]][license-url] [![Security][security-badge]][security-url]
+[![CI][ci-badge]][ci-url] [![Security][security-badge]][security-url] [![License][license-badge]][license-url] [![Slither][slither-badge]][slither-url]
 
 AGIJobManager is an owner-operated on-chain job escrow and settlement contract for employer/agent workflows with validator voting and moderator dispute resolution.
-
-[ci-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/ci.yml?branch=main&style=flat-square&label=CI
-[ci-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml
-[slither-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/security-verification.yml?branch=main&style=flat-square&label=Slither
-[slither-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/security-verification.yml
-[license-badge]: https://img.shields.io/github/license/MontrealAI/AGIJobManager?style=flat-square
-[license-url]: ./LICENSE
-[security-badge]: https://img.shields.io/badge/Security-Policy-blue?style=flat-square
-[security-url]: ./SECURITY.md
 
 ## Start here
 
@@ -101,3 +92,12 @@ npm run docs:gen
 npm run docs:check
 npm run check:no-binaries  # check-no-binaries
 ```
+
+[ci-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/ci.yml?branch=main&style=flat-square&label=CI
+[ci-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml
+[security-badge]: https://img.shields.io/badge/Security-Policy-1f6feb?style=flat-square
+[security-url]: ./SECURITY.md
+[license-badge]: https://img.shields.io/github/license/MontrealAI/AGIJobManager?style=flat-square
+[license-url]: ./LICENSE
+[slither-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/security-verification.yml?branch=main&style=flat-square&label=Slither
+[slither-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/security-verification.yml


### PR DESCRIPTION
### Motivation
- Improve the project front-door by presenting a small, conservative set of official-looking badges (CI, Security Policy, License, Slither) that are truthful, stable, and audit-friendly.

### Description
- Reordered the top-of-file badge row to `CI → Security Policy → License → Slither`, moved the badge reference definitions to the end of `README.md`, and adjusted the security badge color string for visual consistency, with no other content or assertions added.

### Testing
- Ran the repository documentation integrity check with `npm run docs:check` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995370dcc7c8333a6a4f26bea259435)