### PR TITLE
docs: institutionalize deployment playbook and tighten docs integrity checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,11 @@ npm run size
 ## Documentation
 
 - Main docs index: [`docs/README.md`](docs/README.md)
+- Deployment and configuration guide: [`docs/DEPLOYMENT.md`](docs/DEPLOYMENT.md)
 - Quintessential end-to-end walkthrough: [`docs/QUINTESSENTIAL_USE_CASE.md`](docs/QUINTESSENTIAL_USE_CASE.md)
+- Diagrams are Mermaid plus text-only SVG assets under [`docs/assets/`](docs/assets/)
+- Documentation freshness is enforced by deterministic generators (`docs:gen`) and CI checks (`docs:check`)
+- No-binaries policy is enforced in CI via `check:no-binaries`
 
 ## Sovereign Ops Console UI
 

--- a/docs/DEPLOYMENT.md
+++ b/docs/DEPLOYMENT.md
@@ -1,0 +1,67 @@
+# Deployment and Configuration
+
+Institutional deployment guidance for deterministic local rehearsal, testnet rehearsal, and production execution.
+
+## Deployment entrypoints
+
+| Stage | Entrypoint | Purpose | Source of truth |
+| --- | --- | --- | --- |
+| Contract deployment | `migrations/1_deploy_contracts.js` | Deploys AGIJobManager with network-aware constructor args | [`migrations/1_deploy_contracts.js`](../migrations/1_deploy_contracts.js) |
+| Deployment parameters | `migrations/deploy-config.js` | Defines network profiles and deploy-time constants | [`migrations/deploy-config.js`](../migrations/deploy-config.js) |
+| Post-deploy owner setup | `scripts/postdeploy-config.js` | Applies moderator/allowlist/root/parameter configuration | [`scripts/postdeploy-config.js`](../scripts/postdeploy-config.js) |
+| Parameter sanity checks | `scripts/ops/validate-params.js` | Validates operator parameter packages before owner txs | [`scripts/ops/validate-params.js`](../scripts/ops/validate-params.js) |
+
+## Deterministic local deployment
+
+```bash
+npm ci
+npm run build
+npx ganache --wallet.totalAccounts 10 --wallet.defaultBalance 1000 --chain.chainId 1337
+truffle migrate --network development --reset
+```
+
+Expected verification:
+- Deployment tx confirms AGIJobManager address and owner address.
+- Read `owner()`, `agiToken()`, `agentRootNode`, and pause flags immediately after deploy.
+
+## Testnet and mainnet deployment discipline
+
+```bash
+# compile + tests before any live migration
+npm run build
+npm test
+
+# dry-run parameter validation before owner transactions
+node scripts/ops/validate-params.js --help
+
+# deploy by network profile configured in truffle-config.js
+truffle migrate --network <network_name> --reset
+
+# run post-deploy owner configuration if the operational plan requires it
+node scripts/postdeploy-config.js --network <network_name>
+```
+
+## Preflight checklist (no secrets in repo)
+
+1. Confirm chain ID, RPC endpoint, and signer separation are documented in internal change ticket.
+2. Confirm no `.env` secrets are in git status (`.env.example` placeholders only).
+3. Rehearse the exact parameter package on testnet and archive tx hashes.
+4. Confirm monitoring alerts are armed for `JobCreated`, `JobDisputed`, `DisputeResolvedWithCode`, `SettlementPauseSet`, and `AGIWithdrawn`.
+5. Confirm rollback/containment plan (`pause`, `setSettlementPaused`, selective blacklist actions).
+
+## Post-deploy acceptance checks
+
+| Check | Command / Method | Accept criteria |
+| --- | --- | --- |
+| Constructor wiring | Truffle console + getters | AGI token and ENS references match approved config |
+| Role setup | Event scan + role getters | Moderators and allowlists match approved roster |
+| Solvency guard | `withdrawableAGI()` + locked totals | Withdrawable equals balance minus locked buckets |
+| Lifecycle smoke | Execute low-value canonical job | Create → apply → complete → validate → finalize succeeds |
+| Incident controls | Owner dry-run toggles in rehearsal env | `pause`/`setSettlementPaused`/blacklist controls callable by owner only |
+
+## Related pages
+
+- [QUICKSTART.md](./QUICKSTART.md)
+- [QUINTESSENTIAL_USE_CASE.md](./QUINTESSENTIAL_USE_CASE.md)
+- [OPERATIONS/RUNBOOK.md](./OPERATIONS/RUNBOOK.md)
+- [OPERATIONS/INCIDENT_RESPONSE.md](./OPERATIONS/INCIDENT_RESPONSE.md)

--- a/docs/QUICKSTART.md
+++ b/docs/QUICKSTART.md
@@ -18,14 +18,20 @@ npm run build
 npm test
 ```
 
-## 4) Docs integrity
+## 4) Local deploy rehearsal
+
+```bash
+truffle migrate --network development --reset
+```
+
+## 5) Documentation integrity
 
 ```bash
 npm run docs:gen
 npm run docs:check
 ```
 
-## 5) Optional UI smoke test
+## 6) Optional UI smoke test
 
 ```bash
 npm run test:ui
@@ -33,10 +39,11 @@ npm run test:ui
 
 ## Command catalog
 
-| Command | Outcome | When to use | Common failures |
-| --- | --- | --- | --- |
-| `npm ci` | Deterministic dependency install | Fresh clone / CI | Lockfile mismatch |
-| `npm run build` | Truffle compile and artifacts | Before tests/deploy | Solidity compile errors |
-| `npm test` | Contract + invariant/regression suites | Pre-PR safety gate | Local node/toolchain drift |
-| `node scripts/ops/validate-params.js --help` | Parameter schema guidance | Before owner param changes | Invalid bounds/input format |
-| `npm run docs:check` | Verifies required docs freshness, links, Mermaid, SVG | Pre-PR for docs | Stale generated docs |
+| Command | Outcome | When to use | Common failures | Fix |
+| --- | --- | --- | --- | --- |
+| `npm ci` | Deterministic dependency install | Fresh clone / CI | Lockfile mismatch | Re-run with clean lockfile and Node version parity |
+| `npm run build` | Truffle compile and artifacts | Before tests/deploy | Solidity compile errors | Inspect compiler diagnostics and contract imports |
+| `npm test` | Contract + invariant/regression suites | Pre-PR safety gate | Local node/toolchain drift | Reinstall deps and ensure Ganache/Truffle versions match lockfile |
+| `truffle migrate --network development --reset` | Local deployment rehearsal | Validate migration path end-to-end | Missing local chain or wrong network config | Start Ganache and confirm `truffle-config.js` network settings |
+| `node scripts/ops/validate-params.js --help` | Parameter schema guidance | Before owner param changes | Invalid bounds/input format | Correct parameter package before signing owner txs |
+| `npm run docs:check` | Verifies required docs freshness, links, Mermaid, SVG | Pre-PR for docs | Stale generated docs | Run `npm run docs:gen` and recommit generated outputs |

--- a/docs/QUINTESSENTIAL_USE_CASE.md
+++ b/docs/QUINTESSENTIAL_USE_CASE.md
@@ -19,6 +19,12 @@ npx ganache --wallet.totalAccounts 10 --wallet.defaultBalance 1000 --chain.chain
 truffle migrate --network development --reset
 ```
 
+Optional: open Truffle console for direct function execution during the walkthrough.
+
+```bash
+truffle console --network development
+```
+
 ### Step table
 
 | Step | Actor | Function/Command | Preconditions | Expected on-chain outcome | Events emitted | What to verify next |
@@ -95,3 +101,21 @@ stateDiagram-v2
 7. **Control rehearsals**: rehearse `pause`, `setSettlementPaused`, blacklist actions, and stale-dispute owner recovery path.
 8. **Mainnet go/no-go gate**: proceed only after configuration parity checks and operator sign-off.
 9. **Post-launch verification**: continuously reconcile locked totals (`lockedEscrow`, `locked*Bonds`) against treasury withdrawals.
+
+
+### Production-oriented verification checklist
+
+| Checkpoint | Testnet expectation | Mainnet expectation | Verification method |
+| --- | --- | --- | --- |
+| Chain identity | Approved testnet chain ID (e.g., Sepolia `11155111`) | Ethereum Mainnet `1` | RPC `eth_chainId` + explorer network label |
+| Deployment bytecode parity | Matches CI-compiled artifact hash | Matches audited/tagged artifact hash | Compare artifact metadata + on-chain code hash |
+| Role roster parity | Moderators/allowlists mirror approved test plan | Moderators/allowlists match signed production change request | Getter reads + emitted role events |
+| Parameter envelope | Conservative, low-risk values for rehearsal | Production values signed off in change ticket | `scripts/ops/validate-params.js` + getter readback |
+| Monitoring readiness | Alerts tested with synthetic events | Alerts active with pager routing | Event indexer dashboards and alert test logs |
+
+### Operator notes for canonical steps
+
+- **Step 2 (configuration):** run owner configuration in tightly scoped batches and verify each tx by event before sending the next tx.
+- **Step 6 (validation outcomes):** explicitly rehearse both approval and disapproval quorum outcomes on testnet before production launch.
+- **Step 8 (dispute path):** enforce moderator rationale discipline (`reason` strings must map to case ticket IDs).
+- **Step 10 (observability):** maintain a per-job reconciliation ledger linking event stream, getter snapshots, and accounting sanity checks.

--- a/docs/README.md
+++ b/docs/README.md
@@ -18,6 +18,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [QUICKSTART.md](./QUICKSTART.md)
 - [QUINTESSENTIAL_USE_CASE.md](./QUINTESSENTIAL_USE_CASE.md)
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
+- [DEPLOYMENT.md](./DEPLOYMENT.md)
 - [CONTRACTS/AGIJobManager.md](./CONTRACTS/AGIJobManager.md)
 - [CONTRACTS/INTEGRATIONS.md](./CONTRACTS/INTEGRATIONS.md)
 - [INTEGRATIONS/ENS.md](./INTEGRATIONS/ENS.md)
@@ -42,3 +43,10 @@ Institutional documentation for operators, integrators, contributors, and audito
 
 - [assets/palette.svg](./assets/palette.svg)
 - [assets/architecture-wireframe.svg](./assets/architecture-wireframe.svg)
+
+## Operational and CI assurances
+
+- Deterministic generators: `npm run docs:gen` updates generated references.
+- Freshness/integrity gate: `npm run docs:check` validates links, required sections, Mermaid, SVG, and generated drift.
+- No-binaries enforcement: `npm run check:no-binaries` blocks new binary files in PRs.
+- CI enforcement workflow: [`.github/workflows/docs.yml`](../.github/workflows/docs.yml).

--- a/docs/REPO_MAP.md
+++ b/docs/REPO_MAP.md
@@ -1,7 +1,7 @@
 # Repository Map (Generated)
 
-- Generated at (deterministic source fingerprint): `b16a32b567f3`.
-- Source snapshot fingerprint: `b16a32b567f3`.
+- Generated at (deterministic source fingerprint): `3f108e773ec2`.
+- Source snapshot fingerprint: `3f108e773ec2`.
 
 ## Curated high-signal map
 
@@ -16,10 +16,13 @@
 | `forge-test/` | Foundry fuzz/invariant suites | Optional hardening lane |
 | `scripts/ops/validate-params.js` | Parameter sanity checker for operations | Run before live changes |
 | `scripts/postdeploy-config.js` | Post-deploy owner configuration routine | Operational setup automation |
+| `scripts/docs/` | Deterministic documentation generators and integrity gates | Maintains docs freshness in CI |
+| `scripts/check-no-binaries.mjs` | PR-time binary policy enforcement | Blocks forbidden binary additions |
 | `ui/` | Next.js operator/demo frontend | Contains own docs and checks |
 | `.github/workflows/ci.yml` | Main build/lint/test workflow | PR and main branch gate |
 | `.github/workflows/docs.yml` | Docs and no-binaries policy workflow | Documentation freshness gate |
 | `docs/` | Institutional documentation and generated references | Read docs/README.md first |
+| `docs/DEPLOYMENT.md` | Deployment/configuration and operator acceptance checks | Use before testnet/mainnet rollout |
 
 ## Top-level directories
 
@@ -41,6 +44,7 @@
 
 - [`README.md`](../README.md)
 - [`docs/README.md`](../docs/README.md)
+- [`docs/DEPLOYMENT.md`](../docs/DEPLOYMENT.md)
 - [`contracts/AGIJobManager.sol`](../contracts/AGIJobManager.sol)
 - [`test/AGIJobManager.test.js`](../test/AGIJobManager.test.js)
 - [`migrations/1_deploy_contracts.js`](../migrations/1_deploy_contracts.js)

--- a/scripts/docs/check-docs.mjs
+++ b/scripts/docs/check-docs.mjs
@@ -5,7 +5,7 @@ import { execFileSync } from 'node:child_process';
 
 const root = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..');
 const requiredFiles = [
-  'docs/README.md','docs/OVERVIEW.md','docs/REPO_MAP.md','docs/QUICKSTART.md','docs/QUINTESSENTIAL_USE_CASE.md','docs/ARCHITECTURE.md',
+  'docs/README.md','docs/OVERVIEW.md','docs/REPO_MAP.md','docs/QUICKSTART.md','docs/QUINTESSENTIAL_USE_CASE.md','docs/ARCHITECTURE.md','docs/DEPLOYMENT.md',
   'docs/CONTRACTS/AGIJobManager.md','docs/CONTRACTS/INTEGRATIONS.md','docs/OPERATIONS/RUNBOOK.md','docs/OPERATIONS/INCIDENT_RESPONSE.md',
   'docs/OPERATIONS/MONITORING.md','docs/SECURITY_MODEL.md','docs/TESTING.md','docs/TROUBLESHOOTING.md','docs/GLOSSARY.md',
   'docs/REFERENCE/VERSIONS.md','docs/REFERENCE/CONTRACT_INTERFACE.md','docs/REFERENCE/EVENTS_AND_ERRORS.md',
@@ -22,7 +22,8 @@ for (const file of requiredFiles) {
 const mermaidChecks = [
   ['docs/ARCHITECTURE.md', ['flowchart', 'Repo architecture']],
   ['docs/CONTRACTS/AGIJobManager.md', ['stateDiagram-v2', 'sequenceDiagram']],
-  ['docs/OPERATIONS/INCIDENT_RESPONSE.md', ['flowchart', 'settlementPaused']]
+  ['docs/OPERATIONS/INCIDENT_RESPONSE.md', ['flowchart', 'settlementPaused']],
+  ['docs/QUINTESSENTIAL_USE_CASE.md', ['sequenceDiagram', 'stateDiagram-v2']]
 ];
 for (const [file, snippets] of mermaidChecks) {
   const text = fs.readFileSync(path.join(root, file), 'utf8');
@@ -121,6 +122,7 @@ const requiredSectionSnippets = [
   ['docs/SECURITY_MODEL.md', ['## Threat model', '| Vector | Impact | Mitigation | Residual risk | Operator responsibility |']],
   ['docs/TESTING.md', ['## Test matrix', '| Suite | Purpose | Command | Validates |']],
   ['docs/OPERATIONS/RUNBOOK.md', ['## Parameter change checklist']],
+  ['docs/DEPLOYMENT.md', ['## Deployment entrypoints', '## Preflight checklist (no secrets in repo)', '| Stage | Entrypoint | Purpose | Source of truth |']],
   ['docs/OPERATIONS/MONITORING.md', ['## Events catalog']],
   ['docs/OPERATIONS/INCIDENT_RESPONSE.md', ['active exploit', 'settlementPaused', 'blacklist', 'lockIdentityConfiguration']]
 ];

--- a/scripts/docs/generate-repo-map.mjs
+++ b/scripts/docs/generate-repo-map.mjs
@@ -17,10 +17,13 @@ const curated = [
   ['forge-test/', 'Foundry fuzz/invariant suites', 'Optional hardening lane'],
   ['scripts/ops/validate-params.js', 'Parameter sanity checker for operations', 'Run before live changes'],
   ['scripts/postdeploy-config.js', 'Post-deploy owner configuration routine', 'Operational setup automation'],
+  ['scripts/docs/', 'Deterministic documentation generators and integrity gates', 'Maintains docs freshness in CI'],
+  ['scripts/check-no-binaries.mjs', 'PR-time binary policy enforcement', 'Blocks forbidden binary additions'],
   ['ui/', 'Next.js operator/demo frontend', 'Contains own docs and checks'],
   ['.github/workflows/ci.yml', 'Main build/lint/test workflow', 'PR and main branch gate'],
   ['.github/workflows/docs.yml', 'Docs and no-binaries policy workflow', 'Documentation freshness gate'],
-  ['docs/', 'Institutional documentation and generated references', 'Read docs/README.md first']
+  ['docs/', 'Institutional documentation and generated references', 'Read docs/README.md first'],
+  ['docs/DEPLOYMENT.md', 'Deployment/configuration and operator acceptance checks', 'Use before testnet/mainnet rollout']
 ];
 
 const topLevel = fs.readdirSync(repoRoot, { withFileTypes: true })
@@ -40,6 +43,7 @@ const topLevelDirs = topLevel.filter((e) => e.type === 'dir');
 const keyEntrypoints = [
   'README.md',
   'docs/README.md',
+  'docs/DEPLOYMENT.md',
   'contracts/AGIJobManager.sol',
   'test/AGIJobManager.test.js',
   'migrations/1_deploy_contracts.js',


### PR DESCRIPTION
### Motivation
- Provide an institutional, operator-grade deployment and configuration playbook that is copy/paste reproducible and tied to the repository entrypoints. 
- Ensure repository documentation remains current and auditable by adding deterministic generators and demanding CI checks that fail on drift. 
- Prevent accidental binary assets entering the repo by enforcing a no‑binaries policy at PR time and in CI.

### Description
- Added a new deployment and configuration playbook at `docs/DEPLOYMENT.md` documenting deterministic local rehearsal, testnet/mainnet discipline, preflight (no‑secrets) checks, and post‑deploy acceptance checks. 
- Improved documentation hub and quickstart by updating `docs/README.md`, `docs/QUICKSTART.md`, `docs/QUINTESSENTIAL_USE_CASE.md`, and the root `README.md` to surface deployment guidance, CI assurances, and text‑only graphics policy. 
- Strengthened deterministic doc tooling by updating `scripts/docs/generate-repo-map.mjs` (now includes docs tooling and binary-policy entrypoints) and `scripts/docs/check-docs.mjs` (now enforces presence of `docs/DEPLOYMENT.md`, key Mermaid blocks, explicit code-fence language labels, SVG envelope validity, and freshness of generated references). 
- Regenerated reference outputs and repository map: `docs/REPO_MAP.md` and `docs/REFERENCE/*` are produced by `npm run docs:gen`, and existing text-only SVG assets under `docs/assets/` remain the canonical visual assets enforced by the checker.

### Testing
- Ran `npm ci` successfully to install dependencies. 
- Ran `npm run docs:gen` which produced deterministic reference docs (`docs/REFERENCE/VERSIONS.md`, `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REPO_MAP.md`, `docs/REFERENCE/EVENTS_AND_ERRORS.md`) and completed successfully. 
- Ran `npm run check:no-binaries` (node `scripts/check-no-binaries.mjs`) and it reported no forbidden binary additions. 
- Ran `npm run docs:check` (node `scripts/docs/check-docs.mjs`) and it returned success after validating required files, Mermaid presence, SVG envelopes, link resolution, and generated-doc freshness. 
- Ran the repository test lane `npm test` which executed the Truffle/JS suites and returned a green test result (351 passing) under the repo toolchain. 

Notes: No binary files were added and the repository now enforces no‑binaries + docs freshness in CI via the existing `.github/workflows/docs.yml` job.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995ea5b61548333bfa15c3c395ce53b)