### PR TITLE
test: split merkle-root operational guarantees into focused cases (no contract change)

### DIFF
--- a/test/merkleRoots.operational.test.js
+++ b/test/merkleRoots.operational.test.js
@@ -57,7 +57,7 @@ contract('merkleRoots.operational', (accounts) => {
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
   });
 
-  it('updates merkle roots after identity lock while other locked config remains blocked', async () => {
+  it('updates merkle roots after identity lock', async () => {
     await manager.lockIdentityConfiguration({ from: owner });
 
     const newValidatorRoot = web3.utils.soliditySha3('validator-root-v3');
@@ -66,6 +66,10 @@ contract('merkleRoots.operational', (accounts) => {
 
     assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+  });
+
+  it('keeps identity-locked setters blocked after lockIdentityConfiguration', async () => {
+    await manager.lockIdentityConfiguration({ from: owner });
 
     await expectCustomError(
       manager.updateRootNodes.call(rootNode('club2'), rootNode('agent2'), rootNode('club3'), rootNode('agent3'), { from: owner }),


### PR DESCRIPTION
### Motivation
- The owner must be able to rotate `validatorMerkleRoot` and `agentMerkleRoot` at any time (including after `lockIdentityConfiguration()` and while escrows are active); on inspection `updateMerkleRoots` already meets that requirement, so the change needed was to make the test suite explicitly assert this operational guarantee.

### Description
- No Solidity logic or access control was changed; `contracts/AGIJobManager.sol` already exposes `updateMerkleRoots(bytes32,bytes32)` as `external onlyOwner` with the same assignments and `MerkleRootsUpdated` emission.  No modifiers or `_requireEmptyEscrow()` lines were added/removed in this PR (surgical check confirmed). 
- Test-only change: `test/merkleRoots.operational.test.js` was split into two focused cases so the suite maps to the acceptance criteria: (A) merkle roots updatable while escrow is active, (B) merkle roots updatable after `lockIdentityConfiguration()`, and (C) a focused assertion that identity-locked setters (e.g. `updateRootNodes`) still revert with `ConfigLocked`.
- Unified diff (git patch for the single test change):

diff --git a/test/merkleRoots.operational.test.js b/test/merkleRoots.operational.test.js
index 9402d0d..dec5d82 100644
--- a/test/merkleRoots.operational.test.js
+++ b/test/merkleRoots.operational.test.js
@@ -57,7 +57,7 @@ contract('merkleRoots.operational', (accounts) => {
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
   });
 
-  it('updates merkle roots after identity lock while other locked config remains blocked', async () => {
+  it('updates merkle roots after identity lock', async () => {
     await manager.lockIdentityConfiguration({ from: owner });
 
     const newValidatorRoot = web3.utils.soliditySha3('validator-root-v3');
@@ -66,6 +66,10 @@ contract('merkleRoots.operational', (accounts) => {
 
     assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+  });
+
+  it('keeps identity-locked setters blocked after lockIdentityConfiguration', async () => {
+    await manager.lockIdentityConfiguration({ from: owner });
 
     await expectCustomError(
       manager.updateRootNodes.call(rootNode('club2'), rootNode('agent2'), rootNode('club3'), rootNode('agent3'), { from: owner }),
       'ConfigLocked',

### Testing
- Commands run: `npm ci`, `npx truffle compile`, `npx truffle test test/merkleRoots.operational.test.js --network test`, and `npm run size`.
- Automated test outcomes: the modified `merkleRoots.operational` test file ran successfully with 3 passing tests; `npx truffle compile` completed without errors; size guard reports `AGIJobManager runtime bytecode size: 24457 bytes` which is under the repo threshold.
- Summary of verification: compilation succeeded, the new/adjusted tests passed, and the runtime bytecode size remained within the EIP-170 guard.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ba6e1f008333a5889aeb253df83f)