### PR TITLE
Make operational limits configurable during active escrow; update tests and regenerate UI ABI

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -42,6 +42,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [REFERENCE/CONTRACT_INTERFACE.md](./REFERENCE/CONTRACT_INTERFACE.md)
 - [REFERENCE/EVENTS_AND_ERRORS.md](./REFERENCE/EVENTS_AND_ERRORS.md)
 - [REFERENCE/ENS_REFERENCE.md](./REFERENCE/ENS_REFERENCE.md)
+- [REFERENCE/OPERATIONAL_LIMITS.md](./REFERENCE/OPERATIONAL_LIMITS.md)
 
 ## Design assets (text-only)
 

--- a/docs/REFERENCE/CONTRACT_INTERFACE.md
+++ b/docs/REFERENCE/CONTRACT_INTERFACE.md
@@ -1,7 +1,7 @@
 # AGIJobManager Interface Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `29091418f23a`.
-- Source snapshot fingerprint: `29091418f23a`.
+- Generated at (deterministic source fingerprint): `d24e414eb2c3`.
+- Source snapshot fingerprint: `d24e414eb2c3`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Operator-facing interface
@@ -31,6 +31,7 @@
 | `lockedEscrow` | `uint256` |
 | `lockedValidatorBonds` | `uint256` |
 | `lockIdentityConfig` | `bool` |
+| `maxActiveJobsPerAgent` | `uint256` |
 | `maxJobPayout` | `uint256` |
 | `nameWrapper` | `NameWrapper` |
 | `nextJobId` | `uint256` |
@@ -96,6 +97,7 @@
 | `setDisputeReviewPeriod(uint256 _period)` | external | nonpayable | — |
 | `setEnsJobPages(address _ensJobPages)` | external | nonpayable | — |
 | `setJobDurationLimit(uint256 _limit)` | external | nonpayable | — |
+| `setMaxActiveJobsPerAgent(uint256 value)` | external | nonpayable | — |
 | `setMaxJobPayout(uint256 _maxPayout)` | external | nonpayable | — |
 | `setPremiumReputationThreshold(uint256 _threshold)` | external | nonpayable | — |
 | `setRequiredValidatorApprovals(uint256 _approvals)` | external | nonpayable | — |
@@ -146,6 +148,7 @@
 | `JobDisputed` | `uint256 indexed jobId, address indexed disputant` |
 | `JobExpired` | `uint256 indexed jobId, address indexed employer, address agent, uint256 indexed payout` |
 | `JobValidated` | `uint256 indexed jobId, address indexed validator` |
+| `MaxActiveJobsPerAgentUpdated` | `uint256 oldValue, uint256 newValue` |
 | `MerkleRootsUpdated` | `bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot` |
 | `NameWrapperUpdated` | `address newNameWrapper` |
 | `NFTIssued` | `uint256 indexed tokenId, address indexed employer, string tokenURI` |

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,7 +1,7 @@
 # ENS Reference (Generated)
 
 Generated at (UTC): 1970-01-01T00:00:00Z
-Source fingerprint: e8328d217f46c4a8
+Source fingerprint: f2e3de26e534ceff
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -32,20 +32,20 @@ Source files used:
 
 ## Config and locks
 
-- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L580](../../contracts/AGIJobManager.sol#L580))
-- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L738](../../contracts/AGIJobManager.sol#L738))
-- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L770](../../contracts/AGIJobManager.sol#L770))
-- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L832](../../contracts/AGIJobManager.sol#L832))
-- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L840](../../contracts/AGIJobManager.sol#L840))
-- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1033](../../contracts/AGIJobManager.sol#L1033))
-- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1040](../../contracts/AGIJobManager.sol#L1040))
-- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1046](../../contracts/AGIJobManager.sol#L1046))
-- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1052](../../contracts/AGIJobManager.sol#L1052))
-- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1061](../../contracts/AGIJobManager.sol#L1061))
-- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1074](../../contracts/AGIJobManager.sol#L1074))
-- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
-- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1533](../../contracts/AGIJobManager.sol#L1533))
-- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1538](../../contracts/AGIJobManager.sol#L1538))
+- `function _initRoots(bytes32[4] memory rootNodes, bytes32[2] memory merkleRoots) internal` ([contracts/AGIJobManager.sol#L581](../../contracts/AGIJobManager.sol#L581))
+- `function lockIdentityConfiguration() external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L739](../../contracts/AGIJobManager.sol#L739))
+- `function applyForJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L771](../../contracts/AGIJobManager.sol#L771))
+- `function validateJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L833](../../contracts/AGIJobManager.sol#L833))
+- `function disapproveJob(uint256 _jobId, string memory subdomain, bytes32[] calldata proof)` ([contracts/AGIJobManager.sol#L841](../../contracts/AGIJobManager.sol#L841))
+- `function updateAGITokenAddress(address _newTokenAddress) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1034](../../contracts/AGIJobManager.sol#L1034))
+- `function updateEnsRegistry(address _newEnsRegistry) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1041](../../contracts/AGIJobManager.sol#L1041))
+- `function updateNameWrapper(address _newNameWrapper) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1047](../../contracts/AGIJobManager.sol#L1047))
+- `function setEnsJobPages(address _ensJobPages) external onlyOwner whenIdentityConfigurable` ([contracts/AGIJobManager.sol#L1053](../../contracts/AGIJobManager.sol#L1053))
+- `function updateRootNodes(` ([contracts/AGIJobManager.sol#L1062](../../contracts/AGIJobManager.sol#L1062))
+- `function updateMerkleRoots(bytes32 _validatorMerkleRoot, bytes32 _agentMerkleRoot)` ([contracts/AGIJobManager.sol#L1075](../../contracts/AGIJobManager.sol#L1075))
+- `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1299](../../contracts/AGIJobManager.sol#L1299))
+- `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1535](../../contracts/AGIJobManager.sol#L1535))
+- `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1540](../../contracts/AGIJobManager.sol#L1540))
 - `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L101](../../contracts/ens/ENSJobPages.sol#L101))
 - `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L109](../../contracts/ens/ENSJobPages.sol#L109))
 - `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L125](../../contracts/ens/ENSJobPages.sol#L125))
@@ -65,9 +65,9 @@ Source files used:
 - `event EnsRegistryUpdated(address newEnsRegistry);` ([contracts/AGIJobManager.sol#L477](../../contracts/AGIJobManager.sol#L477))
 - `event RootNodesUpdated(` ([contracts/AGIJobManager.sol#L479](../../contracts/AGIJobManager.sol#L479))
 - `event MerkleRootsUpdated(bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot);` ([contracts/AGIJobManager.sol#L485](../../contracts/AGIJobManager.sol#L485))
-- `event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);` ([contracts/AGIJobManager.sol#L492](../../contracts/AGIJobManager.sol#L492))
-- `event EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages);` ([contracts/AGIJobManager.sol#L499](../../contracts/AGIJobManager.sol#L499))
-- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L514](../../contracts/AGIJobManager.sol#L514))
+- `event IdentityConfigurationLocked(address indexed locker, uint256 indexed atTimestamp);` ([contracts/AGIJobManager.sol#L493](../../contracts/AGIJobManager.sol#L493))
+- `event EnsJobPagesUpdated(address indexed oldEnsJobPages, address indexed newEnsJobPages);` ([contracts/AGIJobManager.sol#L500](../../contracts/AGIJobManager.sol#L500))
+- `event EnsHookAttempted(uint8 indexed hook, uint256 indexed jobId, address indexed target, bool success);` ([contracts/AGIJobManager.sol#L515](../../contracts/AGIJobManager.sol#L515))
 - `error ENSNotConfigured();` ([contracts/ens/ENSJobPages.sol#L34](../../contracts/ens/ENSJobPages.sol#L34))
 - `error ENSNotAuthorized();` ([contracts/ens/ENSJobPages.sol#L35](../../contracts/ens/ENSJobPages.sol#L35))
 - `error InvalidParameters();` ([contracts/ens/ENSJobPages.sol#L36](../../contracts/ens/ENSJobPages.sol#L36))
@@ -86,8 +86,8 @@ Source files used:
 - @notice Total AGI locked as validator bonds for unsettled votes. ([contracts/AGIJobManager.sol#L388](../../contracts/AGIJobManager.sol#L388))
 - @notice Total AGI locked as dispute bonds for unsettled disputes. ([contracts/AGIJobManager.sol#L390](../../contracts/AGIJobManager.sol#L390))
 - @notice Freezes token/ENS/namewrapper/root nodes. Not a governance lock; ops remain owner-controlled. ([contracts/AGIJobManager.sol#L404](../../contracts/AGIJobManager.sol#L404))
-- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1295](../../contracts/AGIJobManager.sol#L1295))
-- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1296](../../contracts/AGIJobManager.sol#L1296))
-- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1343](../../contracts/AGIJobManager.sol#L1343))
-- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1568](../../contracts/AGIJobManager.sol#L1568))
+- @notice Anyone may lock ENS records after a job reaches a terminal state; only the owner may burn fuses. ([contracts/AGIJobManager.sol#L1297](../../contracts/AGIJobManager.sol#L1297))
+- @dev Fuse burning is irreversible and remains owner-only; ENS hook execution is best-effort. ([contracts/AGIJobManager.sol#L1298](../../contracts/AGIJobManager.sol#L1298))
+- @dev as long as lockedEscrow/locked*Bonds are fully covered. ([contracts/AGIJobManager.sol#L1345](../../contracts/AGIJobManager.sol#L1345))
+- @dev Owner withdrawals are limited to balances not backing lockedEscrow/locked*Bonds. ([contracts/AGIJobManager.sol#L1570](../../contracts/AGIJobManager.sol#L1570))
 

--- a/docs/REFERENCE/EVENTS_AND_ERRORS.md
+++ b/docs/REFERENCE/EVENTS_AND_ERRORS.md
@@ -1,6 +1,6 @@
 # Events and Errors Reference (Generated)
 
-- Generated at (deterministic source fingerprint): `29091418f23a`.
+- Generated at (deterministic source fingerprint): `d24e414eb2c3`.
 - Source: `contracts/AGIJobManager.sol`.
 
 ## Events catalog
@@ -30,6 +30,7 @@
 | `JobDisputed` | `uint256 indexed jobId, address indexed disputant` | Dispute lane entered | Page moderator operations queue |
 | `JobExpired` | `uint256 indexed jobId, address indexed employer, address agent, uint256 indexed payout` | Job missed deadline and expired | Track employer protection triggers |
 | `JobValidated` | `uint256 indexed jobId, address indexed validator` | Validator approval vote | Track validator participation and threshold trajectory |
+| `MaxActiveJobsPerAgentUpdated` | `uint256 oldValue, uint256 newValue` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `MerkleRootsUpdated` | `bytes32 validatorMerkleRoot, bytes32 agentMerkleRoot` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `NameWrapperUpdated` | `address newNameWrapper` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |
 | `NFTIssued` | `uint256 indexed tokenId, address indexed employer, string tokenURI` | Contract-defined emission point | Add event-specific monitors in SOC pipeline |

--- a/docs/REFERENCE/OPERATIONAL_LIMITS.md
+++ b/docs/REFERENCE/OPERATIONAL_LIMITS.md
@@ -1,0 +1,32 @@
+# Operational Limits (Owner Reference)
+
+> **Intended operations model: AI agents exclusively.** Human operators provide governance and oversight; routine job flow is for autonomous AI agents.
+
+This note classifies major protocol limits into safety-critical controls vs. operator-tunable controls.
+
+## Owner-tunable without empty escrow
+
+- `setMaxActiveJobsPerAgent(uint256 value)`
+  - Controls per-agent concurrent assignments.
+  - Must be in range `1..10_000`.
+  - Default is `3` for conservative startup posture.
+- `setAgentBondParams(uint256 bps, uint256 min, uint256 max)`
+- `setAgentBond(uint256 bond)`
+- `setValidatorBondParams(uint256 bps, uint256 min, uint256 max)`
+
+The bond setters above only impact future bond computations and do not retroactively rewrite already snapshotted job bond amounts.
+
+## AGI type capacity durability
+
+- `MAX_AGI_TYPES` remains capped at 32 to bound loops and gas.
+- Disabled AGI types (`payoutPercentage == 0`) remain disabled for eligibility, but do not currently shrink array length.
+
+## Safety-critical limits to keep conservative
+
+The following controls are still escrow-gated (`_requireEmptyEscrow()`) because changing them can alter in-flight settlement fairness:
+
+- Validator approval/disapproval thresholds
+- Vote quorum
+- Completion/dispute review periods
+- Validator slash bps
+- Challenge period after approval

--- a/docs/ui/abi/AGIJobManager.json
+++ b/docs/ui/abi/AGIJobManager.json
@@ -682,6 +682,25 @@
       "inputs": [
         {
           "indexed": false,
+          "internalType": "uint256",
+          "name": "oldValue",
+          "type": "uint256"
+        },
+        {
+          "indexed": false,
+          "internalType": "uint256",
+          "name": "newValue",
+          "type": "uint256"
+        }
+      ],
+      "name": "MaxActiveJobsPerAgentUpdated",
+      "type": "event"
+    },
+    {
+      "anonymous": false,
+      "inputs": [
+        {
+          "indexed": false,
           "internalType": "bytes32",
           "name": "validatorMerkleRoot",
           "type": "bytes32"
@@ -1487,6 +1506,19 @@
     {
       "inputs": [],
       "name": "lockedValidatorBonds",
+      "outputs": [
+        {
+          "internalType": "uint256",
+          "name": "",
+          "type": "uint256"
+        }
+      ],
+      "stateMutability": "view",
+      "type": "function"
+    },
+    {
+      "inputs": [],
+      "name": "maxActiveJobsPerAgent",
       "outputs": [
         {
           "internalType": "uint256",
@@ -2436,6 +2468,19 @@
         }
       ],
       "name": "setJobDurationLimit",
+      "outputs": [],
+      "stateMutability": "nonpayable",
+      "type": "function"
+    },
+    {
+      "inputs": [
+        {
+          "internalType": "uint256",
+          "name": "value",
+          "type": "uint256"
+        }
+      ],
+      "name": "setMaxActiveJobsPerAgent",
       "outputs": [],
       "stateMutability": "nonpayable",
       "type": "function"

--- a/forge-test/harness/AGIJobManagerHarness.sol
+++ b/forge-test/harness/AGIJobManagerHarness.sol
@@ -48,7 +48,7 @@ contract AGIJobManagerHarness is AGIJobManager {
         return jobs[jobId].assignedAgent;
     }
 
-    function maxActiveJobsPerAgentView() external pure returns (uint256) {
+    function maxActiveJobsPerAgentView() external view returns (uint256) {
         return maxActiveJobsPerAgent;
     }
 

--- a/test/incentiveHardening.test.js
+++ b/test/incentiveHardening.test.js
@@ -161,10 +161,7 @@ contract("AGIJobManager incentive hardening", (accounts) => {
 
     await manager.applyForJob(jobLarge, "agent-slow", EMPTY_PROOF, { from: agentSlow });
 
-    await expectCustomError(
-      manager.setAgentBond.call(bondSmall.add(toBN(toWei("50"))), { from: owner }),
-      "InvalidState"
-    );
+    await manager.setAgentBond(bondSmall.add(toBN(toWei("50"))), { from: owner });
     await manager.requestJobCompletion(jobSmall, "ipfs-small-complete", { from: agentFast });
     await time.increase(2);
     const beforeFinalize = await token.balanceOf(agentFast);

--- a/test/mainnetGovernanceAndOps.regression.test.js
+++ b/test/mainnetGovernanceAndOps.regression.test.js
@@ -72,8 +72,9 @@ contract('mainnet governance + ops regressions', (accounts) => {
     await expectCustomError(ctx.manager.setVoteQuorum.call(1, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setCompletionReviewPeriod.call(1, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setDisputeReviewPeriod.call(1, { from: owner }), 'InvalidState');
-    await expectCustomError(ctx.manager.setValidatorBondParams.call(100, 1, 1, { from: owner }), 'InvalidState');
-    await expectCustomError(ctx.manager.setAgentBondParams.call(100, 1, 1, { from: owner }), 'InvalidState');
+    await ctx.manager.setValidatorBondParams(100, 1, 1, { from: owner });
+    await ctx.manager.setAgentBondParams(100, 1, 1, { from: owner });
+    await ctx.manager.setAgentBond(1, { from: owner });
     await expectCustomError(ctx.manager.setValidatorSlashBps.call(100, { from: owner }), 'InvalidState');
     await expectCustomError(ctx.manager.setChallengePeriodAfterApproval.call(1, { from: owner }), 'InvalidState');
     const inFlightValidatorRoot = web3.utils.randomHex(32);

--- a/test/operationalDurability.test.js
+++ b/test/operationalDurability.test.js
@@ -1,0 +1,85 @@
+const { BN } = require('@openzeppelin/test-helpers');
+
+const AGIJobManager = artifacts.require('AGIJobManager');
+const MockERC20 = artifacts.require('MockERC20');
+const MockENS = artifacts.require('MockENS');
+const MockNameWrapper = artifacts.require('MockNameWrapper');
+const MockERC721 = artifacts.require('MockERC721');
+
+const { buildInitConfig } = require('./helpers/deploy');
+const { expectCustomError } = require('./helpers/errors');
+
+const ZERO32 = '0x' + '00'.repeat(32);
+const EMPTY_PROOF = [];
+
+contract('operational durability', (accounts) => {
+  const [owner, employer, agent] = accounts;
+
+  async function deployManager() {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const wrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(token.address, 'ipfs://base', ens.address, wrapper.address, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32, ZERO32),
+      { from: owner }
+    );
+    await manager.addAdditionalAgent(agent, { from: owner });
+    return { token, manager };
+  }
+
+  it('makes max active jobs per agent owner-configurable with validation', async () => {
+    const { token, manager } = await deployManager();
+    const payout = web3.utils.toWei('1');
+    const agiType = await MockERC721.new({ from: owner });
+    await agiType.mint(agent, { from: owner });
+    await manager.addAGIType(agiType.address, 1, { from: owner });
+
+    await expectCustomError(manager.setMaxActiveJobsPerAgent.call(0, { from: owner }), 'InvalidParameters');
+    await expectCustomError(manager.setMaxActiveJobsPerAgent.call(10001, { from: owner }), 'InvalidParameters');
+
+    await token.mint(employer, web3.utils.toWei('10'), { from: owner });
+    await token.approve(manager.address, web3.utils.toWei('10'), { from: employer });
+
+    for (let i = 0; i < 4; i += 1) {
+      await manager.createJob(`ipfs://spec-${i}`, payout, 1000, 'details', { from: employer });
+    }
+
+    await manager.setAgentBondParams(0, 0, 0, { from: owner });
+    await manager.applyForJob(0, 'agent', EMPTY_PROOF, { from: agent });
+    await manager.applyForJob(1, 'agent', EMPTY_PROOF, { from: agent });
+    await manager.applyForJob(2, 'agent', EMPTY_PROOF, { from: agent });
+    await expectCustomError(manager.applyForJob.call(3, 'agent', EMPTY_PROOF, { from: agent }), 'InvalidState');
+
+    const tx = await manager.setMaxActiveJobsPerAgent(4, { from: owner });
+    const evt = tx.logs.find((log) => log.event === 'MaxActiveJobsPerAgentUpdated');
+    assert.equal(evt.args.oldValue.toString(), '3');
+    assert.equal(evt.args.newValue.toString(), '4');
+    assert.equal((await manager.maxActiveJobsPerAgent()).toString(), '4');
+
+    await manager.applyForJob(3, 'agent', EMPTY_PROOF, { from: agent });
+  });
+
+  it('allows bond parameter updates while escrow is locked for in-flight jobs', async () => {
+    const { token, manager } = await deployManager();
+    const payout = web3.utils.toWei('2');
+
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+    await manager.createJob('ipfs://spec', payout, 1000, 'details', { from: employer });
+
+    assert((await manager.lockedEscrow()).gt(new BN('0')), 'precondition: escrow should be locked');
+
+    // Pre-change these owner operations reverted with InvalidState due to _requireEmptyEscrow().
+    await manager.setAgentBondParams(600, web3.utils.toWei('2'), web3.utils.toWei('20'), { from: owner });
+    await manager.setAgentBond(web3.utils.toWei('3'), { from: owner });
+    await manager.setValidatorBondParams(1700, web3.utils.toWei('2'), web3.utils.toWei('30'), { from: owner });
+
+    assert.equal((await manager.agentBondBps()).toString(), '600');
+    assert.equal((await manager.agentBond()).toString(), web3.utils.toWei('3'));
+    assert.equal((await manager.agentBondMax()).toString(), web3.utils.toWei('20'));
+    assert.equal((await manager.validatorBondBps()).toString(), '1700');
+    assert.equal((await manager.validatorBondMin()).toString(), web3.utils.toWei('2'));
+    assert.equal((await manager.validatorBondMax()).toString(), web3.utils.toWei('30'));
+  });
+
+});


### PR DESCRIPTION
### Motivation
- Operator-facing durability changes make some operational knobs (e.g. per-agent concurrency and bond parameters) owner-tunable without requiring an empty escrow, and tests/ABI needed to be aligned with that behavior.
- The test suite and UI ABI were failing because of the new stateful `maxActiveJobsPerAgent` and relaxed escrow-gating for bond/operational setters.

### Description
- Exposed `maxActiveJobsPerAgent` as a public `uint256` and added `setMaxActiveJobsPerAgent(uint256)` with validation and `MaxActiveJobsPerAgentUpdated` event, replacing the prior internal constant.
- Relaxed escrow gating for operational setters by removing `_requireEmptyEscrow()` where appropriate, tightened `setAgentBond` validation, and added owner-side setter behavior that works while escrow is non-empty.
- Updated the Foundry harness getter (`maxActiveJobsPerAgentView()`) to be `view`, regenerated the UI ABI (`docs/ui/abi/AGIJobManager.json`), and added `docs/REFERENCE/OPERATIONAL_LIMITS.md` documenting the new operator model.
- Aligned tests to the new behavior by updating `test/incentiveHardening.test.js`, adjusting `test/mainnetGovernanceAndOps.regression.test.js`, and adding `test/operationalDurability.test.js` to exercise the new operational durability surface.

### Testing
- Ran `npm run build` (Truffle compile) and `npm run ui:abi` successfully to regenerate artifacts and the exported ABI.
- Ran the full test matrix via `npm run test` (which executes Truffle tests, Node-based tests, and contract size checks) and achieved a clean suite with all automated tests passing (`356 passing`, `0 failing`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a063f69e48333874ec5b42b07c27d)