### PR TITLE
Allow owner updates to Merkle roots during active escrow/identity lock; adjust tests & docs

### DIFF
--- a/contracts/AGIJobManager.sol
+++ b/contracts/AGIJobManager.sol
@@ -1074,9 +1074,7 @@ contract AGIJobManager is Ownable, ReentrancyGuard, Pausable, ERC721 {
     function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)
         external
         onlyOwner
-        whenIdentityConfigurable
     {
-        _requireEmptyEscrow();
         validatorMerkleRoot = _validatorMerkleRoot;
         agentMerkleRoot = _agentMerkleRoot;
         emit MerkleRootsUpdated(_validatorMerkleRoot, _agentMerkleRoot);

--- a/docs/REFERENCE/CONTRACT_INTERFACE.md
+++ b/docs/REFERENCE/CONTRACT_INTERFACE.md
@@ -1,7 +1,7 @@
 # AGIJobManager Interface Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `468c1f0aa579`.
-- Source snapshot fingerprint: `468c1f0aa579`.
+- Generated at (deterministic source fingerprint): `29091418f23a`.
+- Source snapshot fingerprint: `29091418f23a`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Operator-facing interface

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,7 +1,7 @@
 # ENS Reference (Generated)
 
 Generated at (UTC): 1970-01-01T00:00:00Z
-Source fingerprint: 0ae25e93eb3efe5b
+Source fingerprint: e8328d217f46c4a8
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -43,9 +43,9 @@ Source files used:
 - `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1052](../../contracts/AGIJobManager.sol#L1052))
 - `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1061](../../contracts/AGIJobManager.sol#L1061))
 - `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1074](../../contracts/AGIJobManager.sol#L1074))
-- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1299](../../contracts/AGIJobManager.sol#L1299))
-- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1535](../../contracts/AGIJobManager.sol#L1535))
-- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1540](../../contracts/AGIJobManager.sol#L1540))
+- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
+- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1533](../../contracts/AGIJobManager.sol#L1533))
+- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1538](../../contracts/AGIJobManager.sol#L1538))
 - `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L101](../../contracts/ens/ENSJobPages.sol#L101))
 - `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L109](../../contracts/ens/ENSJobPages.sol#L109))
 - `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L125](../../contracts/ens/ENSJobPages.sol#L125))
@@ -86,8 +86,8 @@ Source files used:
 - @notice Total AGI locked as validator bonds for unsettled votes. ([contracts/AGIJobManager.sol#L388](../../contracts/AGIJobManager.sol#L388))
 - @notice Total AGI locked as dispute bonds for unsettled disputes. ([contracts/AGIJobManager.sol#L390](../../contracts/AGIJobManager.sol#L390))
 - @notice Freezes token/ENS/namewrapper/root nodes. Not a governance lock; ops remain owner-controlled. ([contracts/AGIJobManager.sol#L404](../../contracts/AGIJobManager.sol#L404))
-- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
-- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1298](../../contracts/AGIJobManager.sol#L1298))
-- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1345](../../contracts/AGIJobManager.sol#L1345))
-- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1570](../../contracts/AGIJobManager.sol#L1570))
+- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1295](../../contracts/AGIJobManager.sol#L1295))
+- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1296](../../contracts/AGIJobManager.sol#L1296))
+- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1343](../../contracts/AGIJobManager.sol#L1343))
+- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1568](../../contracts/AGIJobManager.sol#L1568))
 

--- a/docs/REFERENCE/EVENTS_AND_ERRORS.md
+++ b/docs/REFERENCE/EVENTS_AND_ERRORS.md
@@ -1,6 +1,6 @@
 # Events and Errors Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `468c1f0aa579`.
+- Generated at (deterministic source fingerprint): `29091418f23a`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Events catalog

--- a/test/adminOps.test.js
+++ b/test/adminOps.test.js
@@ -308,7 +308,7 @@ contract("AGIJobManager admin ops", (accounts) => {
     await manager.lockIdentityConfiguration({ from: owner });
     assert.equal(await manager.lockIdentityConfig(), true, "config should be locked");
 
-    await expectCustomError(manager.updateMerkleRoots.call(clubRoot, agentRoot, { from: owner }), "ConfigLocked");
+    await manager.updateMerkleRoots(clubRoot, agentRoot, { from: owner });
 
     await manager.setMaxJobPayout(toBN(toWei("1")), { from: owner });
     await expectCustomError(manager.setJobDurationLimit.call(0, { from: owner }), "InvalidParameters");

--- a/test/mainnetGovernanceAndOps.regression.test.js
+++ b/test/mainnetGovernanceAndOps.regression.test.js
@@ -63,7 +63,7 @@ contract('mainnet governance + ops regressions', (accounts) => {
     assert.equal(capped.toString(), '88888');
   });
 
-  it('locks governance knobs and merkle roots while funds are in-flight', async () => {
+  it('locks governance knobs while funds are in-flight but keeps merkle roots operational', async () => {
     const ctx = await deployManager();
     await seedAssignedJob(ctx);
 
@@ -76,7 +76,7 @@ contract('mainnet governance + ops regressions', (accounts) => {
     await expectCustomError(ctx.manager.setAgentBondParams.call(100, 1, 1, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setValidatorSlashBps.call(100, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setChallengePeriodAfterApproval.call(1, { from: owner }), 'InvalidState');
-    await expectCustomError(ctx.manager.updateMerkleRoots.call(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner }), 'InvalidState');
+    await ctx.manager.updateMerkleRoots(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner });
 
     await time.increase(1001);
     await ctx.manager.expireJob(0, { from: employer });
@@ -162,9 +162,9 @@ contract('mainnet governance + ops regressions', (accounts) => {
     assert.equal(hookLog.args.success, false);
   });
 
-  it('includes merkle roots in identity lock', async () => {
+  it('keeps merkle roots owner-updatable after identity lock', async () => {
     const ctx = await deployManager();
     await ctx.manager.lockIdentityConfiguration({ from: owner });
-    await expectCustomError(ctx.manager.updateMerkleRoots.call(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner }), 'ConfigLocked');
+    await ctx.manager.updateMerkleRoots(web3.utils.randomHex(32), web3.utils.randomHex(32), { from: owner });
   });
 });

--- a/test/merkleRoots.operational.test.js
+++ b/test/merkleRoots.operational.test.js
@@ -1,0 +1,75 @@
+const assert = require('assert');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { rootNode } = require('./helpers/ens');
+const { expectCustomError } = require('./helpers/errors');
+
+const ZERO_ROOT = '0x' + '00'.repeat(32);
+
+contract('merkleRoots.operational', (accounts) => {
+  const [owner, employer] = accounts;
+  const payout = web3.utils.toWei('1');
+
+  let manager;
+  let token;
+
+  beforeEach(async () => {
+    token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+
+    manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        'ipfs://base',
+        ens.address,
+        nameWrapper.address,
+        rootNode('club'),
+        rootNode('agent'),
+        rootNode('club'),
+        rootNode('agent'),
+        ZERO_ROOT,
+        ZERO_ROOT,
+      ),
+      { from: owner },
+    );
+
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+  });
+
+  it('updates merkle roots even while escrow is active', async () => {
+    await manager.createJob('ipfs-job', payout, 3600, 'details', { from: employer });
+
+    const newValidatorRoot = web3.utils.soliditySha3('validator-root-v2');
+    const newAgentRoot = web3.utils.soliditySha3('agent-root-v2');
+    const receipt = await manager.updateMerkleRoots(newValidatorRoot, newAgentRoot, { from: owner });
+
+    assert.equal(receipt.logs[0].event, 'MerkleRootsUpdated');
+    assert.equal(receipt.logs[0].args.validatorMerkleRoot, newValidatorRoot);
+    assert.equal(receipt.logs[0].args.agentMerkleRoot, newAgentRoot);
+    assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
+    assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+  });
+
+  it('updates merkle roots after identity lock while other locked config remains blocked', async () => {
+    await manager.lockIdentityConfiguration({ from: owner });
+
+    const newValidatorRoot = web3.utils.soliditySha3('validator-root-v3');
+    const newAgentRoot = web3.utils.soliditySha3('agent-root-v3');
+    await manager.updateMerkleRoots(newValidatorRoot, newAgentRoot, { from: owner });
+
+    assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
+    assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+
+    await expectCustomError(
+      manager.updateRootNodes.call(rootNode('club2'), rootNode('agent2'), rootNode('club3'), rootNode('agent3'), { from: owner }),
+      'ConfigLocked',
+    );
+  });
+});


### PR DESCRIPTION
### Motivation
- Merkle roots are operational metadata and must remain owner-updatable even while escrow is active or after identity wiring is locked, so tests and behavior should reflect that intended policy.

### Description
- Relaxed `updateMerkleRoots` in `AGIJobManager.sol` by removing the `whenIdentityConfigurable` guard and the `_requireEmptyEscrow()` check so the owner can update validator/agent Merkle roots at any time.
- Updated tests to match the new behavior by allowing `updateMerkleRoots` calls in `test/adminOps.test.js` and `test/mainnetGovernanceAndOps.regression.test.js` instead of expecting `ConfigLocked`/`InvalidState` reverts.
- Added `test/merkleRoots.operational.test.js` to exercise Merkle-root updates during active escrow and after identity lock while confirming other identity-root updates remain locked.
- Regenerated reference docs (`docs/REFERENCE/CONTRACT_INTERFACE.md`, `ENS_REFERENCE.md`, `EVENTS_AND_ERRORS.md`) to reflect the interface changes and source fingerprint updates.

### Testing
- Ran the full test suite with `npm run test`, which compiles contracts, runs Truffle tests, executes the node test harness, and checks contract sizes; result: `353 passing` and `0 failing` (ABI smoke and contract-size checks included).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699932c1fcbc8333ad458eaaaf5501ea)