### PR TITLE
docs/scripts: add dispute helper and tighten Etherscan prep checklists

### DIFF
--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -379,6 +379,7 @@ node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --dur
 node scripts/etherscan/prepare_inputs.js --action apply --jobId 42 --subdomain alice-agent --proof "0xaaa...,0xbbb..."
 node scripts/etherscan/prepare_inputs.js --action request-completion --jobId 42 --jobCompletionURI ipfs://bafy.../completion.json
 node scripts/etherscan/prepare_inputs.js --action validate --jobId 42 --subdomain val-1 --proof "[]"
+node scripts/etherscan/prepare_inputs.js --action dispute --jobId 42
 node scripts/etherscan/prepare_inputs.js --action resolve-dispute --jobId 42 --code 1 --reason "EVIDENCE:v1|summary:milestones met|facts:...|links:ipfs://...|policy:ops-2.1|moderator:mod-07|ts:1736465000"
 ```
 

--- a/docs/VERIFY_ON_ETHERSCAN.md
+++ b/docs/VERIFY_ON_ETHERSCAN.md
@@ -14,6 +14,12 @@ From `truffle-config.js` deployment path:
 
 Foundry settings in `foundry.toml` are for forge tests and are not the canonical truffle deployment profile.
 
+Foundry profile details (for test parity and reproducibility):
+- compiler: `solc 0.8.19`
+- optimizer: enabled, `runs = 50`
+- EVM version: `london`
+- source dir: `contracts`, test dir: `forge-test`, libs: `lib,node_modules`
+
 ## 2) Build exactly as CI/deploy path
 
 ```bash

--- a/scripts/etherscan/prepare_inputs.js
+++ b/scripts/etherscan/prepare_inputs.js
@@ -69,6 +69,19 @@ function checklist(action) {
     '- Confirm you are using token base units and seconds',
   ];
   if (action === 'create-job') common.push('- Confirm intake is not paused');
+  if (action === 'apply') {
+    common.push('- Confirm target job is OPEN (no assigned agent, not completed/disputed/expired)');
+    common.push('- Confirm auth route now: owner allowlist OR Merkle proof OR ENS subdomain ownership');
+  }
+  if (action === 'request-completion') {
+    common.push('- Confirm caller is the assigned agent and current time is before assignedAt + duration');
+  }
+  if (action === 'validate' || action === 'disapprove') {
+    common.push('- Confirm completionRequested == true and review window is still open');
+    common.push('- Confirm validator auth route now: owner allowlist OR Merkle proof OR ENS subdomain ownership');
+  }
+  if (action === 'approve') common.push('- Confirm spender is the AGIJobManager contract address');
+  if (action === 'dispute') common.push('- Confirm dispute window is currently open for this job');
   if (action === 'finalize') common.push('- Confirm review/challenge windows are elapsed or early-approval criteria met');
   if (action === 'resolve-dispute') common.push('- Confirm disputed=true and your address is a moderator/owner');
   return common;
@@ -87,7 +100,7 @@ function run() {
 
   if (action === 'help' || args.help) {
     console.log('Usage: node scripts/etherscan/prepare_inputs.js --action <action> [options]');
-    console.log('Actions: convert, approve, create-job, apply, request-completion, validate, disapprove, resolve-dispute, finalize');
+    console.log('Actions: convert, approve, create-job, apply, request-completion, validate, disapprove, dispute, resolve-dispute, finalize');
     process.exit(0);
   }
 
@@ -155,6 +168,10 @@ function run() {
 
   if (action === 'finalize') {
     printBlock('Copy/paste into Etherscan: finalizeJob(jobId)', [`jobId: ${args.jobId || '0'}`]);
+  }
+
+  if (action === 'dispute') {
+    printBlock('Copy/paste into Etherscan: disputeJob(jobId)', [`jobId: ${args.jobId || '0'}`]);
   }
 
   printBlock(`Pre-flight checklist for action=${action}`, checklist(action));


### PR DESCRIPTION
### Motivation
- Non-technical users and low-touch operators need clear, copy/paste-friendly Etherscan inputs and action-specific pre-flight checks to avoid common mistakes. 
- Moderators/operators require a reliable offline pathway to draft dispute transactions without RPC access. 
- Verification and reproducibility guidance should explicitly document the repo's multi-toolchain profiles to reduce Etherscan verification mismatches.

### Description
- Enhanced `scripts/etherscan/prepare_inputs.js` with a new `dispute` action that prints a paste-ready `disputeJob(jobId)` block, expands action-specific pre-flight checklist items for `approve`, `apply`, `request-completion`, `validate`/`disapprove`, and `dispute`, and updated the help/action list. 
- Updated `docs/ETHERSCAN_GUIDE.md` to include the `--action dispute` example in the offline helper CLI copy/paste block so users/operators see the flow end-to-end. 
- Clarified `docs/VERIFY_ON_ETHERSCAN.md` by adding Foundry profile details (compiler/profile notes for test parity) while preserving Truffle as the canonical deployment/verification profile. 
- No Solidity or ABI changes were made and ENS selector/calldata compatibility tests remain intact.

### Testing
- `npm run lint` completed (solhint warnings present upstream but no new lint errors introduced). 
- `npm run size` completed and reported the runtime bytecode size check. 
- `node scripts/check-contract-sizes.js` completed successfully and printed contract size outputs. 
- `npx truffle test test/ensAbiCompatibility.test.js --network test` passed (7 passing), preserving the ENS selectors and exact calldata-length assertions. 
- Ran `node scripts/merkle/export_merkle_proofs.js` and `node scripts/etherscan/prepare_inputs.js --action dispute --jobId 42` and `node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json` successfully as smoke checks. 
- `timeout 180 npm test` did not complete within the environment timeout after compilation finished (partial run); `forge test` was not available in this environment (`forge: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974c15e3748333b6fe3d60da59c906)