### PR TITLE
test: tighten operational merkle-root update guarantees

### DIFF
--- a/test/merkleRoots.operational.test.js
+++ b/test/merkleRoots.operational.test.js
@@ -45,6 +45,7 @@ contract('merkleRoots.operational', (accounts) => {
 
   it('updates merkle roots even while escrow is active', async () => {
     await manager.createJob('ipfs-job', payout, 3600, 'details', { from: employer });
+    assert.equal((await manager.lockedEscrow()).toString(), payout);
 
     const newValidatorRoot = web3.utils.soliditySha3('validator-root-v2');
     const newAgentRoot = web3.utils.soliditySha3('agent-root-v2');
@@ -57,7 +58,7 @@ contract('merkleRoots.operational', (accounts) => {
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
   });
 
-  it('updates merkle roots after identity lock while other locked config remains blocked', async () => {
+  it('updates merkle roots after identity lock', async () => {
     await manager.lockIdentityConfiguration({ from: owner });
 
     const newValidatorRoot = web3.utils.soliditySha3('validator-root-v3');
@@ -66,6 +67,10 @@ contract('merkleRoots.operational', (accounts) => {
 
     assert.equal(await manager.validatorMerkleRoot(), newValidatorRoot);
     assert.equal(await manager.agentMerkleRoot(), newAgentRoot);
+  });
+
+  it('keeps other identity-locked updates blocked after lock', async () => {
+    await manager.lockIdentityConfiguration({ from: owner });
 
     await expectCustomError(
       manager.updateRootNodes.call(rootNode('club2'), rootNode('agent2'), rootNode('club3'), rootNode('agent3'), { from: owner }),


### PR DESCRIPTION
### Motivation
- Ensure the repo explicitly proves the operational guarantee that the owner can update `validatorMerkleRoot` and `agentMerkleRoot` while escrows are active and after `lockIdentityConfiguration()` is set. 
- Confirm other identity-lock behavior remains unchanged (i.e., non‑Merkle identity updates continue to be blocked by `ConfigLocked`).

### Description
- Updated `test/merkleRoots.operational.test.js` to assert `lockedEscrow()` equals the job payout before calling `updateMerkleRoots`, proving updates succeed while escrow is active. 
- Split the previous combined post-lock test into two focused tests so one asserts `updateMerkleRoots` still succeeds after `lockIdentityConfiguration()` and the other asserts `updateRootNodes` still reverts with `ConfigLocked` after lock. 
- No Solidity or runtime contract code was changed; the `AGIJobManager` contract already matched the requested always-owner-callable shape for `updateMerkleRoots` and remains identical.

### Testing
- Ran `npm run build` (Truffle compile) and compilation succeeded with `solc 0.8.23`.
- Ran the focused test file with `npx truffle test test/merkleRoots.operational.test.js --network test` and observed `3 passing` for the updated cases.
- Verified bytecode size via `npm run size` and `node scripts/check-contract-sizes.js`, with `AGIJobManager` runtime bytecode reported as `24457` bytes, showing no increase.
- Commands executed during validation: `npm run build`, `npx truffle test test/merkleRoots.operational.test.js --network test`, `npm run size`, and `node scripts/check-contract-sizes.js`, all completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999ba6e1f008333a5889aeb253df83f)