### PR TITLE
Harden legacy snapshot migration safety and parity checks

### DIFF
--- a/docs/MAINNET_MIGRATION_FROM_LEGACY.md
+++ b/docs/MAINNET_MIGRATION_FROM_LEGACY.md
@@ -19,7 +19,7 @@ Required environment variables:
 Safety gates:
 
 - `CONFIRM_MAINNET_DEPLOY=1` is mandatory when `chainId == 1`.
-- Optional owner override: `NEW_OWNER=0x...` (checksummed address).
+- Optional owner override: `NEW_OWNER=0x...` (must already be EIP-55 checksummed; migration rejects non-checksummed input).
 
 ## 2) Generate deterministic snapshot (pin a block)
 


### PR DESCRIPTION
### Motivation
- Improve operator safety and deterministic parity when restoring live legacy AGIJobManager config via the committed snapshot migration. 
- Fail loudly on ambiguous or unsafe operator inputs (non-checksummed owner) and on any replay/shape mismatches (extra AGI types) to avoid silent drift.

### Description
- Added strict EIP-55 checksum enforcement for owner overrides by adding `mustChecksummedAddress` and rejecting non-checksummed `NEW_OWNER`. (updated `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Made pause/settlement replay deterministic by calling `unpauseIntake()` when snapshot says unpaused but deployed contract is paused, and always calling `setSettlementPaused(Boolean(...))` to set the exact settlement pause boolean. (updated `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Added an AGI types shape assertion that probes `agiTypes(snapshotLength)` and expects a revert to ensure no extra on-chain AGI types exist beyond the snapshot, in addition to per-index NFT/payout checks. (updated `migrations/2_deploy_agijobmanager_from_legacy_snapshot.js`)
- Documented the stricter `NEW_OWNER` requirement in `docs/MAINNET_MIGRATION_FROM_LEGACY.md`.

### Testing
- Syntax checks: ran `node --check migrations/2_deploy_agijobmanager_from_legacy_snapshot.js` and `node --check scripts/snapshotLegacyMainnetConfig.js`, both succeeded. 
- Snapshot extractor run (example): `MAINNET_RPC_URL=... ETHERSCAN_API_KEY=YourApiKeyToken node scripts/snapshotLegacyMainnetConfig.js --block 24480106` failed in this environment due to `Missing/Invalid API Key` (expected without a valid key). 
- Build: attempted `npx truffle compile --all` in this environment but the compiler fetch did not complete in the allowed window (network/tooling timing); therefore no full compile artifacts were validated here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6996627b7b0c83339beae1f5f9cf11c2)