### PR TITLE
docs: add institutional owner guide for mainnet deployment and operations

### DIFF
--- a/docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md
+++ b/docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md
@@ -110,6 +110,19 @@ npx truffle compile
 cp migrations/config/agijobmanager.config.example.js migrations/config/agijobmanager.config.js
 ```
 
+### 6.3 Edit deployment config before any migration
+
+Open `migrations/config/agijobmanager.config.js` and set approved values before running dry-run or mainnet migration.
+
+Minimum required edits for mainnet:
+- `ownership.finalOwner` must be a real address (not `null`),
+- keep `ownership.requireFinalOwnerOnMainnet: true`,
+- confirm `identity` fields (token/ENS/nameWrapper/base URL),
+- confirm `merkleRoots`, `authorizationRoots`/`rootNodes`,
+- confirm `protocolParameters`, `dynamicLists`, and `agiTypes`.
+
+If `finalOwner` is unset on mainnet, validation will fail before deployment.
+
 Set environment variables:
 
 ```bash


### PR DESCRIPTION
### Motivation

- Provide an owner-facing, Etherscan-first, non-technical Mainnet deployment and operations manual that makes it safe for institutional owners to deploy, verify, secure, and operate AGIJobManager while emphasising the policy that the protocol is for AI agents exclusively. 
- Capture and present verifiable legacy defaults from the legacy mainnet deployment and map them to recommended defaults for new deployments so owners have an auditable starting point.

### Description

- Added a single comprehensive owner guide at `docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md` covering the required 14 sections (Executive Summary → Compliance), with Mermaid diagrams, a permissions+preconditions matrix, Etherscan-first operational instructions, an incident-response flow, lifecycle diagrams, and an allowlisting runbook. 
- Documented the real production Truffle migration and config files used by the repo, specifically `migrations/6_deploy_agijobmanager_production_operator.js` and `migrations/config/agijobmanager.config.example.js`, and included exact copy/paste `truffle` commands and the required mainnet guard phrase. 
- Extracted and recorded legacy constructor arguments and runtime defaults from the legacy verified deployment (`0x0178b6bad606aaf908f72135b8ec32fc1d5ba477`) and on-chain reads, and produced a “Legacy Defaults” table plus a “Recommended Defaults” table for new deployments that defaults to the repo’s `$AGIALPHA` token where appropriate; fields that must be re-chosen by the owner are explicitly marked. 
- Preserved repository constraints: no Solidity sources were changed; a deterministic Merkle helper is referenced (existing `node scripts/merkle/export_merkle_proofs.js`) and the guide documents the exact leaf format and proof expectations taken from `contracts/utils/ENSOwnership.sol`.

### Testing

- Documentation and tooling checks: ran `npm ci` (completed), `npm run docs:gen` (generated reference docs), `npm run docs:ens:gen` (generated ENS reference), and `npm run docs:check` (all checks passed). 
- Verified legacy deployment data by fetching the legacy contract page HTML from Etherscan and decoding constructor arguments, and performed on-chain `eth_call` reads (RPC calls) against the legacy address to validate runtime values used in the Legacy Defaults table (calls returned expected constructor-derived addresses and many runtime parameters). 
- Static verification: ensured the new markdown renders with the required headings, tables and Mermaid diagrams and that docs integrity checks in the repo passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6999f81a3c408333b206cf7d022870c4)