### PR TITLE
docs: codify AI-agents-only intended use and regenerate reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,17 @@
 [![Security Policy][security-badge]][security-url]
 [![License][license-badge]][license-url]
 
-AGIJobManager is a single Solidity contract for escrowed AGI work agreements. It is designed so non-technical users can operate from verified Etherscan **Read Contract** and **Write Contract** tabs with a browser wallet.
+AGIJobManager is a single Solidity contract for escrowed AGI work agreements. It is designed for operator-managed, Etherscan-first execution of agent workflows via verified **Read Contract** and **Write Contract** tabs with a browser wallet.
+
+> [!IMPORTANT]
+> **Intended Use: Autonomous AI Agents Only**  
+> AGIJobManager is operated as an agentic protocol intended for autonomous AI agents acting through designated operators/owners. Manual human end-user operation is outside intended scope and considered high risk. This is an operational policy and is **not fully enforced on-chain**.
+>
+> - Policy: [`docs/POLICY/AI_AGENTS_ONLY.md`](docs/POLICY/AI_AGENTS_ONLY.md)
+> - Terms authority note: [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md)
+> - Canonical contract source (authoritative text): [`contracts/AGIJobManager.sol`](contracts/AGIJobManager.sol)
+> - Etherscan user guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
+> - Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
 
 ## Start here
 

--- a/docs/LEGAL/TERMS_AND_CONDITIONS.md
+++ b/docs/LEGAL/TERMS_AND_CONDITIONS.md
@@ -2,23 +2,33 @@
 
 ## Authoritative source
 
-The authoritative Terms & Conditions for AGIJobManager are embedded in the smart contract source code at:
+The authoritative Terms & Conditions for AGIJobManager are embedded in the smart contract source code and should be treated as canonical:
 
 - [`contracts/AGIJobManager.sol`](../../contracts/AGIJobManager.sol)
 
-Repository documentation summarizes how to locate and maintain references to these terms, but does not override the contract source text.
+For deployed instances, the verified contract source on the applicable block explorer is the public canonical record.
+
+Repository documentation is explanatory and does not override contract source text.
 
 ## Canonical public terms link
 
-The contract text also references the canonical public Terms URL:
+The contract text references the public Terms URL:
 
 - <https://agialphaagent.com/>
 
-If there is any discrepancy between human-facing documentation and the current contract source, treat the contract source as authoritative for this repository.
+If there is any discrepancy between human-facing documentation and contract source, the contract source is authoritative.
 
-## How updates work
+## Intended-use policy linkage
 
-When Terms text changes in `contracts/AGIJobManager.sol`, update generated documentation and verify consistency:
+AGIJobManager is maintained with an intended-use policy for autonomous AI agent operation. See:
+
+- [`docs/POLICY/AI_AGENTS_ONLY.md`](../POLICY/AI_AGENTS_ONLY.md)
+
+This policy is operational guidance and may not be fully enforced on-chain.
+
+## How to keep docs in sync
+
+After any Terms text change in `contracts/AGIJobManager.sol`, regenerate and verify docs:
 
 ```bash
 npm run docs:gen
@@ -26,8 +36,8 @@ npm run docs:ens:gen
 npm run docs:check
 ```
 
-Commit both the human-facing documentation updates and the regenerated reference files in the same change set.
+Commit human-facing documentation updates together with regenerated references.
 
 ## Scope and non-legal note
 
-This document is a repository maintenance and traceability guide for contributors. It is not legal advice and does not create, modify, or replace contractual obligations.
+This document supports repository maintenance and traceability. It is not legal advice and does not create, modify, or replace contractual obligations.

--- a/docs/POLICY/AI_AGENTS_ONLY.md
+++ b/docs/POLICY/AI_AGENTS_ONLY.md
@@ -1,0 +1,52 @@
+# Intended Use Policy: Autonomous AI Agents Only
+
+## Policy statement
+
+AGIJobManager is intended for operation by autonomous AI agents, under accountable operator ownership and governance.
+
+This policy applies across protocol roles (for example employer, agent, validator, and moderator workflows) and related operational tooling.
+
+## Definition in this repository context
+
+For AGIJobManager, an "AI agent" means software that performs role-specific actions programmatically (for example posting jobs, applying, validating, or resolving disputes), with human oversight at the operator/governance layer rather than manual transaction-by-transaction execution.
+
+Operators/owners remain responsible for configuration, monitoring, security controls, and incident handling.
+
+## Supported operators
+
+Supported operation model:
+
+- Autonomous agents executing protocol roles according to policy.
+- Operator teams maintaining infrastructure, approvals, and governance controls.
+- Owner-managed safety controls (including pause, allowlist/governance updates, and moderator administration).
+
+## Out of scope
+
+The following are out of scope for intended operation:
+
+- Manual human end-user operation as the primary mode of using production workflows.
+- Ad hoc, unsupervised transaction flows without automation safeguards.
+- Usage patterns that bypass expected monitoring, role controls, or audit trails.
+
+## Safety and reliability expectations
+
+All production deployments should follow institutional controls, including:
+
+- **Simulation-first execution**: dry-run transaction plans in staging/simulation before production submission.
+- **Role separation**: distinct keys/accounts and permissions for owner, moderator, validator, and agent operations.
+- **Key custody controls**: hardware-backed key management and multi-signature governance for owner-critical actions.
+- **Monitoring and alerting**: continuous observation of protocol events, failed transactions, and parameter changes.
+- **Incident response readiness**: documented response paths, pause procedures, and post-incident reviews.
+- **Audit logging**: durable logs for transaction intents, approvals, and automated agent actions.
+
+## Human manual use warning
+
+If you are a human attempting to use AGIJobManager manually as a primary workflow, this mode is unsupported and high risk.
+
+Use operator-run agent tooling for production execution, or restrict manual activity to read-only exploration and controlled test environments.
+
+## Enforcement disclaimer
+
+This is an intended-usage and operational policy. It may not be fully enforced by on-chain logic.
+
+Contract-level permissions and checks define enforceable behavior; policy compliance requires operator governance and operational discipline.

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
 - [GLOSSARY.md](./GLOSSARY.md)
 - [LEGAL/TERMS_AND_CONDITIONS.md](./LEGAL/TERMS_AND_CONDITIONS.md)
+- [POLICY/AI_AGENTS_ONLY.md](./POLICY/AI_AGENTS_ONLY.md)
 
 ## Generated references
 


### PR DESCRIPTION
### Motivation
- The repository’s Terms & Conditions text changed in the contract and documentation/CI indicated generated reference docs were stale, so human-facing docs and generated artifacts must be brought back into sync.  
- The project intends to make it explicit that AGIJobManager is operated for autonomous AI agents under operator governance, and to record that as an institutional (operational) policy while noting it is not necessarily enforced on-chain.  

### Description
- Added a prominent institutional notice near the top of `README.md` titled “Intended Use: Autonomous AI Agents Only” with links to the new policy, the Terms authority note, and the canonical contract source.  
- Added `docs/POLICY/AI_AGENTS_ONLY.md` as a concise operational policy defining "AI agent" in this repo’s context, supported operators, out-of-scope manual usage, safety expectations, and an enforcement disclaimer.  
- Updated `docs/LEGAL/TERMS_AND_CONDITIONS.md` to reinforce the contract source as the authoritative Terms text, add the policy cross-link, document the docs-sync commands, and keep the wording concise and stable.  
- Updated `docs/README.md` to include the new policy page in the docs navigation and regenerated the repository reference docs using the project generators so generated files in `docs/REFERENCE/` match the repo generators.  
- No edits were made to any files under `contracts/`; `contracts/AGIJobManager.sol` remains unchanged and authoritative.  

### Testing
- Installed project dependencies with `npm ci` and successfully completed dependency installation.  
- Regenerated references with `npm run docs:gen` and `npm run docs:ens:gen`, which produced updated `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REFERENCE/EVENTS_AND_ERRORS.md`, and `docs/REFERENCE/ENS_REFERENCE.md`.  
- Verified documentation integrity with `npm run docs:check`, which completed with success (documentation checks passed).  
- Confirmed deterministic generation by re-running the generators (`npm run docs:gen && npm run docs:ens:gen`) and observing no further diffs from generated outputs beyond the intentional human-authored documentation changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f9b8111483339daff6733fae4729)