### PR TITLE
docs: add stable institutional README badges (CI, Security Scan, Security Policy, License)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # AGIJobManager
 
-[![CI][ci-badge]][ci-url] [![Security][security-badge]][security-url] [![License][license-badge]][license-url] [![Slither][slither-badge]][slither-url]
+[![CI][ci-badge]][ci-url] [![Security Scan][security-scan-badge]][security-scan-url] [![Security Policy][security-badge]][security-url] [![License][license-badge]][license-url]
 
 AGIJobManager is an owner-operated on-chain job escrow and settlement contract for employer/agent workflows with validator voting and moderator dispute resolution.
 
@@ -95,9 +95,9 @@ npm run check:no-binaries  # check-no-binaries
 
 [ci-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/ci.yml?branch=main&style=flat-square&label=CI
 [ci-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/ci.yml
-[security-badge]: https://img.shields.io/badge/Security-Policy-1f6feb?style=flat-square
+[security-scan-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/security-verification.yml?branch=main&style=flat-square&label=Security%20Scan
+[security-scan-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/security-verification.yml
+[security-badge]: https://img.shields.io/badge/Security-Policy-blue?style=flat-square
 [security-url]: ./SECURITY.md
 [license-badge]: https://img.shields.io/github/license/MontrealAI/AGIJobManager?style=flat-square
 [license-url]: ./LICENSE
-[slither-badge]: https://img.shields.io/github/actions/workflow/status/MontrealAI/AGIJobManager/security-verification.yml?branch=main&style=flat-square&label=Slither
-[slither-url]: https://github.com/MontrealAI/AGIJobManager/actions/workflows/security-verification.yml


### PR DESCRIPTION
### Motivation
- Improve the repository front door by adding a small, conservative set of truthful, institutional-grade badges that reflect existing CI, security scanning, security policy, and license information.

### Description
- Updated `README.md` to replace the prior Slither label with a `Security Scan` workflow-status badge that points to `.github/workflows/security-verification.yml`, and ensured the badge row uses `style=flat-square` with canonical links to the `ci.yml` workflow, `SECURITY.md`, and `LICENSE`.

### Testing
- Performed automated repository checks and assertions: used `curl` + `jq` to confirm default branch and license, `ls -1 .github/workflows` to verify workflows, `sed -n` to inspect `README.md`, `rg` to confirm no coverage integration, and a `python` assertion to verify the new badge reference keys exist, and then committed the change; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699540dce76c833383cf613fb1439c9a)