### PR TITLE
Fail fast on ensJobPages and AGI type EOA misconfiguration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -141,3 +141,7 @@ dist
 # Vite logs files
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Deployment runtime artifacts
+deployments/
+migrations/config/agijobmanager.config.js

--- a/docs/DEPLOYMENT/TRUFFLE_PRODUCTION_DEPLOY.md
+++ b/docs/DEPLOYMENT/TRUFFLE_PRODUCTION_DEPLOY.md
@@ -1,0 +1,46 @@
+# AGIJobManager Truffle Production Deployment
+
+## Prerequisites
+- `npm ci`
+- RPC + signer env vars configured for `truffle-config.js` (`PRIVATE_KEYS`, `MAINNET_RPC_URL`/`SEPOLIA_RPC_URL` or Alchemy/Infura keys).
+- Etherscan API key if you will verify immediately.
+
+## 1) Configure deployment inputs (single file)
+```bash
+cp migrations/config/agijobmanager.config.example.js migrations/config/agijobmanager.config.js
+```
+Edit `migrations/config/agijobmanager.config.js` and verify every placeholder value before mainnet.
+
+Optional: use a different path via `AGIJOBMANAGER_CONFIG_PATH=/abs/or/relative/path.js`.
+
+## 2) Dry-run (validation + summary only)
+```bash
+AGIJOBMANAGER_DEPLOY=1 DEPLOY_DRY_RUN=1 npx truffle migrate --network sepolia --f 4 --to 4
+```
+
+## 3) Test deploy on local/sepolia
+```bash
+AGIJOBMANAGER_DEPLOY=1 npx truffle migrate --network development --f 4 --to 4
+AGIJOBMANAGER_DEPLOY=1 npx truffle migrate --network sepolia --f 4 --to 4
+```
+
+## 4) Mainnet deploy (guarded)
+Mainnet requires **both** env vars:
+- `AGIJOBMANAGER_DEPLOY=1`
+- `DEPLOY_CONFIRM_MAINNET=I_UNDERSTAND_THIS_WILL_DEPLOY_TO_ETHEREUM_MAINNET`
+
+```bash
+AGIJOBMANAGER_DEPLOY=1 DEPLOY_CONFIRM_MAINNET=I_UNDERSTAND_THIS_WILL_DEPLOY_TO_ETHEREUM_MAINNET npx truffle migrate --network mainnet --f 4 --to 4
+```
+
+## 5) Receipt output
+A receipt is written to:
+- `deployments/<network>/AGIJobManager.<chainId>.<blockNumber>.json`
+
+## 6) Post-deploy checklist
+- Confirm `owner()` equals intended final owner.
+- Confirm root nodes and merkle roots match deployment config.
+- Confirm pausable flags (`paused()`, `settlementPaused()`) are expected.
+- Confirm key params (`voteQuorum`, reward %, bond params, durations).
+- Verify contract/libraries on Etherscan.
+- Record receipt file in release artifacts.

--- a/migrations/4_deploy_agijobmanager_production_mainnet.js
+++ b/migrations/4_deploy_agijobmanager_production_mainnet.js
@@ -1,0 +1,387 @@
+const fs = require('fs');
+const path = require('path');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const UriUtils = artifacts.require('UriUtils');
+const TransferUtils = artifacts.require('TransferUtils');
+const BondMath = artifacts.require('BondMath');
+const ReputationMath = artifacts.require('ReputationMath');
+const ENSOwnership = artifacts.require('ENSOwnership');
+
+const { loadConfig } = require('./lib/loadConfig');
+const { validateProductionConfig } = require('./lib/validateProductionConfig');
+const { pretty, formatEthWei, redactAddress } = require('./lib/format');
+
+const MAINNET_CONFIRMATION_VALUE = 'I_UNDERSTAND_THIS_WILL_DEPLOY_TO_ETHEREUM_MAINNET';
+const DEFAULT_ONCHAIN = {
+  requiredValidatorApprovals: '3',
+  requiredValidatorDisapprovals: '3',
+  voteQuorum: '3',
+  validationRewardPercentage: '8',
+  premiumReputationThreshold: '10000',
+  maxJobPayout: '88888888000000000000000000',
+  jobDurationLimit: '10000000',
+  completionReviewPeriod: String(7 * 24 * 60 * 60),
+  disputeReviewPeriod: String(14 * 24 * 60 * 60),
+  challengePeriodAfterApproval: String(24 * 60 * 60),
+  validatorBondBps: '1500',
+  validatorBondMin: '10000000000000000000',
+  validatorBondMax: '88888888000000000000000000',
+  validatorSlashBps: '8000',
+  agentBondBps: '500',
+  agentBondMin: '1000000000000000000',
+  agentBondMax: '88888888000000000000000000',
+  agentBond: '1000000000000000000',
+};
+
+function ensureEnabled() {
+  if (process.env.AGIJOBMANAGER_DEPLOY !== '1') {
+    console.log('Skipping AGIJobManager production migration (disabled). Set AGIJOBMANAGER_DEPLOY=1 to enable.');
+    return false;
+  }
+  return true;
+}
+
+function toStringOrNull(value) {
+  return value === null || value === undefined ? null : String(value);
+}
+
+async function deployLibrary(deployer, library, networkId) {
+  await deployer.deploy(library);
+  const instance = await library.deployed();
+  return {
+    address: instance.address,
+    txHash: library.networks?.[String(networkId)]?.transactionHash || instance.transactionHash || null,
+  };
+}
+
+async function ownerTx(manager, from, receipt, label, fn) {
+  const tx = await fn();
+  receipt.actions.push({ label, txHash: tx.tx, blockNumber: tx.receipt?.blockNumber || null });
+  console.log(`  ✓ ${label} :: ${tx.tx}`);
+}
+
+function resolveExpectedParameters(protocolParameters) {
+  const expected = { ...DEFAULT_ONCHAIN };
+  for (const [key, value] of Object.entries(protocolParameters)) {
+    if (value !== null && value !== undefined && key !== 'agentBondMinOverride') {
+      expected[key] = String(value);
+    }
+  }
+  if (protocolParameters.agentBondMin !== null && protocolParameters.agentBondMin !== undefined) {
+    expected.agentBond = String(protocolParameters.agentBondMin);
+  }
+  if (protocolParameters.agentBondMinOverride !== null && protocolParameters.agentBondMinOverride !== undefined) {
+    expected.agentBond = String(protocolParameters.agentBondMinOverride);
+  }
+  return expected;
+}
+
+function assertEq(label, actual, expected) {
+  if (String(actual).toLowerCase() !== String(expected).toLowerCase()) {
+    throw new Error(`Verification failed for ${label}. expected=${expected}, actual=${actual}`);
+  }
+}
+
+
+function isValidThresholdPair(approvals, disapprovals) {
+  const a = Number(approvals);
+  const d = Number(disapprovals);
+  return Number.isInteger(a) && Number.isInteger(d) && a >= 0 && d >= 0 && a <= 50 && d <= 50 && (a + d <= 50);
+}
+
+async function applyValidatorThresholdUpdates(manager, deployerAddress, receipt, protocolParameters) {
+  const hasApprovals = protocolParameters.requiredValidatorApprovals !== null && protocolParameters.requiredValidatorApprovals !== undefined;
+  const hasDisapprovals = protocolParameters.requiredValidatorDisapprovals !== null && protocolParameters.requiredValidatorDisapprovals !== undefined;
+  if (!hasApprovals && !hasDisapprovals) return;
+
+  const currentApprovals = Number((await manager.requiredValidatorApprovals()).toString());
+  const currentDisapprovals = Number((await manager.requiredValidatorDisapprovals()).toString());
+  const targetApprovals = hasApprovals ? Number(protocolParameters.requiredValidatorApprovals) : currentApprovals;
+  const targetDisapprovals = hasDisapprovals ? Number(protocolParameters.requiredValidatorDisapprovals) : currentDisapprovals;
+
+  if (!isValidThresholdPair(targetApprovals, targetDisapprovals)) {
+    throw new Error(`Invalid final validator threshold pair: approvals=${targetApprovals}, disapprovals=${targetDisapprovals}`);
+  }
+
+  if (hasApprovals && hasDisapprovals && targetApprovals !== currentApprovals && targetDisapprovals !== currentDisapprovals) {
+    const canApprovalsFirst = isValidThresholdPair(targetApprovals, currentDisapprovals) && isValidThresholdPair(targetApprovals, targetDisapprovals);
+    const canDisapprovalsFirst = isValidThresholdPair(currentApprovals, targetDisapprovals) && isValidThresholdPair(targetApprovals, targetDisapprovals);
+
+    if (canApprovalsFirst) {
+      await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorApprovals', () => manager.setRequiredValidatorApprovals(targetApprovals, { from: deployerAddress }));
+      await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorDisapprovals', () => manager.setRequiredValidatorDisapprovals(targetDisapprovals, { from: deployerAddress }));
+      return;
+    }
+    if (canDisapprovalsFirst) {
+      await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorDisapprovals', () => manager.setRequiredValidatorDisapprovals(targetDisapprovals, { from: deployerAddress }));
+      await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorApprovals', () => manager.setRequiredValidatorApprovals(targetApprovals, { from: deployerAddress }));
+      return;
+    }
+
+    throw new Error(
+      `Cannot apply validator thresholds from (${currentApprovals}, ${currentDisapprovals}) to (${targetApprovals}, ${targetDisapprovals}) without intermediate invalid pair.`
+    );
+  }
+
+  if (hasApprovals && targetApprovals !== currentApprovals) {
+    await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorApprovals', () => manager.setRequiredValidatorApprovals(targetApprovals, { from: deployerAddress }));
+  }
+  if (hasDisapprovals && targetDisapprovals !== currentDisapprovals) {
+    await ownerTx(manager, deployerAddress, receipt, 'setRequiredValidatorDisapprovals', () => manager.setRequiredValidatorDisapprovals(targetDisapprovals, { from: deployerAddress }));
+  }
+}
+module.exports = async function (deployer, network, accounts) {
+  if (!ensureEnabled()) return;
+
+  const chainId = await web3.eth.getChainId();
+  if (Number(chainId) === 1 && process.env.DEPLOY_CONFIRM_MAINNET !== MAINNET_CONFIRMATION_VALUE) {
+    throw new Error(
+      `Mainnet deployment blocked. Set DEPLOY_CONFIRM_MAINNET=${MAINNET_CONFIRMATION_VALUE} and re-run.`
+    );
+  }
+
+  const deployerAddress = accounts[0];
+  const deployerBalance = await web3.eth.getBalance(deployerAddress);
+  const dryRun = process.env.DEPLOY_DRY_RUN === '1';
+
+  const loaded = loadConfig({ network, chainId, web3 });
+  const { config, constructorArgs } = loaded;
+  const validation = await validateProductionConfig({ config, constructorArgs, chainId, web3 });
+
+  const summary = {
+    network,
+    chainId,
+    dryRun,
+    deployer: redactAddress(deployerAddress),
+    deployerBalanceEth: formatEthWei(deployerBalance, web3),
+    configPath: loaded.configPath,
+    constructorArgs,
+    protocolParameters: config.protocolParameters,
+    dynamicLists: {
+      moderators: config.dynamicLists.moderators.length,
+      additionalAgents: config.dynamicLists.additionalAgents.length,
+      additionalValidators: config.dynamicLists.additionalValidators.length,
+      blacklistedAgents: config.dynamicLists.blacklistedAgents.length,
+      blacklistedValidators: config.dynamicLists.blacklistedValidators.length,
+    },
+    agiTypes: config.agiTypes.length,
+    warnings: validation.warnings,
+  };
+
+  console.log('================ AGIJobManager Production Deployment Summary ================');
+  console.log(pretty(summary));
+  console.log('==============================================================================');
+
+  if (dryRun) {
+    console.log('DEPLOY_DRY_RUN=1 detected: config validated, deployment skipped.');
+    return;
+  }
+
+  const receipt = {
+    timestamp: new Date().toISOString(),
+    network,
+    chainId,
+    deployerAddress,
+    configPath: loaded.configPath,
+    resolvedConfig: config,
+    constructorArgs,
+    warnings: validation.warnings,
+    libraries: {},
+    manager: null,
+    actions: [],
+    verification: {
+      checks: [],
+      notes: [
+        'baseIpfsUrl and useEnsJobTokenURI are private/non-readable and cannot be asserted on-chain via public getter.',
+      ],
+    },
+  };
+
+  console.log('Deploying libraries...');
+  receipt.libraries.BondMath = await deployLibrary(deployer, BondMath, deployer.network_id);
+  receipt.libraries.ENSOwnership = await deployLibrary(deployer, ENSOwnership, deployer.network_id);
+  receipt.libraries.ReputationMath = await deployLibrary(deployer, ReputationMath, deployer.network_id);
+  receipt.libraries.TransferUtils = await deployLibrary(deployer, TransferUtils, deployer.network_id);
+  receipt.libraries.UriUtils = await deployLibrary(deployer, UriUtils, deployer.network_id);
+
+  await deployer.link(BondMath, AGIJobManager);
+  await deployer.link(ENSOwnership, AGIJobManager);
+  await deployer.link(ReputationMath, AGIJobManager);
+  await deployer.link(TransferUtils, AGIJobManager);
+  await deployer.link(UriUtils, AGIJobManager);
+
+  console.log('Deploying AGIJobManager...');
+  await deployer.deploy(
+    AGIJobManager,
+    constructorArgs.agiTokenAddress,
+    constructorArgs.baseIpfsUrl,
+    constructorArgs.ensConfig,
+    constructorArgs.rootNodes,
+    constructorArgs.merkleRoots
+  );
+
+  const manager = await AGIJobManager.deployed();
+  receipt.manager = {
+    address: manager.address,
+    txHash: AGIJobManager.networks?.[String(deployer.network_id)]?.transactionHash || manager.transactionHash || null,
+  };
+
+  const p = config.protocolParameters;
+  const i = config.identity;
+  const f = config.operationalFlags;
+
+  if (p.validationRewardPercentage !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setValidationRewardPercentage', () => manager.setValidationRewardPercentage(p.validationRewardPercentage, { from: deployerAddress }));
+  }
+  await applyValidatorThresholdUpdates(manager, deployerAddress, receipt, p);
+  if (p.voteQuorum !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setVoteQuorum', () => manager.setVoteQuorum(p.voteQuorum, { from: deployerAddress }));
+  }
+  if (p.premiumReputationThreshold !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setPremiumReputationThreshold', () => manager.setPremiumReputationThreshold(p.premiumReputationThreshold, { from: deployerAddress }));
+  }
+  if (p.maxJobPayout !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setMaxJobPayout', () => manager.setMaxJobPayout(p.maxJobPayout, { from: deployerAddress }));
+  }
+  if (p.jobDurationLimit !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setJobDurationLimit', () => manager.setJobDurationLimit(p.jobDurationLimit, { from: deployerAddress }));
+  }
+  if (p.completionReviewPeriod !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setCompletionReviewPeriod', () => manager.setCompletionReviewPeriod(p.completionReviewPeriod, { from: deployerAddress }));
+  }
+  if (p.disputeReviewPeriod !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setDisputeReviewPeriod', () => manager.setDisputeReviewPeriod(p.disputeReviewPeriod, { from: deployerAddress }));
+  }
+  if (p.challengePeriodAfterApproval !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setChallengePeriodAfterApproval', () => manager.setChallengePeriodAfterApproval(p.challengePeriodAfterApproval, { from: deployerAddress }));
+  }
+  if (p.validatorBondBps !== null || p.validatorBondMin !== null || p.validatorBondMax !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setValidatorBondParams', () => manager.setValidatorBondParams(
+      toStringOrNull(p.validatorBondBps) || DEFAULT_ONCHAIN.validatorBondBps,
+      toStringOrNull(p.validatorBondMin) || DEFAULT_ONCHAIN.validatorBondMin,
+      toStringOrNull(p.validatorBondMax) || DEFAULT_ONCHAIN.validatorBondMax,
+      { from: deployerAddress }
+    ));
+  }
+  if (p.validatorSlashBps !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setValidatorSlashBps', () => manager.setValidatorSlashBps(p.validatorSlashBps, { from: deployerAddress }));
+  }
+  if (p.agentBondBps !== null || p.agentBondMin !== null || p.agentBondMax !== null) {
+    await ownerTx(manager, deployerAddress, receipt, 'setAgentBondParams', () => manager.setAgentBondParams(
+      toStringOrNull(p.agentBondBps) || DEFAULT_ONCHAIN.agentBondBps,
+      toStringOrNull(p.agentBondMin) || DEFAULT_ONCHAIN.agentBondMin,
+      toStringOrNull(p.agentBondMax) || DEFAULT_ONCHAIN.agentBondMax,
+      { from: deployerAddress }
+    ));
+  }
+  if (p.agentBondMinOverride !== null && p.agentBondMinOverride !== undefined) {
+    await ownerTx(manager, deployerAddress, receipt, 'setAgentBond', () => manager.setAgentBond(p.agentBondMinOverride, { from: deployerAddress }));
+  }
+  if (i.baseIpfsUrl) {
+    await ownerTx(manager, deployerAddress, receipt, 'setBaseIpfsUrl', () => manager.setBaseIpfsUrl(i.baseIpfsUrl, { from: deployerAddress }));
+  }
+  if (i.ensJobPages) {
+    await ownerTx(manager, deployerAddress, receipt, 'setEnsJobPages', () => manager.setEnsJobPages(i.ensJobPages, { from: deployerAddress }));
+  }
+  if (i.useEnsJobTokenURI !== null && i.useEnsJobTokenURI !== undefined) {
+    await ownerTx(manager, deployerAddress, receipt, 'setUseEnsJobTokenURI', () => manager.setUseEnsJobTokenURI(i.useEnsJobTokenURI, { from: deployerAddress }));
+  }
+
+  for (const moderator of config.dynamicLists.moderators) {
+    await ownerTx(manager, deployerAddress, receipt, `addModerator(${moderator})`, () => manager.addModerator(moderator, { from: deployerAddress }));
+  }
+  for (const agent of config.dynamicLists.additionalAgents) {
+    await ownerTx(manager, deployerAddress, receipt, `addAdditionalAgent(${agent})`, () => manager.addAdditionalAgent(agent, { from: deployerAddress }));
+  }
+  for (const validator of config.dynamicLists.additionalValidators) {
+    await ownerTx(manager, deployerAddress, receipt, `addAdditionalValidator(${validator})`, () => manager.addAdditionalValidator(validator, { from: deployerAddress }));
+  }
+  for (const blacklistedAgent of config.dynamicLists.blacklistedAgents) {
+    await ownerTx(manager, deployerAddress, receipt, `blacklistAgent(${blacklistedAgent})`, () => manager.blacklistAgent(blacklistedAgent, true, { from: deployerAddress }));
+  }
+  for (const blacklistedValidator of config.dynamicLists.blacklistedValidators) {
+    await ownerTx(manager, deployerAddress, receipt, `blacklistValidator(${blacklistedValidator})`, () => manager.blacklistValidator(blacklistedValidator, true, { from: deployerAddress }));
+  }
+
+  for (let idx = 0; idx < config.agiTypes.length; idx += 1) {
+    const agiType = config.agiTypes[idx];
+    await ownerTx(manager, deployerAddress, receipt, `addAGIType[${idx}](${agiType.nftAddress})`, () =>
+      manager.addAGIType(agiType.nftAddress, agiType.payoutPercentage, { from: deployerAddress }));
+  }
+
+  if (f.settlementPaused !== null && f.settlementPaused !== undefined) {
+    await ownerTx(manager, deployerAddress, receipt, `setSettlementPaused(${f.settlementPaused})`, () => manager.setSettlementPaused(f.settlementPaused, { from: deployerAddress }));
+  }
+  if (f.paused !== null && f.paused !== undefined) {
+    const currentlyPaused = await manager.paused();
+    if (f.paused && !currentlyPaused) {
+      await ownerTx(manager, deployerAddress, receipt, 'pause', () => manager.pause({ from: deployerAddress }));
+    }
+    if (!f.paused && currentlyPaused) {
+      await ownerTx(manager, deployerAddress, receipt, 'unpause', () => manager.unpause({ from: deployerAddress }));
+    }
+  }
+
+  if (i.lockIdentityConfiguration) {
+    await ownerTx(manager, deployerAddress, receipt, 'lockIdentityConfiguration', () => manager.lockIdentityConfiguration({ from: deployerAddress }));
+  }
+  if (config.ownership.finalOwner) {
+    await ownerTx(manager, deployerAddress, receipt, `transferOwnership(${config.ownership.finalOwner})`, () => manager.transferOwnership(config.ownership.finalOwner, { from: deployerAddress }));
+  }
+
+  const expected = resolveExpectedParameters(config.protocolParameters);
+
+  const checks = [
+    ['agiToken', (await manager.agiToken()).toString(), config.identity.agiTokenAddress],
+    ['ens', (await manager.ens()).toString(), config.identity.ensRegistry],
+    ['nameWrapper', (await manager.nameWrapper()).toString(), config.identity.nameWrapper],
+    ['ensJobPages', (await manager.ensJobPages()).toString(), config.identity.ensJobPages || '0x0000000000000000000000000000000000000000'],
+    ['clubRootNode', await manager.clubRootNode(), constructorArgs.resolvedRootNodes.clubRootNode],
+    ['agentRootNode', await manager.agentRootNode(), constructorArgs.resolvedRootNodes.agentRootNode],
+    ['alphaClubRootNode', await manager.alphaClubRootNode(), constructorArgs.resolvedRootNodes.alphaClubRootNode],
+    ['alphaAgentRootNode', await manager.alphaAgentRootNode(), constructorArgs.resolvedRootNodes.alphaAgentRootNode],
+    ['validatorMerkleRoot', await manager.validatorMerkleRoot(), config.merkleRoots.validatorMerkleRoot],
+    ['agentMerkleRoot', await manager.agentMerkleRoot(), config.merkleRoots.agentMerkleRoot],
+    ['requiredValidatorApprovals', (await manager.requiredValidatorApprovals()).toString(), expected.requiredValidatorApprovals],
+    ['requiredValidatorDisapprovals', (await manager.requiredValidatorDisapprovals()).toString(), expected.requiredValidatorDisapprovals],
+    ['voteQuorum', (await manager.voteQuorum()).toString(), expected.voteQuorum],
+    ['validationRewardPercentage', (await manager.validationRewardPercentage()).toString(), expected.validationRewardPercentage],
+    ['premiumReputationThreshold', (await manager.premiumReputationThreshold()).toString(), expected.premiumReputationThreshold],
+    ['maxJobPayout', (await manager.maxJobPayout()).toString(), expected.maxJobPayout],
+    ['jobDurationLimit', (await manager.jobDurationLimit()).toString(), expected.jobDurationLimit],
+    ['completionReviewPeriod', (await manager.completionReviewPeriod()).toString(), expected.completionReviewPeriod],
+    ['disputeReviewPeriod', (await manager.disputeReviewPeriod()).toString(), expected.disputeReviewPeriod],
+    ['challengePeriodAfterApproval', (await manager.challengePeriodAfterApproval()).toString(), expected.challengePeriodAfterApproval],
+    ['validatorBondBps', (await manager.validatorBondBps()).toString(), expected.validatorBondBps],
+    ['validatorBondMin', (await manager.validatorBondMin()).toString(), expected.validatorBondMin],
+    ['validatorBondMax', (await manager.validatorBondMax()).toString(), expected.validatorBondMax],
+    ['validatorSlashBps', (await manager.validatorSlashBps()).toString(), expected.validatorSlashBps],
+    ['agentBondBps', (await manager.agentBondBps()).toString(), expected.agentBondBps],
+    ['agentBond', (await manager.agentBond()).toString(), expected.agentBond],
+    ['agentBondMax', (await manager.agentBondMax()).toString(), expected.agentBondMax],
+    ['settlementPaused', String(await manager.settlementPaused()), String(config.operationalFlags.settlementPaused ?? false)],
+    ['paused', String(await manager.paused()), String(config.operationalFlags.paused ?? false)],
+  ];
+
+  for (const [label, actual, expectedValue] of checks) {
+    assertEq(label, actual, expectedValue);
+    receipt.verification.checks.push({ label, actual: String(actual), expected: String(expectedValue), ok: true });
+  }
+
+  if (i.lockIdentityConfiguration) {
+    const lockState = await manager.lockIdentityConfig();
+    assertEq('lockIdentityConfig', String(lockState), 'true');
+    receipt.verification.checks.push({ label: 'lockIdentityConfig', actual: 'true', expected: 'true', ok: true });
+  }
+
+  const blockNumber = Number(receipt.actions[receipt.actions.length - 1]?.blockNumber || (await web3.eth.getBlockNumber()));
+  const deploymentDir = path.resolve(process.cwd(), 'deployments', network);
+  fs.mkdirSync(deploymentDir, { recursive: true });
+  const receiptPath = path.join(deploymentDir, `AGIJobManager.${chainId}.${blockNumber}.json`);
+  fs.writeFileSync(receiptPath, `${JSON.stringify(receipt, null, 2)}\n`, 'utf8');
+
+  console.log('Deployment completed successfully.');
+  console.log(`AGIJobManager: ${receipt.manager.address}`);
+  console.log(`Receipt: ${receiptPath}`);
+};

--- a/migrations/config/agijobmanager.config.example.js
+++ b/migrations/config/agijobmanager.config.example.js
@@ -1,0 +1,80 @@
+/**
+ * AGIJobManager production deployment config.
+ *
+ * VERIFY BEFORE MAINNET: placeholder defaults are convenience values only.
+ */
+module.exports = {
+  defaults: {
+    identity: {
+      // VERIFY BEFORE MAINNET
+      agiTokenAddress: '0xA61a3B3a130a9c20768EEBF97E21515A6046a1Fa',
+      baseIpfsUrl: 'https://ipfs.io/ipfs/',
+      ensRegistry: '0x00000000000C2E074eC69A0dFb2997BA6C7d2e1e',
+      nameWrapper: '0xD4416b13d2b3a9aBae7AcD5D6C2BbDBE25686401',
+      ensJobPages: null,
+      useEnsJobTokenURI: false,
+      lockIdentityConfiguration: false,
+    },
+    authorizationRoots: {
+      roots: {
+        clubName: 'club.agi.eth',
+        agentName: 'agent.agi.eth',
+        alphaClubName: 'alpha.club.agi.eth',
+        alphaAgentName: 'alpha.agent.agi.eth',
+      },
+      rootNodes: null,
+    },
+    merkleRoots: {
+      // VERIFY BEFORE MAINNET
+      validatorMerkleRoot: '0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b',
+      agentMerkleRoot: '0x0effa6c54d4c4866ca6e9f4fc7426ba49e70e8f6303952e04c8f0218da68b99b',
+    },
+    protocolParameters: {
+      requiredValidatorApprovals: null,
+      requiredValidatorDisapprovals: null,
+      voteQuorum: null,
+      validationRewardPercentage: null,
+      premiumReputationThreshold: null,
+      maxJobPayout: null,
+      jobDurationLimit: null,
+      completionReviewPeriod: null,
+      disputeReviewPeriod: null,
+      challengePeriodAfterApproval: null,
+      validatorBondBps: null,
+      validatorBondMin: null,
+      validatorBondMax: null,
+      validatorSlashBps: null,
+      agentBondBps: null,
+      agentBondMin: null,
+      agentBondMax: null,
+      agentBondMinOverride: null,
+    },
+    dynamicLists: {
+      moderators: [],
+      additionalAgents: [],
+      additionalValidators: [],
+      blacklistedAgents: [],
+      blacklistedValidators: [],
+    },
+    agiTypes: [
+      {
+        // VERIFY BEFORE MAINNET (example only)
+        nftAddress: '0x130909390ac76c53986957814bde8786b8605ff3',
+        payoutPercentage: 80,
+      },
+    ],
+    operationalFlags: {
+      paused: null,
+      settlementPaused: null,
+    },
+    ownership: {
+      finalOwner: null,
+      requireFinalOwnerOnMainnet: true,
+    },
+  },
+  networks: {
+    mainnet: {},
+    sepolia: {},
+    development: {},
+  },
+};

--- a/migrations/lib/durations.js
+++ b/migrations/lib/durations.js
@@ -1,0 +1,24 @@
+const UNIT_TO_SECONDS = {
+  s: 1,
+  m: 60,
+  h: 3600,
+  d: 86400,
+  w: 604800,
+};
+
+function parseDurationSeconds(value, label = 'duration') {
+  if (value === null || value === undefined || value === '') return null;
+  if (typeof value === 'number') {
+    if (!Number.isInteger(value) || value < 0) throw new Error(`${label} must be a non-negative integer.`);
+    return value;
+  }
+  const raw = String(value).trim().toLowerCase();
+  if (/^\d+$/.test(raw)) return Number(raw);
+  const match = raw.match(/^(\d+)\s*([smhdw])$/);
+  if (!match) throw new Error(`${label} must be seconds or use suffix s/m/h/d/w (received: ${value}).`);
+  return Number(match[1]) * UNIT_TO_SECONDS[match[2]];
+}
+
+module.exports = {
+  parseDurationSeconds,
+};

--- a/migrations/lib/format.js
+++ b/migrations/lib/format.js
@@ -1,0 +1,22 @@
+function pretty(value) {
+  return JSON.stringify(value, null, 2);
+}
+
+function redactAddress(address) {
+  if (!address || typeof address !== 'string' || !address.startsWith('0x') || address.length < 10) return address;
+  return `${address.slice(0, 6)}…${address.slice(-4)}`;
+}
+
+function formatEthWei(wei, web3) {
+  try {
+    return web3.utils.fromWei(String(wei), 'ether');
+  } catch (_) {
+    return String(wei);
+  }
+}
+
+module.exports = {
+  pretty,
+  redactAddress,
+  formatEthWei,
+};

--- a/migrations/lib/loadConfig.js
+++ b/migrations/lib/loadConfig.js
@@ -1,0 +1,150 @@
+const fs = require('fs');
+const path = require('path');
+const { parseDurationSeconds } = require('./durations');
+const { namehash } = require('./namehash');
+
+const DEFAULT_CONFIG_PATH = path.resolve(__dirname, '..', 'config', 'agijobmanager.config.js');
+
+function deepClone(v) {
+  return JSON.parse(JSON.stringify(v));
+}
+
+function isObject(v) {
+  return !!v && typeof v === 'object' && !Array.isArray(v);
+}
+
+function deepMerge(base, patch) {
+  if (!isObject(base) || !isObject(patch)) return patch;
+  const out = { ...base };
+  for (const [key, value] of Object.entries(patch)) {
+    out[key] = isObject(value) && isObject(base[key]) ? deepMerge(base[key], value) : value;
+  }
+  return out;
+}
+
+function loadModuleFromFile(filePath) {
+  const resolved = path.isAbsolute(filePath) ? filePath : path.resolve(process.cwd(), filePath);
+  // eslint-disable-next-line import/no-dynamic-require, global-require
+  return { path: resolved, module: require(resolved) };
+}
+
+function resolveConfigPath() {
+  if (process.env.AGIJOBMANAGER_CONFIG_PATH) {
+    return path.isAbsolute(process.env.AGIJOBMANAGER_CONFIG_PATH)
+      ? process.env.AGIJOBMANAGER_CONFIG_PATH
+      : path.resolve(process.cwd(), process.env.AGIJOBMANAGER_CONFIG_PATH);
+  }
+  if (fs.existsSync(DEFAULT_CONFIG_PATH)) {
+    return DEFAULT_CONFIG_PATH;
+  }
+  throw new Error(
+    'Missing deployment config. Copy migrations/config/agijobmanager.config.example.js to migrations/config/agijobmanager.config.js or set AGIJOBMANAGER_CONFIG_PATH.'
+  );
+}
+
+function parseBoolean(v) {
+  if (v === undefined || v === null || v === '') return null;
+  const normalized = String(v).trim().toLowerCase();
+  if (['1', 'true', 'yes', 'y'].includes(normalized)) return true;
+  if (['0', 'false', 'no', 'n'].includes(normalized)) return false;
+  throw new Error(`Invalid boolean value: ${v}`);
+}
+
+function getNetworkOverride(configModule, network, chainId) {
+  const networks = isObject(configModule.networks) ? configModule.networks : {};
+  return networks[network] || networks[String(chainId)] || {};
+}
+
+function applyEnvOverrides(config) {
+  const out = deepClone(config);
+  const setIf = (pathParts, value) => {
+    if (value === undefined || value === null || value === '') return;
+    let target = out;
+    for (let i = 0; i < pathParts.length - 1; i += 1) {
+      target = target[pathParts[i]];
+    }
+    target[pathParts[pathParts.length - 1]] = value;
+  };
+
+  setIf(['identity', 'agiTokenAddress'], process.env.AGIJOBMANAGER_AGI_TOKEN_ADDRESS);
+  setIf(['identity', 'baseIpfsUrl'], process.env.AGIJOBMANAGER_BASE_IPFS_URL);
+  setIf(['identity', 'ensRegistry'], process.env.AGIJOBMANAGER_ENS_REGISTRY);
+  setIf(['identity', 'nameWrapper'], process.env.AGIJOBMANAGER_NAME_WRAPPER);
+  setIf(['identity', 'ensJobPages'], process.env.AGIJOBMANAGER_ENS_JOB_PAGES);
+  setIf(['merkleRoots', 'validatorMerkleRoot'], process.env.AGIJOBMANAGER_VALIDATOR_MERKLE_ROOT);
+  setIf(['merkleRoots', 'agentMerkleRoot'], process.env.AGIJOBMANAGER_AGENT_MERKLE_ROOT);
+  setIf(['ownership', 'finalOwner'], process.env.AGIJOBMANAGER_FINAL_OWNER);
+
+  const paused = parseBoolean(process.env.AGIJOBMANAGER_PAUSED);
+  if (paused !== null) out.operationalFlags.paused = paused;
+  const settlementPaused = parseBoolean(process.env.AGIJOBMANAGER_SETTLEMENT_PAUSED);
+  if (settlementPaused !== null) out.operationalFlags.settlementPaused = settlementPaused;
+
+  return out;
+}
+
+function resolveRootNodes(authRoots, web3) {
+  if (authRoots.rootNodes) {
+    return authRoots.rootNodes;
+  }
+  const roots = authRoots.roots || {};
+  return {
+    clubRootNode: namehash(roots.clubName || roots.club || '', web3),
+    agentRootNode: namehash(roots.agentName || roots.agent || '', web3),
+    alphaClubRootNode: namehash(roots.alphaClubName || roots.alphaClub || '', web3),
+    alphaAgentRootNode: namehash(roots.alphaAgentName || roots.alphaAgent || '', web3),
+  };
+}
+
+function normalizeDurations(parameters) {
+  return {
+    ...parameters,
+    jobDurationLimit: parameters.jobDurationLimit === null || parameters.jobDurationLimit === undefined
+      ? null
+      : parseDurationSeconds(parameters.jobDurationLimit, 'protocolParameters.jobDurationLimit'),
+    completionReviewPeriod: parameters.completionReviewPeriod === null || parameters.completionReviewPeriod === undefined
+      ? null
+      : parseDurationSeconds(parameters.completionReviewPeriod, 'protocolParameters.completionReviewPeriod'),
+    disputeReviewPeriod: parameters.disputeReviewPeriod === null || parameters.disputeReviewPeriod === undefined
+      ? null
+      : parseDurationSeconds(parameters.disputeReviewPeriod, 'protocolParameters.disputeReviewPeriod'),
+    challengePeriodAfterApproval: parameters.challengePeriodAfterApproval === null || parameters.challengePeriodAfterApproval === undefined
+      ? null
+      : parseDurationSeconds(parameters.challengePeriodAfterApproval, 'protocolParameters.challengePeriodAfterApproval'),
+  };
+}
+
+function loadConfig({ network, chainId, web3 }) {
+  const configPath = resolveConfigPath();
+  const loaded = loadModuleFromFile(configPath);
+  const defaults = loaded.module.defaults || {};
+  const networkOverride = getNetworkOverride(loaded.module, network, chainId);
+  const merged = deepMerge(defaults, networkOverride);
+  const config = applyEnvOverrides(merged);
+
+  config.protocolParameters = normalizeDurations(config.protocolParameters || {});
+  config.authorizationRoots = config.authorizationRoots || {};
+
+  const rootNodes = resolveRootNodes(config.authorizationRoots, web3);
+  return {
+    configPath: loaded.path,
+    config,
+    constructorArgs: {
+      agiTokenAddress: config.identity.agiTokenAddress,
+      baseIpfsUrl: config.identity.baseIpfsUrl,
+      ensConfig: [config.identity.ensRegistry, config.identity.nameWrapper],
+      rootNodes: [
+        rootNodes.clubRootNode,
+        rootNodes.agentRootNode,
+        rootNodes.alphaClubRootNode,
+        rootNodes.alphaAgentRootNode,
+      ],
+      merkleRoots: [config.merkleRoots.validatorMerkleRoot, config.merkleRoots.agentMerkleRoot],
+      resolvedRootNodes: rootNodes,
+    },
+  };
+}
+
+module.exports = {
+  loadConfig,
+};

--- a/migrations/lib/namehash.js
+++ b/migrations/lib/namehash.js
@@ -1,0 +1,21 @@
+const ZERO_BYTES32 = `0x${'00'.repeat(32)}`;
+
+function namehash(name, web3) {
+  const labels = String(name || '')
+    .trim()
+    .toLowerCase()
+    .split('.')
+    .filter(Boolean);
+
+  let node = ZERO_BYTES32;
+  for (let i = labels.length - 1; i >= 0; i -= 1) {
+    const labelHash = web3.utils.keccak256(labels[i]);
+    node = web3.utils.soliditySha3({ type: 'bytes32', value: node }, { type: 'bytes32', value: labelHash });
+  }
+  return node;
+}
+
+module.exports = {
+  ZERO_BYTES32,
+  namehash,
+};

--- a/migrations/lib/validateProductionConfig.js
+++ b/migrations/lib/validateProductionConfig.js
@@ -1,0 +1,166 @@
+const { ZERO_BYTES32 } = require('./namehash');
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000';
+const MAX_PERIOD_SECONDS = 365 * 24 * 60 * 60;
+
+function assert(condition, message) {
+  if (!condition) throw new Error(message);
+}
+
+function isBytes32(value) {
+  return /^0x[a-fA-F0-9]{64}$/.test(String(value || ''));
+}
+
+function asBigInt(value, label) {
+  const raw = String(value);
+  assert(/^\d+$/.test(raw), `${label} must be a non-negative integer string.`);
+  return BigInt(raw);
+}
+
+function normalizeAddress(value, label, web3, { allowZero = false } = {}) {
+  assert(typeof value === 'string', `${label} must be a string.`);
+  const candidate = String(value).trim();
+  const canonicalCandidate = web3.utils.isAddress(candidate) ? candidate : candidate.toLowerCase();
+  assert(web3.utils.isAddress(canonicalCandidate), `${label} is not a valid address: ${value}`);
+  const checksum = web3.utils.toChecksumAddress(canonicalCandidate);
+  assert(allowZero || checksum.toLowerCase() !== ZERO_ADDRESS.toLowerCase(), `${label} cannot be the zero address.`);
+  return checksum;
+}
+
+
+async function assertAddressHasCode(web3, label, address) {
+  const code = await web3.eth.getCode(address);
+  assert(code && code !== '0x', `${label} must point to deployed contract bytecode: ${address}`);
+}
+
+async function validateProductionConfig({ config, constructorArgs, chainId, web3 }) {
+  const warnings = [];
+  const identity = config.identity || {};
+  const protocolParameters = config.protocolParameters || {};
+  const dynamicLists = config.dynamicLists || {};
+
+  identity.agiTokenAddress = normalizeAddress(identity.agiTokenAddress, 'identity.agiTokenAddress', web3);
+  identity.ensRegistry = normalizeAddress(identity.ensRegistry, 'identity.ensRegistry', web3, { allowZero: true });
+  identity.nameWrapper = normalizeAddress(identity.nameWrapper, 'identity.nameWrapper', web3, { allowZero: true });
+  if (identity.ensJobPages) {
+    identity.ensJobPages = normalizeAddress(identity.ensJobPages, 'identity.ensJobPages', web3, { allowZero: true });
+  }
+  assert(typeof identity.baseIpfsUrl === 'string', 'identity.baseIpfsUrl must be a string.');
+  assert(Buffer.byteLength(identity.baseIpfsUrl, 'utf8') <= 512, 'identity.baseIpfsUrl must be <= 512 bytes.');
+
+  await assertAddressHasCode(web3, 'identity.agiTokenAddress', identity.agiTokenAddress);
+  if (identity.ensRegistry.toLowerCase() !== ZERO_ADDRESS.toLowerCase()) {
+    await assertAddressHasCode(web3, 'identity.ensRegistry', identity.ensRegistry);
+  }
+  if (identity.nameWrapper.toLowerCase() !== ZERO_ADDRESS.toLowerCase()) {
+    await assertAddressHasCode(web3, 'identity.nameWrapper', identity.nameWrapper);
+  }
+  if (identity.ensJobPages && identity.ensJobPages.toLowerCase() !== ZERO_ADDRESS.toLowerCase()) {
+    await assertAddressHasCode(web3, 'identity.ensJobPages', identity.ensJobPages);
+  }
+
+  Object.entries(constructorArgs.resolvedRootNodes).forEach(([key, value]) => {
+    assert(isBytes32(value), `authorizationRoots.${key} must resolve to bytes32.`);
+  });
+
+  assert(isBytes32(config.merkleRoots.validatorMerkleRoot), 'merkleRoots.validatorMerkleRoot must be bytes32.');
+  assert(isBytes32(config.merkleRoots.agentMerkleRoot), 'merkleRoots.agentMerkleRoot must be bytes32.');
+
+  const approvals = protocolParameters.requiredValidatorApprovals;
+  const disapprovals = protocolParameters.requiredValidatorDisapprovals;
+  if (approvals !== null && approvals !== undefined) {
+    const n = Number(approvals);
+    assert(Number.isInteger(n) && n >= 0 && n <= 50, 'protocolParameters.requiredValidatorApprovals must be 0..50.');
+  }
+  if (disapprovals !== null && disapprovals !== undefined) {
+    const n = Number(disapprovals);
+    assert(Number.isInteger(n) && n >= 0 && n <= 50, 'protocolParameters.requiredValidatorDisapprovals must be 0..50.');
+  }
+  const effectiveApprovals = Number(approvals ?? 3);
+  const effectiveDisapprovals = Number(disapprovals ?? 3);
+  assert(effectiveApprovals + effectiveDisapprovals <= 50, 'effective approvals + disapprovals must be <= 50.');
+
+  if (protocolParameters.voteQuorum !== null && protocolParameters.voteQuorum !== undefined) {
+    const quorum = Number(protocolParameters.voteQuorum);
+    assert(Number.isInteger(quorum) && quorum >= 1 && quorum <= 50, 'protocolParameters.voteQuorum must be 1..50.');
+  }
+
+  if (protocolParameters.jobDurationLimit !== null && protocolParameters.jobDurationLimit !== undefined) {
+    const limit = Number(protocolParameters.jobDurationLimit);
+    assert(Number.isInteger(limit) && limit > 0, 'protocolParameters.jobDurationLimit must be > 0.');
+  }
+
+  ['completionReviewPeriod', 'disputeReviewPeriod', 'challengePeriodAfterApproval'].forEach((key) => {
+    const v = protocolParameters[key];
+    if (v === null || v === undefined) return;
+    const n = Number(v);
+    assert(Number.isInteger(n) && n > 0 && n <= MAX_PERIOD_SECONDS, `protocolParameters.${key} must be 1..31536000 seconds.`);
+  });
+
+  ['validatorBondBps', 'validatorSlashBps', 'agentBondBps'].forEach((key) => {
+    const v = protocolParameters[key];
+    if (v === null || v === undefined) return;
+    const n = Number(v);
+    assert(Number.isInteger(n) && n >= 0 && n <= 10000, `protocolParameters.${key} must be 0..10000.`);
+  });
+
+  const vBps = asBigInt(protocolParameters.validatorBondBps ?? '1500', 'protocolParameters.validatorBondBps');
+  const vMin = asBigInt(protocolParameters.validatorBondMin ?? '10000000000000000000', 'protocolParameters.validatorBondMin');
+  const vMax = asBigInt(protocolParameters.validatorBondMax ?? '88888888000000000000000000', 'protocolParameters.validatorBondMax');
+  assert(vMin <= vMax, 'protocolParameters.validatorBondMin must be <= validatorBondMax.');
+  if (vBps === 0n && vMin === 0n) assert(vMax === 0n, 'validator bond disabled mode must be (0,0,0).');
+  if (!(vBps === 0n && vMin === 0n)) assert(vMax !== 0n && !(vBps > 0n && vMin === 0n), 'invalid validator bond parameters.');
+
+  const aBps = asBigInt(protocolParameters.agentBondBps ?? '500', 'protocolParameters.agentBondBps');
+  const aMin = asBigInt(protocolParameters.agentBondMin ?? '1000000000000000000', 'protocolParameters.agentBondMin');
+  const aMax = asBigInt(protocolParameters.agentBondMax ?? '88888888000000000000000000', 'protocolParameters.agentBondMax');
+  assert(aMin <= aMax, 'protocolParameters.agentBondMin must be <= agentBondMax.');
+  if (!(aBps === 0n && aMin === 0n && aMax === 0n)) assert(aMax !== 0n, 'protocolParameters.agentBondMax must be non-zero when agent bond enabled.');
+
+  if (protocolParameters.agentBondMinOverride !== null && protocolParameters.agentBondMinOverride !== undefined) {
+    const over = asBigInt(protocolParameters.agentBondMinOverride, 'protocolParameters.agentBondMinOverride');
+    if (aMax === 0n) assert(over === 0n, 'protocolParameters.agentBondMinOverride must be 0 when agent bonds disabled.');
+    else assert(over <= aMax, 'protocolParameters.agentBondMinOverride must be <= agentBondMax.');
+  }
+
+  const valPct = Number(protocolParameters.validationRewardPercentage ?? 8);
+  assert(Number.isInteger(valPct) && valPct >= 1 && valPct <= 100, 'protocolParameters.validationRewardPercentage must be 1..100.');
+  const maxPayoutPct = 100 - valPct;
+  assert(Array.isArray(config.agiTypes), 'agiTypes must be an array.');
+  for (let i = 0; i < config.agiTypes.length; i += 1) {
+    const agiType = config.agiTypes[i];
+    agiType.nftAddress = normalizeAddress(agiType.nftAddress, `agiTypes[${i}].nftAddress`, web3);
+    const pct = Number(agiType.payoutPercentage);
+    assert(Number.isInteger(pct) && pct >= 1 && pct <= 100, `agiTypes[${i}].payoutPercentage must be 1..100.`);
+    assert(pct <= maxPayoutPct, `agiTypes[${i}].payoutPercentage must be <= ${maxPayoutPct}.`);
+    await assertAddressHasCode(web3, `agiTypes[${i}].nftAddress`, agiType.nftAddress);
+  }
+
+  const validateAddressArray = (label, values) => {
+    assert(Array.isArray(values), `${label} must be an array.`);
+    return values.map((value) => normalizeAddress(value, label, web3));
+  };
+
+  dynamicLists.moderators = validateAddressArray('dynamicLists.moderators[]', dynamicLists.moderators || []);
+  dynamicLists.additionalAgents = validateAddressArray('dynamicLists.additionalAgents[]', dynamicLists.additionalAgents || []);
+  dynamicLists.additionalValidators = validateAddressArray('dynamicLists.additionalValidators[]', dynamicLists.additionalValidators || []);
+  dynamicLists.blacklistedAgents = validateAddressArray('dynamicLists.blacklistedAgents[]', dynamicLists.blacklistedAgents || []);
+  dynamicLists.blacklistedValidators = validateAddressArray('dynamicLists.blacklistedValidators[]', dynamicLists.blacklistedValidators || []);
+
+  if (Number(chainId) === 1 && config.ownership.requireFinalOwnerOnMainnet) {
+    assert(config.ownership.finalOwner, 'ownership.finalOwner is required on mainnet when requireFinalOwnerOnMainnet=true.');
+  }
+  if (config.ownership.finalOwner) {
+    config.ownership.finalOwner = normalizeAddress(config.ownership.finalOwner, 'ownership.finalOwner', web3);
+  }
+
+  if (Object.values(constructorArgs.resolvedRootNodes).some((v) => String(v).toLowerCase() !== ZERO_BYTES32.toLowerCase())) {
+    assert(identity.ensRegistry.toLowerCase() !== ZERO_ADDRESS.toLowerCase(), 'identity.ensRegistry must be non-zero when root nodes are configured.');
+  }
+
+  return { warnings };
+}
+
+module.exports = {
+  validateProductionConfig,
+};


### PR DESCRIPTION
### Motivation
- Prevent deployments from progressing when addresses that must be contracts are misconfigured as EOAs, which currently causes on-chain reverts during `setEnsJobPages` and `addAGIType` after gas has already been spent. 
- Align validation behavior with migration operations by making contract-bytecode checks authoritative instead of warning-only for fields that are later used in on-chain calls. 

### Description
- Enforce bytecode presence for `identity.ensJobPages` when configured and non-zero by calling `assertAddressHasCode` instead of emitting a warning. 
- Enforce bytecode presence for every `agiTypes[i].nftAddress` by calling `assertAddressHasCode` in the AGI types validation loop. 
- Add new production deployment helpers and scaffolding: `migrations/4_deploy_agijobmanager_production_mainnet.js`, `migrations/lib/{durations,format,loadConfig,namehash}.js`, and a `migrations/config/agijobmanager.config.example.js` example. 
- Update `.gitignore` to exclude deployment runtime artifacts and add a Truffle production deployment doc at `docs/DEPLOYMENT/TRUFFLE_PRODUCTION_DEPLOY.md`.

### Testing
- Ran a syntax check with `node -c migrations/lib/validateProductionConfig.js`, which succeeded. 
- Compiled contracts with `npx truffle compile`, which completed successfully. 
- Performed static verification using `rg` to confirm `assertAddressHasCode` is used for `identity.ensJobPages` and `agiTypes[].nftAddress` and the updated file is staged for the change; the checks matched as expected.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998c7f9ca28833392984bbb18e50023)