### PR TITLE
Etherscan input prep: add auth-route guidance (merkle/ens/owner) and update docs examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ npm run size
 - Etherscan write-input preparation + unit conversion:
   ```bash
   node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 7d --jobSpecURI ipfs://bafy.../job.json --details "Translate legal packet EN->ES"
+  node scripts/etherscan/prepare_inputs.js --action apply --auth-route merkle --jobId 42 --proof "0xaaa...,0xbbb..."
   ```
 - Offline state advisor (no RPC required):
   ```bash

--- a/docs/ETHERSCAN_GUIDE.md
+++ b/docs/ETHERSCAN_GUIDE.md
@@ -376,9 +376,11 @@ node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addres
 ```bash
 node scripts/etherscan/prepare_inputs.js --action approve --spender 0xYourAGIJobManager --amount 1200
 node scripts/etherscan/prepare_inputs.js --action create-job --payout 1200 --duration 3d --jobSpecURI ipfs://bafy.../job.json --details "Translate legal packet EN->ES"
-node scripts/etherscan/prepare_inputs.js --action apply --jobId 42 --subdomain alice-agent --proof "0xaaa...,0xbbb..."
+node scripts/etherscan/prepare_inputs.js --action apply --auth-route merkle --jobId 42 --proof "0xaaa...,0xbbb..."
+node scripts/etherscan/prepare_inputs.js --action apply --auth-route ens --jobId 42 --subdomain alice-agent --proof "[]"
 node scripts/etherscan/prepare_inputs.js --action request-completion --jobId 42 --jobCompletionURI ipfs://bafy.../completion.json
-node scripts/etherscan/prepare_inputs.js --action validate --jobId 42 --subdomain val-1 --proof "[]"
+node scripts/etherscan/prepare_inputs.js --action validate --auth-route ens --jobId 42 --subdomain val-1 --proof "[]"
+node scripts/etherscan/prepare_inputs.js --action disapprove --auth-route merkle --jobId 42 --proof "0xaaa...,0xbbb..."
 node scripts/etherscan/prepare_inputs.js --action resolve-dispute --jobId 42 --code 1 --reason "EVIDENCE:v1|summary:milestones met|facts:...|links:ipfs://...|policy:ops-2.1|moderator:mod-07|ts:1736465000"
 ```
 

--- a/scripts/etherscan/prepare_inputs.js
+++ b/scripts/etherscan/prepare_inputs.js
@@ -74,6 +74,31 @@ function checklist(action) {
   return common;
 }
 
+function authChecklist(route) {
+  if (route === 'owner-allowlist') {
+    return [
+      '- Auth route: owner additional allowlist (additionalAgents/additionalValidators)',
+      '- Use your allowlisted wallet, set proof to []',
+      '- subdomain can be empty if you are not using ENS route',
+    ];
+  }
+  if (route === 'merkle') {
+    return [
+      '- Auth route: Merkle proof',
+      '- Confirm proof leaf is keccak256(abi.encodePacked(address))',
+      '- For Merkle-only auth use subdomain as empty string and paste proof bytes32[]',
+    ];
+  }
+  if (route === 'ens') {
+    return [
+      '- Auth route: ENS subdomain ownership',
+      '- subdomain must be label-only (no dots), lowercase [a-z0-9-], 1..63 chars',
+      '- If not combining with Merkle, proof should be []',
+    ];
+  }
+  return [];
+}
+
 function asProofArray(input) {
   if (!input) return '[]';
   if (input.trim().startsWith('[')) return input;
@@ -123,11 +148,16 @@ function run() {
   }
 
   if (action === 'apply') {
+    const route = args['auth-route'] || 'merkle';
     printBlock('Copy/paste into Etherscan: applyForJob(jobId, subdomain, proof)', [
       `jobId: ${args.jobId || '0'}`,
-      `subdomain: ${args.subdomain || 'alice-agent'}`,
-      `proof: ${asProofArray(args.proof)}`,
+      `subdomain: ${args.subdomain || (route === 'ens' ? 'alice-agent' : '')}`,
+      `proof: ${asProofArray(args.proof || (route === 'merkle' ? '0xaaa...,0xbbb...' : '[]'))}`,
     ]);
+    const routeChecklist = authChecklist(route);
+    if (routeChecklist.length > 0) {
+      printBlock(`Auth checklist (${route})`, routeChecklist);
+    }
   }
 
   if (action === 'request-completion') {
@@ -138,11 +168,16 @@ function run() {
   }
 
   if (action === 'validate' || action === 'disapprove') {
+    const route = args['auth-route'] || 'merkle';
     printBlock(`Copy/paste into Etherscan: ${action === 'validate' ? 'validateJob' : 'disapproveJob'}(jobId, subdomain, proof)`, [
       `jobId: ${args.jobId || '0'}`,
-      `subdomain: ${args.subdomain || 'validator-1'}`,
-      `proof: ${asProofArray(args.proof)}`,
+      `subdomain: ${args.subdomain || (route === 'ens' ? 'validator-1' : '')}`,
+      `proof: ${asProofArray(args.proof || (route === 'merkle' ? '0xaaa...,0xbbb...' : '[]'))}`,
     ]);
+    const routeChecklist = authChecklist(route);
+    if (routeChecklist.length > 0) {
+      printBlock(`Auth checklist (${route})`, routeChecklist);
+    }
   }
 
   if (action === 'resolve-dispute') {


### PR DESCRIPTION
### Motivation
- Non-technical users need unambiguous, copy/paste-ready guidance for the three auth routes (owner-allowlist, Merkle proof, ENS) when using Etherscan `Write Contract` forms. 
- The offline CLI `scripts/etherscan/prepare_inputs.js` and the docs must surface route-aware defaults so people know when to put `subdomain` vs `proof` and what formatting is required. 
- Keep changes minimal and ABI/bytecode-safe (no Solidity edits) while improving Etherscan UX and operator autonomy.

### Description
- Added `authChecklist(route)` and route-aware output to `scripts/etherscan/prepare_inputs.js` so `apply`, `validate`, and `disapprove` now print explicit defaults and a short checklist for `--auth-route` values `merkle`, `ens`, and `owner-allowlist`. 
- Updated copy/paste examples in `docs/ETHERSCAN_GUIDE.md` to show both Merkle and ENS example invocations and added a short example to `README.md` for quicker onboarding. 
- No Solidity or on-chain behavior changed; ENS selector/calldata constraints and bytecode safeguards remain untouched.

### Testing
- Ran `npm test` which completed successfully (tests passed — full suite reported 351 passing). 
- Ran `npm run docs:check` which succeeded (`node scripts/docs/check-docs.mjs` passed). 
- Exercised offline helpers: `node scripts/merkle/export_merkle_proofs.js --input scripts/merkle/sample_addresses.json --output /tmp/proofs.json`, `node scripts/etherscan/prepare_inputs.js --action apply --auth-route merkle --jobId 42 --proof "0xaaa...,0xbbb..."`, and `node scripts/advisor/state_advisor.js --input scripts/advisor/sample_job_state.json`, all of which produced expected outputs. 
- `forge test` was not run here due to environment limitation (`forge: command not found`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69974c15e3748333b6fe3d60da59c906)