### PR TITLE
Allow owner to update Merkle roots during escrow and after identity lock

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1074,9 +1074,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)
         external
         onlyOwner
-        whenIdentityConfigurable
     {
-        _requireEmptyEscrow();
         validatorMerkleRoot = _validatorMerkleRoot;
         agentMerkleRoot = _agentMerkleRoot;
         emit MerkleRootsUpdated(_validatorMerkleRoot, _agentMerkleRoot);

--- a/test/merkleRoots.operational.test.js
+++ b/test/merkleRoots.operational.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { expectCustomError } = require('./helpers/errors');
+
+const ZERO_ROOT = '0x' + '00'.repeat(32);
+
+contract('merkleRoots.operational', (accounts) => {
+  const [owner, employer] = accounts;
+  const payout = web3.utils.toWei('1');
+
+  let manager;
+  let token;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        'ipfs://base',
+        ens.address,
+        nameWrapper.address,
+        rootNode('club'),
+        rootNode('agent'),
+        rootNode('club'),
+        rootNode('agent'),
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner },
+    );
+
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+  });
+
+  it('updates merkle roots even while escrow is active', async () => {
+    await manager.createJob('ipfs-job', payout, 3600, 'details', { from: employer });
+
+    const newValidatorRoot = web3.utils.soliditySha3('validator-root-v2');
+    const newAgentRoot = web3.utils.soliditySha3('agent-root-v2');
+    const receipt = await manager.updateMerkleRoots(newValidatorRoot, newAgentRoot, { from: owner });
+
+    assert.equal(receipt.logs[0].event, 'MerkleRootsUpdated');
+    assert.equal(receipt.logs[0].args.validatorMerkleRoot, newValidatorRoot);
+    assert.equal(receipt.logs[0].args.agentMerkleRoot, newAgentRoot);
+    assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
+    assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+  });
+
+  it('updates merkle roots after identity lock while other locked config remains blocked', async () => {
+    await manager.lockIdentityConfiguration({ from: owner });
+
+    const newValidatorRoot = web3.utils.soliditySha3('validator-root-v3');
+    const newAgentRoot = web3.utils.soliditySha3('agent-root-v3');
+    await manager.updateMerkleRoots(newValidatorRoot, newAgentRoot, { from: owner });
+
+    assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
+    assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+
+    await expectCustomError(
+      manager.updateRootNodes.call(rootNode('club2'), rootNode('agent2'), rootNode('club3'), rootNode('agent3'), { from: owner }),
+      'ConfigLocked',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Enable operational updates to the validator and agent Merkle allowlists by the contract owner at any time (including while jobs/escrows are active and after `lockIdentityConfiguration()`), so new Validators/Agents can be added without disrupting live activity.

### Description
- Surgically removed the `whenIdentityConfigurable` modifier and the `_requireEmptyEscrow()` call from `updateMerkleRoots`, keeping `onlyOwner`, the state assignments, and the `MerkleRootsUpdated` event intact, and added a small Truffle test file `test/merkleRoots.operational.test.js` that validates the new behavior and that other identity-locked functions still revert with `ConfigLocked`.

### Testing
- Ran `npm run build` (compile succeeded), `npx truffle test --network test test/merkleRoots.operational.test.js` (2 passing), `npm run size` (reported AGIJobManager runtime bytecode 24457 bytes) and `node scripts/check-contract-sizes.js`, and confirmed the runtime bytecode size stayed under the repo size guard (no increase in deployed runtime size).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699932c1fcbc8333ad458eaaaf5501ea)