### PR TITLE
Harden owner operational controls under bytecode guard

### DIFF
--- a/docs/OPERATIONS.md
+++ b/docs/OPERATIONS.md
@@ -4,6 +4,16 @@
 
 `AGIJobManager` is owner-operated with moderator-assisted dispute handling. There is no autonomous governance module in current code.
 
+## Intended operator profile
+
+The system is operated for **autonomous AI agents exclusively** with accountable human oversight. Human-only manual operation is outside normal operating policy.
+
+## Parameter change safety boundaries
+
+- `setAgentBondParams`, `setAgentBond`, and `setValidatorBondParams` can be adjusted during active escrow because each job snapshots the effective bond amounts when assignment/voting occurs.
+- Keep `_requireEmptyEscrow()` guarded settings for values that can alter live settlement fairness (for example, slash rates, approval/disapproval thresholds, and review windows).
+- `updateMerkleRoots` is intentionally available without escrow-empty gating so validator/agent rosters can be updated continuously.
+
 ## Monitoring and alerting
 
 ### Recommended event subscriptions

--- a/docs/REFERENCE.md
+++ b/docs/REFERENCE.md
@@ -18,6 +18,7 @@ The following `public` state variables have auto‑generated getter functions:
 - `validatorVotedJobs(address, index)`
 - `blacklistedAgents(address)`, `blacklistedValidators(address)`
 - `agiTypes(index)`
+- `maxActiveJobsPerAgent()`
 
 Explicit job accessors:
 - `getJobCore(jobId)`, `getJobValidation(jobId)`
@@ -84,6 +85,12 @@ Sets approval/disapproval thresholds.
 ### `setValidationRewardPercentage(uint256)`
 Sets validator reward percentage (1‑100).
 
+### `setValidatorBondParams(uint256 bps, uint256 min, uint256 max)`
+Updates validator bond parameters for future votes. Existing jobs keep their snapshotted validator bond amount.
+
+### `setAgentBondParams(uint256 bps, uint256 min, uint256 max)` / `setAgentBond(uint256 bond)`
+Updates agent bond configuration for future assignments. Existing jobs keep their snapshotted agent bond amount.
+
 ### `setPremiumReputationThreshold(uint256)`
 Sets the reputation required for premium feature access.
 
@@ -92,6 +99,9 @@ Sets max payout allowed.
 
 ### `setJobDurationLimit(uint256)`
 Sets max job duration allowed.
+
+### `setMaxActiveJobsPerAgent(uint256)`
+Owner control for concurrent active jobs per agent. Must be in `(0, 10_000]`. Impacts only future intake checks in `applyForJob`.
 
 ### `updateTermsAndConditionsIpfsHash(string)`
 ### `updateContactEmail(string)`

--- a/docs/REFERENCE/CONTRACT_INTERFACE.md
+++ b/docs/REFERENCE/CONTRACT_INTERFACE.md
@@ -1,7 +1,7 @@
 # AGIJobManager Interface Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `29091418f23a`.
-- Source snapshot fingerprint: `29091418f23a`.
+- Generated at (deterministic source fingerprint): `f3122a317e45`.
+- Source snapshot fingerprint: `f3122a317e45`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Operator-facing interface
@@ -31,6 +31,7 @@
 | `lockedEscrow` | `uint256` |
 | `lockedValidatorBonds` | `uint256` |
 | `lockIdentityConfig` | `bool` |
+| `maxActiveJobsPerAgent` | `uint256` |
 | `maxJobPayout` | `uint256` |
 | `nameWrapper` | `NameWrapper` |
 | `nextJobId` | `uint256` |
@@ -96,6 +97,7 @@
 | `setDisputeReviewPeriod(uint256 _period)` | external | nonpayable | — |
 | `setEnsJobPages(address _ensJobPages)` | external | nonpayable | — |
 | `setJobDurationLimit(uint256 _limit)` | external | nonpayable | — |
+| `setMaxActiveJobsPerAgent(uint256 value)` | external | nonpayable | — |
 | `setMaxJobPayout(uint256 _maxPayout)` | external | nonpayable | — |
 | `setPremiumReputationThreshold(uint256 _threshold)` | external | nonpayable | — |
 | `setRequiredValidatorApprovals(uint256 _approvals)` | external | nonpayable | — |
@@ -146,6 +148,7 @@
 | `JobDisputed` | `uint256 indexed jobId, address indexed disputant` |
 | `JobExpired` | `uint256 indexed jobId, address indexed employer, address agent, uint256 indexed payout` |
 | `JobValidated` | `uint256 indexed jobId, address indexed validator` |
+| `MaxActiveJobsPerAgentUpdated` | `uint256 oldValue, uint256 newValue` |
 | `MerkleRootsUpdated` | `bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot` |
 | `NameWrapperUpdated` | `address newNameWrapper` |
 | `NFTIssued` | `uint256 indexed tokenId, address indexed employer, string tokenURI` |

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,7 +1,7 @@
 # ENS Reference (Generated)
 
 Generated at (UTC): 1970-01-01T00:00:00Z
-Source fingerprint: e8328d217f46c4a8
+Source fingerprint: 6ce883cf7e4f25a3
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -32,20 +32,20 @@ Source files used:
 
 ## Config and locks
 
-- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L580](../../contracts/AGIJobManager.sol#L580))
-- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L738](../../contracts/AGIJobManager.sol#L738))
-- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L770](../../contracts/AGIJobManager.sol#L770))
-- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L832](../../contracts/AGIJobManager.sol#L832))
-- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L840](../../contracts/AGIJobManager.sol#L840))
-- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1033](../../contracts/AGIJobManager.sol#L1033))
-- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1040](../../contracts/AGIJobManager.sol#L1040))
-- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1046](../../contracts/AGIJobManager.sol#L1046))
-- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1052](../../contracts/AGIJobManager.sol#L1052))
-- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1061](../../contracts/AGIJobManager.sol#L1061))
-- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1074](../../contracts/AGIJobManager.sol#L1074))
-- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
-- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1533](../../contracts/AGIJobManager.sol#L1533))
-- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1538](../../contracts/AGIJobManager.sol#L1538))
+- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L581](../../contracts/AGIJobManager.sol#L581))
+- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L739](../../contracts/AGIJobManager.sol#L739))
+- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L771](../../contracts/AGIJobManager.sol#L771))
+- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L833](../../contracts/AGIJobManager.sol#L833))
+- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L841](../../contracts/AGIJobManager.sol#L841))
+- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1034](../../contracts/AGIJobManager.sol#L1034))
+- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1041](../../contracts/AGIJobManager.sol#L1041))
+- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1047](../../contracts/AGIJobManager.sol#L1047))
+- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1053](../../contracts/AGIJobManager.sol#L1053))
+- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1062](../../contracts/AGIJobManager.sol#L1062))
+- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1075](../../contracts/AGIJobManager.sol#L1075))
+- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1293](../../contracts/AGIJobManager.sol#L1293))
+- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1529](../../contracts/AGIJobManager.sol#L1529))
+- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1534](../../contracts/AGIJobManager.sol#L1534))
 - `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L101](../../contracts/ens/ENSJobPages.sol#L101))
 - `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L109](../../contracts/ens/ENSJobPages.sol#L109))
 - `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L125](../../contracts/ens/ENSJobPages.sol#L125))
@@ -67,7 +67,7 @@ Source files used:
 - `event MerkleRootsUpdated(bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot);` ([contracts/AGIJobManager.sol#L485](../../contracts/AGIJobManager.sol#L485))
 - `event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);` ([contracts/AGIJobManager.sol#L492](../../contracts/AGIJobManager.sol#L492))
 - `event EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages);` ([contracts/AGIJobManager.sol#L499](../../contracts/AGIJobManager.sol#L499))
-- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L514](../../contracts/AGIJobManager.sol#L514))
+- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L515](../../contracts/AGIJobManager.sol#L515))
 - `error ENSNotConfigured();` ([contracts/ens/ENSJobPages.sol#L34](../../contracts/ens/ENSJobPages.sol#L34))
 - `error ENSNotAuthorized();` ([contracts/ens/ENSJobPages.sol#L35](../../contracts/ens/ENSJobPages.sol#L35))
 - `error InvalidParameters();` ([contracts/ens/ENSJobPages.sol#L36](../../contracts/ens/ENSJobPages.sol#L36))
@@ -86,8 +86,8 @@ Source files used:
 - @notice Total AGI locked as validator bonds for unsettled votes. ([contracts/AGIJobManager.sol#L388](../../contracts/AGIJobManager.sol#L388))
 - @notice Total AGI locked as dispute bonds for unsettled disputes. ([contracts/AGIJobManager.sol#L390](../../contracts/AGIJobManager.sol#L390))
 - @notice Freezes token/ENS/namewrapper/root nodes. Not a governance lock; ops remain owner-controlled. ([contracts/AGIJobManager.sol#L404](../../contracts/AGIJobManager.sol#L404))
-- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1295](../../contracts/AGIJobManager.sol#L1295))
-- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1296](../../contracts/AGIJobManager.sol#L1296))
-- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1343](../../contracts/AGIJobManager.sol#L1343))
-- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1568](../../contracts/AGIJobManager.sol#L1568))
+- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1291](../../contracts/AGIJobManager.sol#L1291))
+- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1292](../../contracts/AGIJobManager.sol#L1292))
+- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1339](../../contracts/AGIJobManager.sol#L1339))
+- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1564](../../contracts/AGIJobManager.sol#L1564))
 

--- a/docs/REFERENCE/EVENTS_AND_ERRORS.md
+++ b/docs/REFERENCE/EVENTS_AND_ERRORS.md
@@ -1,6 +1,6 @@
 # Events and Errors Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `29091418f23a`.
+- Generated at (deterministic source fingerprint): `f3122a317e45`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Events catalog
@@ -30,6 +30,7 @@
 | `JobDisputed` | `uint256 indexed jobId, address indexed disputant` | Dispute lane entered | Page moderator operations queue |
 | `JobExpired` | `uint256 indexed jobId, address indexed employer, address agent, uint256 indexed payout` | Job missed deadline and expired | Track employer protection triggers |
 | `JobValidated` | `uint256 indexed jobId, address indexed validator` | Validator approval vote | Track validator participation and threshold trajectory |
+| `MaxActiveJobsPerAgentUpdated` | `uint256 oldValue, uint256 newValue` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `MerkleRootsUpdated` | `bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `NameWrapperUpdated` | `address newNameWrapper` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `NFTIssued` | `uint256 indexed tokenId, address indexed employer, string tokenURI` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |


### PR DESCRIPTION
### Motivation

- Remove operational friction that blocks long-lived owner/operator duties while preserving safety for in-flight jobs and keeping deployed runtime bytecode under the repository EIP‑170 guard. 
- Focus on high-value, low-risk owner controls: per-agent concurrency, bond tuning, and continuous allowlist (Merkle) updates without requiring full escrow drains.

### Description

- Replaced the hard-coded `maxActiveJobsPerAgent` constant with a public `uint256 public maxActiveJobsPerAgent = 3` and added `function setMaxActiveJobsPerAgent(uint256)` with validation `(value > 0 && value <= 10_000)` and the event `MaxActiveJobsPerAgentUpdated(oldValue, newValue)`, which affects only future intake checks in `applyForJob`.
- Removed `_requireEmptyEscrow()` gating from `setValidatorBondParams`, `setAgentBondParams`, and `setAgentBond` to allow owner tuning while `lockedEscrow > 0`, and preserved safety by relying on per-job/per-vote snapshots already present in the codebase.
- Confirmed and covered `updateMerkleRoots` stays owner-callable at any time (not blocked by identity locks or empty-escrow gates) and added a targeted test to exercise this path while escrow is active and identity wiring is locked.
- Minimal docs updates: added an operator note in `docs/OPERATIONS.md` describing the intended AI-agent operator profile, documented that bond params are future‑affecting (snapshotted) and that `maxActiveJobsPerAgent` is owner‑controlled; regenerated reference docs.
- Decision note: AGI‑type slot-rotation (preventing permanent slot exhaustion) was evaluated but not merged because the smallest tested approaches pushed runtime bytecode over the repository size guard; this PR preserves the bytecode cap and implements the remaining high-value fixes surgically.

### Testing

- Ran `npm ci` and `npm run build` to compile the contracts, which succeeded.
- Executed the targeted Truffle test `npx truffle test test/adminOps.test.js --network test`, which passed (17 passing).
- Regenerated and validated docs with `npm run docs:gen && npm run docs:ens:gen && npm run docs:check`, which succeeded.
- Verified the repository bytecode size guard with `npm run size`, and the `AGIJobManager` runtime bytecode is under the cap (final reported size: `24573` bytes), so the change respects the EIP‑170 guard.
- Tests added/modified: extended `test/adminOps.test.js` with tests for configurable `maxActiveJobsPerAgent`, bond-parameter updates while escrow is locked, and live `updateMerkleRoots` behavior; all new assertions succeeded when run with the repo tooling.

Commands run (selection)

- `npm ci`
- `npm run build`
- `npx truffle test test/adminOps.test.js --network test`
- `npm run docs:gen && npm run docs:ens:gen && npm run docs:check`
- `npm run size`

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a063f69e48333874ec5b42b07c27d)