### PR TITLE
docs: add Terms authority note and regenerate reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ AGIJobManager is a single Solidity contract for escrowed AGI work agreements. It
 - Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
 - Contract verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
 - FAQ: [`docs/FAQ.md`](docs/FAQ.md)
+- Terms & Conditions authority note: [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md)
 
 ## Roles (plain language)
 

--- a/docs/LEGAL/TERMS_AND_CONDITIONS.md
+++ b/docs/LEGAL/TERMS_AND_CONDITIONS.md
@@ -1,0 +1,33 @@
+# Terms & Conditions Authority Note
+
+## Authoritative source
+
+The authoritative Terms & Conditions for AGIJobManager are embedded in the smart contract source code at:
+
+- [`contracts/AGIJobManager.sol`](../../contracts/AGIJobManager.sol)
+
+Repository documentation summarizes how to locate and maintain references to these terms, but does not override the contract source text.
+
+## Canonical public terms link
+
+The contract text also references the canonical public Terms URL:
+
+- <https://agialphaagent.com/>
+
+If there is any discrepancy between human-facing documentation and the current contract source, treat the contract source as authoritative for this repository.
+
+## How updates work
+
+When Terms text changes in `contracts/AGIJobManager.sol`, update generated documentation and verify consistency:
+
+```bash
+npm run docs:gen
+npm run docs:ens:gen
+npm run docs:check
+```
+
+Commit both the human-facing documentation updates and the regenerated reference files in the same change set.
+
+## Scope and non-legal note
+
+This document is a repository maintenance and traceability guide for contributors. It is not legal advice and does not create, modify, or replace contractual obligations.

--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [TESTING.md](./TESTING.md)
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
 - [GLOSSARY.md](./GLOSSARY.md)
+- [LEGAL/TERMS_AND_CONDITIONS.md](./LEGAL/TERMS_AND_CONDITIONS.md)
 
 ## Generated references
 

--- a/docs/REFERENCE/CONTRACT_INTERFACE.md
+++ b/docs/REFERENCE/CONTRACT_INTERFACE.md
@@ -1,7 +1,7 @@
 # AGIJobManager Interface Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `3bf75085eee9`.
-- Source snapshot fingerprint: `3bf75085eee9`.
+- Generated at (deterministic source fingerprint): `468c1f0aa579`.
+- Source snapshot fingerprint: `468c1f0aa579`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Operator-facing interface

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,7 +1,7 @@
 # ENS Reference (Generated)
 
 Generated at (UTC): 1970-01-01T00:00:00Z
-Source fingerprint: 72c3b81ccb3ea16c
+Source fingerprint: 0ae25e93eb3efe5b
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -11,16 +11,16 @@ Source files used:
 
 ## ENS surface area
 
-- `bytes32 public clubRootNode;` ([contracts/AGIJobManager.sol#L136](../../contracts/AGIJobManager.sol#L136))
-- `bytes32 public alphaClubRootNode;` ([contracts/AGIJobManager.sol#L137](../../contracts/AGIJobManager.sol#L137))
-- `bytes32 public agentRootNode;` ([contracts/AGIJobManager.sol#L138](../../contracts/AGIJobManager.sol#L138))
-- `bytes32 public alphaAgentRootNode;` ([contracts/AGIJobManager.sol#L139](../../contracts/AGIJobManager.sol#L139))
-- `bytes32 public validatorMerkleRoot;` ([contracts/AGIJobManager.sol#L140](../../contracts/AGIJobManager.sol#L140))
-- `bytes32 public agentMerkleRoot;` ([contracts/AGIJobManager.sol#L141](../../contracts/AGIJobManager.sol#L141))
-- `ENS public ens;` ([contracts/AGIJobManager.sol#L142](../../contracts/AGIJobManager.sol#L142))
-- `NameWrapper public nameWrapper;` ([contracts/AGIJobManager.sol#L143](../../contracts/AGIJobManager.sol#L143))
-- `address public ensJobPages;` ([contracts/AGIJobManager.sol#L144](../../contracts/AGIJobManager.sol#L144))
-- `bool public lockIdentityConfig;` ([contracts/AGIJobManager.sol#L147](../../contracts/AGIJobManager.sol#L147))
+- `bytes32 public clubRootNode;` ([contracts/AGIJobManager.sol#L394](../../contracts/AGIJobManager.sol#L394))
+- `bytes32 public alphaClubRootNode;` ([contracts/AGIJobManager.sol#L395](../../contracts/AGIJobManager.sol#L395))
+- `bytes32 public agentRootNode;` ([contracts/AGIJobManager.sol#L396](../../contracts/AGIJobManager.sol#L396))
+- `bytes32 public alphaAgentRootNode;` ([contracts/AGIJobManager.sol#L397](../../contracts/AGIJobManager.sol#L397))
+- `bytes32 public validatorMerkleRoot;` ([contracts/AGIJobManager.sol#L398](../../contracts/AGIJobManager.sol#L398))
+- `bytes32 public agentMerkleRoot;` ([contracts/AGIJobManager.sol#L399](../../contracts/AGIJobManager.sol#L399))
+- `ENS public ens;` ([contracts/AGIJobManager.sol#L400](../../contracts/AGIJobManager.sol#L400))
+- `NameWrapper public nameWrapper;` ([contracts/AGIJobManager.sol#L401](../../contracts/AGIJobManager.sol#L401))
+- `address public ensJobPages;` ([contracts/AGIJobManager.sol#L402](../../contracts/AGIJobManager.sol#L402))
+- `bool public lockIdentityConfig;` ([contracts/AGIJobManager.sol#L405](../../contracts/AGIJobManager.sol#L405))
 - `IENSRegistry public ens;` ([contracts/ens/ENSJobPages.sol#L71](../../contracts/ens/ENSJobPages.sol#L71))
 - `INameWrapper public nameWrapper;` ([contracts/ens/ENSJobPages.sol#L72](../../contracts/ens/ENSJobPages.sol#L72))
 - `IPublicResolver public publicResolver;` ([contracts/ens/ENSJobPages.sol#L73](../../contracts/ens/ENSJobPages.sol#L73))
@@ -32,20 +32,20 @@ Source files used:
 
 ## Config and locks
 
-- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L322](../../contracts/AGIJobManager.sol#L322))
-- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L480](../../contracts/AGIJobManager.sol#L480))
-- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L512](../../contracts/AGIJobManager.sol#L512))
-- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L574](../../contracts/AGIJobManager.sol#L574))
-- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L582](../../contracts/AGIJobManager.sol#L582))
-- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L775](../../contracts/AGIJobManager.sol#L775))
-- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L782](../../contracts/AGIJobManager.sol#L782))
-- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L788](../../contracts/AGIJobManager.sol#L788))
-- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L794](../../contracts/AGIJobManager.sol#L794))
-- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L803](../../contracts/AGIJobManager.sol#L803))
-- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L816](../../contracts/AGIJobManager.sol#L816))
-- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1041](../../contracts/AGIJobManager.sol#L1041))
-- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1277](../../contracts/AGIJobManager.sol#L1277))
-- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1282](../../contracts/AGIJobManager.sol#L1282))
+- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L580](../../contracts/AGIJobManager.sol#L580))
+- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L738](../../contracts/AGIJobManager.sol#L738))
+- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L770](../../contracts/AGIJobManager.sol#L770))
+- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L832](../../contracts/AGIJobManager.sol#L832))
+- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L840](../../contracts/AGIJobManager.sol#L840))
+- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1033](../../contracts/AGIJobManager.sol#L1033))
+- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1040](../../contracts/AGIJobManager.sol#L1040))
+- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1046](../../contracts/AGIJobManager.sol#L1046))
+- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1052](../../contracts/AGIJobManager.sol#L1052))
+- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1061](../../contracts/AGIJobManager.sol#L1061))
+- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1074](../../contracts/AGIJobManager.sol#L1074))
+- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1299](../../contracts/AGIJobManager.sol#L1299))
+- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1535](../../contracts/AGIJobManager.sol#L1535))
+- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1540](../../contracts/AGIJobManager.sol#L1540))
 - `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L101](../../contracts/ens/ENSJobPages.sol#L101))
 - `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L109](../../contracts/ens/ENSJobPages.sol#L109))
 - `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L125](../../contracts/ens/ENSJobPages.sol#L125))
@@ -59,15 +59,15 @@ Source files used:
 
 ## Events and errors
 
-- `error NotAuthorized();` ([contracts/AGIJobManager.sol#L75](../../contracts/AGIJobManager.sol#L75))
-- `error InvalidParameters();` ([contracts/AGIJobManager.sol#L77](../../contracts/AGIJobManager.sol#L77))
-- `error ConfigLocked();` ([contracts/AGIJobManager.sol#L86](../../contracts/AGIJobManager.sol#L86))
-- `event EnsRegistryUpdated(address newEnsRegistry);` ([contracts/AGIJobManager.sol#L219](../../contracts/AGIJobManager.sol#L219))
-- `event RootNodesUpdated(` ([contracts/AGIJobManager.sol#L221](../../contracts/AGIJobManager.sol#L221))
-- `event MerkleRootsUpdated(bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot);` ([contracts/AGIJobManager.sol#L227](../../contracts/AGIJobManager.sol#L227))
-- `event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);` ([contracts/AGIJobManager.sol#L234](../../contracts/AGIJobManager.sol#L234))
-- `event EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages);` ([contracts/AGIJobManager.sol#L241](../../contracts/AGIJobManager.sol#L241))
-- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L256](../../contracts/AGIJobManager.sol#L256))
+- `error NotAuthorized();` ([contracts/AGIJobManager.sol#L333](../../contracts/AGIJobManager.sol#L333))
+- `error InvalidParameters();` ([contracts/AGIJobManager.sol#L335](../../contracts/AGIJobManager.sol#L335))
+- `error ConfigLocked();` ([contracts/AGIJobManager.sol#L344](../../contracts/AGIJobManager.sol#L344))
+- `event EnsRegistryUpdated(address newEnsRegistry);` ([contracts/AGIJobManager.sol#L477](../../contracts/AGIJobManager.sol#L477))
+- `event RootNodesUpdated(` ([contracts/AGIJobManager.sol#L479](../../contracts/AGIJobManager.sol#L479))
+- `event MerkleRootsUpdated(bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot);` ([contracts/AGIJobManager.sol#L485](../../contracts/AGIJobManager.sol#L485))
+- `event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);` ([contracts/AGIJobManager.sol#L492](../../contracts/AGIJobManager.sol#L492))
+- `event EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages);` ([contracts/AGIJobManager.sol#L499](../../contracts/AGIJobManager.sol#L499))
+- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L514](../../contracts/AGIJobManager.sol#L514))
 - `error ENSNotConfigured();` ([contracts/ens/ENSJobPages.sol#L34](../../contracts/ens/ENSJobPages.sol#L34))
 - `error ENSNotAuthorized();` ([contracts/ens/ENSJobPages.sol#L35](../../contracts/ens/ENSJobPages.sol#L35))
 - `error InvalidParameters();` ([contracts/ens/ENSJobPages.sol#L36](../../contracts/ens/ENSJobPages.sol#L36))
@@ -82,12 +82,12 @@ Source files used:
 
 ## Notes / caveats from code comments
 
-- @notice Total AGI locked as agent performance bonds for unsettled jobs. ([contracts/AGIJobManager.sol#L128](../../contracts/AGIJobManager.sol#L128))
-- @notice Total AGI locked as validator bonds for unsettled votes. ([contracts/AGIJobManager.sol#L130](../../contracts/AGIJobManager.sol#L130))
-- @notice Total AGI locked as dispute bonds for unsettled disputes. ([contracts/AGIJobManager.sol#L132](../../contracts/AGIJobManager.sol#L132))
-- @notice Freezes token/ENS/namewrapper/root nodes. Not a governance lock; ops remain owner-controlled. ([contracts/AGIJobManager.sol#L146](../../contracts/AGIJobManager.sol#L146))
-- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1039](../../contracts/AGIJobManager.sol#L1039))
-- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1040](../../contracts/AGIJobManager.sol#L1040))
-- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1087](../../contracts/AGIJobManager.sol#L1087))
-- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1312](../../contracts/AGIJobManager.sol#L1312))
+- @notice Total AGI locked as agent performance bonds for unsettled jobs. ([contracts/AGIJobManager.sol#L386](../../contracts/AGIJobManager.sol#L386))
+- @notice Total AGI locked as validator bonds for unsettled votes. ([contracts/AGIJobManager.sol#L388](../../contracts/AGIJobManager.sol#L388))
+- @notice Total AGI locked as dispute bonds for unsettled disputes. ([contracts/AGIJobManager.sol#L390](../../contracts/AGIJobManager.sol#L390))
+- @notice Freezes token/ENS/namewrapper/root nodes. Not a governance lock; ops remain owner-controlled. ([contracts/AGIJobManager.sol#L404](../../contracts/AGIJobManager.sol#L404))
+- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
+- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1298](../../contracts/AGIJobManager.sol#L1298))
+- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1345](../../contracts/AGIJobManager.sol#L1345))
+- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1570](../../contracts/AGIJobManager.sol#L1570))
 

--- a/docs/REFERENCE/EVENTS_AND_ERRORS.md
+++ b/docs/REFERENCE/EVENTS_AND_ERRORS.md
@@ -1,6 +1,6 @@
 # Events and Errors Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `3bf75085eee9`.
+- Generated at (deterministic source fingerprint): `468c1f0aa579`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Events catalog


### PR DESCRIPTION
### Motivation
- Ensure human-facing documentation correctly points to the authoritative Terms & Conditions embedded in the contract and to make that authoritative source discoverable and institutionally presented.
- Resolve CI failures caused by stale generated reference docs after the Terms text update inside the contract without changing the contract source.

### Description
- Added `docs/LEGAL/TERMS_AND_CONDITIONS.md` describing that the authoritative Terms & Conditions live in `contracts/AGIJobManager.sol`, including the canonical public Terms URL and a short update workflow. 
- Linked the new legal authority note from the repository `README.md` and the documentation hub `docs/README.md` for discoverability. 
- Regenerated the repository's generated reference docs to reflect the contract text and updated fingerprints, specifically `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REFERENCE/EVENTS_AND_ERRORS.md`, and `docs/REFERENCE/ENS_REFERENCE.md`. 
- Kept the change surface minimal and did not alter `contracts/AGIJobManager.sol` in any way.

### Testing
- Ran `npm ci` which completed successfully. 
- Reproduced the CI failure with `npm run docs:check`, which reported stale generated docs before regeneration. 
- Ran `npm run docs:gen` and `npm run docs:ens:gen`, which produced updated versions of `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REFERENCE/EVENTS_AND_ERRORS.md`, and `docs/REFERENCE/ENS_REFERENCE.md`. 
- Verified `npm run docs:check` and `npm run docs:ens:check` both succeeded after regeneration. 
- Validated determinism by running the generators twice (`npm run docs:gen && npm run docs:ens:gen` twice) and confirming the second run produced no diffs (stable output). 
- Confirmed the contract source `contracts/AGIJobManager.sol` remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997ed2e1c248333a19d50260f91af60)