### PR TITLE
docs: clarify Etherscan input formats and Merkle/ENS auth guidance

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,10 @@ Users should assume an operator-managed escrow model with transparent on-chain c
 5. Validators: `validateJob` / `disapproveJob` during review period.
 6. Employer: `finalizeJob(jobId)` when eligible; if contested, `disputeJob(jobId)` and moderator resolves.
 
+Notes for Etherscan forms:
+- Merkle allowlist route: usually `subdomain = ""` and `proof = ["0x...", ...]`.
+- ENS route: provide `subdomain` (label only, no dots) and usually `proof = []`.
+
 ## Glossary (Etherscan terms)
 
 - **jobId**: numeric job identifier.

--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -55,6 +55,14 @@ node scripts/etherscan/prepare_inputs.js --action convert --amount 1.5 --duratio
 | `ConfigLocked` | identity configuration already locked | cannot change ENS/Merkle identity settings |
 | Finalize opens dispute | tie/under-quorum or contested outcome at finalize time | moderator must resolve dispute |
 
+### Etherscan input formatting quick rules
+- `bytes32`: always `0x` + 64 hex chars (66 chars total).
+- `bytes32[]`: paste as JSON-like array in one line, for example:
+  - empty proof: `[]`
+  - two items: `["0x1111111111111111111111111111111111111111111111111111111111111111","0x2222222222222222222222222222222222222222222222222222222222222222"]`
+- `string` URI fields: plain text (no surrounding quotes in Etherscan inputs).
+- `uint256`: base-10 integer only (no commas, no decimals, no scientific notation).
+
 ---
 
 ## Employer flow
@@ -155,6 +163,8 @@ subdomain: alice-agent
 proof: ["0xaaa...", "0xbbb..."]
 ```
 
+Tip: If you are using Merkle auth and not ENS auth for this tx, keep `subdomain` empty and only provide `proof`.
+
 ### 3) Request completion
 Write function: `requestJobCompletion(jobId, jobCompletionURI)`
 
@@ -203,6 +213,7 @@ Proof format examples:
 Outcome notes:
 - wrong-side validators can be slashed
 - correct-side validators can receive validation rewards
+- if you are voting through Merkle allowlist (not ENS), use empty `subdomain` and paste only `proof`
 
 ---
 


### PR DESCRIPTION
### Motivation
- Reduce copy/paste and input-format errors for non-technical users interacting via Etherscan Read/Write forms. 
- Make the Merkle vs ENS authorization UX explicit so users can provide the correct `subdomain`/`proof` combination without guessing. 
- Keep changes minimal and documentation-first so on-chain behavior, selectors, and bytecode are unchanged.

### Description
- Added an "Etherscan input formatting quick rules" section to `docs/ETHERSCAN_GUIDE.md` describing exact paste formats for `bytes32`, `bytes32[]`, `string`, and `uint256` with copy/paste examples. 
- Added explicit tips in `docs/ETHERSCAN_GUIDE.md` for Agent/Validator flows that instruct Merkle-auth users to leave `subdomain` empty and paste only `proof`. 
- Added a short note to `README.md` quickstart clarifying `subdomain`/`proof` combinations for Merkle vs ENS routes. 
- No Solidity, ABI, selector, or calldata changes were made (on-chain behavior and ENS selector/calldata constraints remain intact).

### Testing
- Ran `npm test` which completed successfully (test suite: 351 passing) and includes ENS selector/calldata compatibility and bytecode-size guard checks. 
- Ran `npm run docs:check` which passed and validated docs integrity and ENS docs checks. 
- `forge test` (CI/Foundry stage) could not be executed in this environment because Foundry/`forge` is not installed; this step should be run in CI or a dev environment with Foundry to fully mirror CI.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69971c44d954833389a1a35862ad4b0e)