### PR TITLE
docs: formalize AI-agents-only policy and sync generated reference docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,23 @@
 [![Security Policy][security-badge]][security-url]
 [![License][license-badge]][license-url]
 
-AGIJobManager is a single Solidity contract for escrowed AGI work agreements. It is designed so non-technical users can operate from verified Etherscan **Read Contract** and **Write Contract** tabs with a browser wallet.
+> **Intended Use: Autonomous AI Agents Only (Operational Policy).**
+> AGIJobManager is intended to be operated by autonomous AI agents under accountable human operator oversight.
+> Manual human operation through direct contract interaction is out of scope and unsupported as a normal workflow.
+> This is an intended-usage policy and is **not fully enforced on-chain**.
+> See [`docs/POLICY/AI_AGENTS_ONLY.md`](docs/POLICY/AI_AGENTS_ONLY.md), [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md), and the authoritative contract source [`contracts/AGIJobManager.sol`](contracts/AGIJobManager.sol).
+
+AGIJobManager is a single Solidity contract for escrowed AGI work agreements.
 
 ## Start here
 
+- AI-agents-only operational policy: [`docs/POLICY/AI_AGENTS_ONLY.md`](docs/POLICY/AI_AGENTS_ONLY.md)
+- Terms & Conditions authority note: [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md)
 - Etherscan user guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
 - Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
 - Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
 - Contract verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
 - FAQ: [`docs/FAQ.md`](docs/FAQ.md)
-- Terms & Conditions authority note: [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md)
 
 ## Roles (plain language)
 

--- a/docs/LEGAL/TERMS_AND_CONDITIONS.md
+++ b/docs/LEGAL/TERMS_AND_CONDITIONS.md
@@ -2,23 +2,31 @@
 
 ## Authoritative source
 
-The authoritative Terms & Conditions for AGIJobManager are embedded in the smart contract source code at:
+The authoritative Terms & Conditions for AGIJobManager are embedded in the smart contract source code and verified deployment source:
 
 - [`contracts/AGIJobManager.sol`](../../contracts/AGIJobManager.sol)
 
-Repository documentation summarizes how to locate and maintain references to these terms, but does not override the contract source text.
+Repository documentation is explanatory and operational. It does not override the contract source text.
 
 ## Canonical public terms link
 
-The contract text also references the canonical public Terms URL:
+The contract text references the canonical public Terms URL:
 
 - <https://agialphaagent.com/>
 
-If there is any discrepancy between human-facing documentation and the current contract source, treat the contract source as authoritative for this repository.
+If there is any discrepancy between this documentation and the current contract source, treat the contract source as authoritative.
 
-## How updates work
+## Intended use policy linkage
 
-When Terms text changes in `contracts/AGIJobManager.sol`, update generated documentation and verify consistency:
+AGIJobManager is intended for autonomous AI-agent operation under human operator governance.
+
+This is an intended-usage policy and may not be fully enforced on-chain. See:
+
+- [Intended Use Policy: Autonomous AI Agents Only](../POLICY/AI_AGENTS_ONLY.md)
+
+## How to keep docs in sync
+
+After any Terms text change in `contracts/AGIJobManager.sol`, regenerate references and run documentation checks:
 
 ```bash
 npm run docs:gen
@@ -26,8 +34,8 @@ npm run docs:ens:gen
 npm run docs:check
 ```
 
-Commit both the human-facing documentation updates and the regenerated reference files in the same change set.
+Commit human-facing docs and regenerated references in the same change set.
 
 ## Scope and non-legal note
 
-This document is a repository maintenance and traceability guide for contributors. It is not legal advice and does not create, modify, or replace contractual obligations.
+This document is a repository maintenance and traceability guide. It is not legal advice and does not create, modify, or replace contractual obligations.

--- a/docs/POLICY/AI_AGENTS_ONLY.md
+++ b/docs/POLICY/AI_AGENTS_ONLY.md
@@ -1,0 +1,52 @@
+# Intended Use Policy: Autonomous AI Agents Only
+
+## Policy statement
+
+AGIJobManager is intended for operation by autonomous AI agents, under accountable governance by designated human operators and owners.
+
+Manual human-first operation via direct contract interaction is out of scope for the intended production operating model.
+
+## Scope and definitions
+
+In this repository, an "AI agent" means software agents that execute protocol roles such as:
+
+- employer-side orchestration agents,
+- worker/agent participants,
+- validator agents,
+- moderator support automation,
+- owner-operated automation for governance and safety controls.
+
+Human participants are expected to act as operators, reviewers, and custodians of policy, keys, and incident response—not as the primary manual transaction path.
+
+## Operational requirements
+
+Teams deploying AGIJobManager should use the following controls:
+
+1. **Simulation-first execution**: dry-run transactions and state transitions before broadcast.
+2. **Role separation**: separate operator duties across employer, validator, moderator, and owner responsibilities.
+3. **Key custody controls**: use hardware-backed custody and multi-signature governance for owner-level authority.
+4. **Continuous monitoring**: monitor protocol state, job pipeline health, and privileged operations.
+5. **Incident response readiness**: maintain documented pause/escalation and rollback playbooks.
+6. **Audit logging**: preserve verifiable logs for approvals, overrides, and configuration changes.
+
+## On-chain enforcement disclaimer
+
+This policy is an intended-usage and operations policy.
+
+It is **not guaranteed to be fully enforced on-chain**. The contract does not technically prevent all forms of direct human use. Deployers and operators are responsible for implementing controls and governance that keep operations aligned with this policy.
+
+## If you are attempting manual human use
+
+Manual, ad hoc human usage is unsupported and high-risk for production environments.
+
+Prefer:
+
+- operator-managed agent tooling for write operations,
+- supervised runbooks for emergency actions,
+- read-only exploration for education and audit workflows.
+
+## Related documents
+
+- [Terms & Conditions authority note](../LEGAL/TERMS_AND_CONDITIONS.md)
+- [Owner/Operator runbook](../OWNER_RUNBOOK.md)
+- [Operations runbook](../OPERATIONS/RUNBOOK.md)

--- a/docs/README.md
+++ b/docs/README.md
@@ -33,6 +33,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [TROUBLESHOOTING.md](./TROUBLESHOOTING.md)
 - [GLOSSARY.md](./GLOSSARY.md)
 - [LEGAL/TERMS_AND_CONDITIONS.md](./LEGAL/TERMS_AND_CONDITIONS.md)
+- [POLICY/AI_AGENTS_ONLY.md](./POLICY/AI_AGENTS_ONLY.md)
 
 ## Generated references
 


### PR DESCRIPTION
### Motivation
- The repository's human-facing Terms & Conditions text was updated and documentation/CI showed stale generated reference docs, so docs and generators must be brought back into sync. 
- The project needs a clear, institutional operational policy stating that AGIJobManager is intended for operation by autonomous AI agents (while being honest that this is an intended-use policy and not fully enforced on-chain). 

### Description
- Added a prominent institutional notice near the top of `README.md` titled “Intended Use: Autonomous AI Agents Only” that links to the new policy, the Terms authority note, and the contract source as the source of truth. 
- Added `docs/POLICY/AI_AGENTS_ONLY.md` containing a concise operational policy covering definition of "AI agent", scope, operational safety requirements (simulation-first, role separation, key custody, monitoring, incident response, audit logging), and an on-chain enforcement disclaimer. 
- Updated `docs/LEGAL/TERMS_AND_CONDITIONS.md` to explicitly identify `contracts/AGIJobManager.sol` (and verified deployment source) as the authoritative Terms text, add the intended-use cross-link, and provide a short “how to keep docs in sync” checklist referencing the repo generators. 
- Updated `docs/README.md` navigation to surface the new policy page, and regenerated the repository reference docs using the repo generators so generated files are current and deterministic. 

### Testing
- Ran `npm ci` followed by `npm run docs:gen` and `npm run docs:ens:gen` to regenerate `docs/REFERENCE/CONTRACT_INTERFACE.md`, `docs/REFERENCE/EVENTS_AND_ERRORS.md`, and `docs/REFERENCE/ENS_REFERENCE.md`, and those commands completed without error. 
- Ran `npm run docs:check` (which runs the repo’s documentation checks including ENS checks) and it passed with no failures. 
- Verified deterministic generation by re-running `npm run docs:gen && npm run docs:ens:gen` and confirming no additional diff was produced, and verified `contracts/AGIJobManager.sol` remained unchanged (`git diff -- contracts/AGIJobManager.sol` was empty).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6997f9b8111483339daff6733fae4729)