### PR TITLE
Strengthen legacy snapshot migration assertions

### DIFF
--- a/docs/MAINNET_MIGRATION_FROM_LEGACY.md
+++ b/docs/MAINNET_MIGRATION_FROM_LEGACY.md
@@ -101,7 +101,8 @@ Confirm:
 - dynamic set membership via public mappings
 - `agiTypes(i)` entries by index and payout
 
-Known getter limitation: `baseIpfsUrl` and `useEnsJobTokenURI` are not directly readable from public getters.
+Known getter limitation: `baseIpfsUrl` is not directly readable from a public getter.
+`useEnsJobTokenURI` / `ensJobPages` are asserted when their getters exist in the deployed bytecode.
 
 ## 7) Etherscan verification with linked libraries
 

--- a/migrations/2_deploy_agijobmanager_from_legacy_snapshot.js
+++ b/migrations/2_deploy_agijobmanager_from_legacy_snapshot.js
@@ -27,6 +27,11 @@ async function maybeSet(manager, fnName, args, from) {
   await manager[fnName](...args, { from });
 }
 
+async function maybeRead(manager, fnName) {
+  if (typeof manager[fnName] !== 'function') return null;
+  return manager[fnName]();
+}
+
 function assertNoUnresolvedLinks(artifact, name) {
   const unresolvedPattern = /__\$[a-fA-F0-9]{34}\$__/;
   const bytecode = String((artifact && (artifact.bytecode || artifact.binary)) || '');
@@ -192,7 +197,24 @@ module.exports = async function (deployer, network, accounts) {
     ['jobDurationLimit', (await manager.jobDurationLimit()).toString(), String(rc.jobDurationLimit)],
     ['completionReviewPeriod', (await manager.completionReviewPeriod()).toString(), String(rc.completionReviewPeriod)],
     ['disputeReviewPeriod', (await manager.disputeReviewPeriod()).toString(), String(rc.disputeReviewPeriod)],
+    ['validatorBondBps', (await manager.validatorBondBps()).toString(), String(rc.validatorBondBps)],
+    ['validatorBondMin', (await manager.validatorBondMin()).toString(), String(rc.validatorBondMin)],
+    ['validatorBondMax', (await manager.validatorBondMax()).toString(), String(rc.validatorBondMax)],
+    ['agentBondBps', (await manager.agentBondBps()).toString(), String(rc.agentBondBps)],
+    ['agentBondMin', (await manager.agentBondMin()).toString(), String(rc.agentBondMin)],
+    ['agentBondMax', (await manager.agentBondMax()).toString(), String(rc.agentBondMax)],
+    ['validatorSlashBps', (await manager.validatorSlashBps()).toString(), String(rc.validatorSlashBps)],
+    ['lockIdentityConfig', String(await manager.lockIdentityConfig()), String(Boolean(rc.lockIdentityConfig))],
   ];
+
+  const ensJobPages = await maybeRead(manager, 'ensJobPages');
+  if (ensJobPages !== null) {
+    checks.push(['ensJobPages', ensJobPages.toString(), mustAddress(rc.ensJobPages || ZERO_ADDRESS, 'runtimeConfig.ensJobPages')]);
+  }
+  const useEnsJobTokenURI = await maybeRead(manager, 'useEnsJobTokenURI');
+  if (useEnsJobTokenURI !== null) {
+    checks.push(['useEnsJobTokenURI', String(useEnsJobTokenURI), String(Boolean(rc.useEnsJobTokenURI))]);
+  }
 
   if (challengePeriod !== '0') {
     checks.push(['challengePeriodAfterApproval', (await manager.challengePeriodAfterApproval()).toString(), challengePeriod]);
@@ -236,5 +258,5 @@ module.exports = async function (deployer, network, accounts) {
 
   console.log(`AGIJobManager deployed at: ${manager.address}`);
   console.log('All assertions passed for mainnet legacy parity.');
-  console.log('Note: baseIpfsUrl/useEnsJobTokenURI cannot be asserted directly because they have no public getters.');
+  console.log('Note: baseIpfsUrl cannot be asserted directly because it has no public getter.');
 };


### PR DESCRIPTION
### Motivation
- Improve the safety and auditability of the hardcoded mainnet migration by asserting more of the runtime configuration restored from the legacy snapshot. 
- Avoid false-negative assertion failures when optional getters are not present in the deployed bytecode by reading them conditionally. 
- Make operator documentation reflect the precise getter/assertion behavior so reviewers know which fields can be verified on-chain.

### Description
- Added a `maybeRead` helper to `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js` to conditionally read and assert optional getters only if they exist. (file: `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Extended post-deploy assertions to include validator bond params, agent bond params, `validatorSlashBps`, and `lockIdentityConfig` to ensure full parity with the snapshot. (file: `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Added conditional assertions for `ensJobPages` and `useEnsJobTokenURI` that only run when the corresponding getter is present in the deployed contract bytecode. (file: `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Updated `docs/MAINNET_MIGRATION_FROM_LEGACY.md` to clarify that `baseIpfsUrl` lacks a direct public getter while ENS-related fields are asserted when getters exist. (file: `docs/MAINNET_MIGRATION_FROM_LEGACY.md`)

### Testing
- Performed syntax checks on modified scripts with `node -c migrations/2_deploy_agijobmanager_from_legacy_snapshot.js` and `node -c scripts/snapshotLegacyMainnetConfig.js`, which succeeded. 
- Attempted repository build via `npm run build` (Truffle compile); the compile process started but was interrupted in this environment due to long-running solc fetch/compile activity and therefore did not complete here. 
- Exercised the snapshot extractor with placeholder `ETHERSCAN_API_KEY` and `MAINNET_RPC_URL` to verify error handling; the script failed as expected with an Etherscan API key error when run with invalid/missing credentials, demonstrating correct precondition checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69964990a03083339595b1168f043e71)