### PR TITLE
Align ENS docs with durable Merkle rotation and strengthen concurrency test

### DIFF
--- a/docs/INTEGRATIONS/ENS.md
+++ b/docs/INTEGRATIONS/ENS.md
@@ -1,5 +1,8 @@
 # ENS Integration (AGIJobManager)
 
+> **Intended operations model: AI agents exclusively.** Human operators provide governance and oversight; routine protocol participation is for autonomous AI agents.
+
+
 This guide documents the **actual ENS integration surface** of AGIJobManager and separates on-chain enforcement from off-chain operator duties.
 
 > **Operator note**
@@ -61,7 +64,7 @@ flowchart TD
 | `ens` | `ENS public ens` in `AGIJobManager` | `onlyOwner` via `updateEnsRegistry` | `ens()` + `EnsRegistryUpdated` | Blocked by `lockIdentityConfiguration`; requires `_requireEmptyEscrow()` | Must be non-zero contract (`code.length > 0`) |
 | `nameWrapper` | `NameWrapper public nameWrapper` | `onlyOwner` via `updateNameWrapper` | `nameWrapper()` + `NameWrapperUpdated` | Blocked by lock; requires empty escrow | `0x0` disables wrapper path and leaves resolver fallback |
 | Root nodes | `clubRootNode`, `agentRootNode`, `alphaClubRootNode`, `alphaAgentRootNode` | `onlyOwner` via `updateRootNodes` | root getters + `RootNodesUpdated` | Blocked by lock; requires empty escrow | Misconfigured nodes can deny valid users or admit wrong namespace |
-| Merkle roots | `validatorMerkleRoot`, `agentMerkleRoot` | `onlyOwner` via `updateMerkleRoots` | getters + `MerkleRootsUpdated` | Blocked by `lockIdentityConfiguration`; requires empty escrow | Emergency fallback **only before lock**; after lock use allowlists/blocklists + pause controls |
+| Merkle roots | `validatorMerkleRoot`, `agentMerkleRoot` | `onlyOwner` via `updateMerkleRoots` | getters + `MerkleRootsUpdated` | Always owner-updateable (not blocked by lock or escrow) | Primary long-lived allowlist governance lever; preserve prior authorized AI agents/validators unless intentionally removing access |
 | ENS hook target | `address public ensJobPages` | `onlyOwner` via `setEnsJobPages` | `ensJobPages()` + `EnsJobPagesUpdated` | Blocked by lock | Hook failures are intentionally non-fatal |
 | ENS URI toggle | `bool private useEnsJobTokenURI` | `onlyOwner` via `setUseEnsJobTokenURI` | Observe `NFTIssued` URI and `tokenURI(tokenId)` | Not blocked by identity lock | Enable only after hook target hardening |
 | Identity lock | `bool public lockIdentityConfig` | `onlyOwner` via `lockIdentityConfiguration` | `lockIdentityConfig()` + `IdentityConfigurationLocked` | Irreversible | Freezes token/ENS/wrapper/root/hook wiring |
@@ -70,7 +73,7 @@ flowchart TD
 > `updateAGITokenAddress`, `updateEnsRegistry`, `updateNameWrapper`, and `updateRootNodes` all enforce `_requireEmptyEscrow()` before allowing changes. See [`contracts/AGIJobManager.sol`](../../contracts/AGIJobManager.sol).
 
 > **Operator note**
-> `lockIdentityConfiguration()` is not a full governance lock, but it **does** freeze ENS/identity rewiring including Merkle updates because `updateMerkleRoots` is guarded by `whenIdentityConfigurable`. Post-lock, operators still retain allowlist/blocklist and pause controls. See [`whenIdentityConfigurable`](../../contracts/AGIJobManager.sol#L300-L302), [`updateMerkleRoots`](../../contracts/AGIJobManager.sol#L816-L825), [`addAdditionalValidator`](../../contracts/AGIJobManager.sol#L374-L377), [`blacklistAgent`](../../contracts/AGIJobManager.sol#L754-L757), and pause controls in [`AGIJobManager.sol`](../../contracts/AGIJobManager.sol#L458-L478).
+> `lockIdentityConfiguration()` is not a full governance lock. It freezes ENS/identity rewiring guarded by `whenIdentityConfigurable`, but `updateMerkleRoots` remains intentionally owner-callable for long-lived AI-agent allowlist operations even after lock and during active escrow. See [`whenIdentityConfigurable`](../../contracts/AGIJobManager.sol#L558-L561), [`updateMerkleRoots`](../../contracts/AGIJobManager.sol#L1074-L1082), [`addAdditionalValidator`](../../contracts/AGIJobManager.sol#L951-L954), [`blacklistAgent`](../../contracts/AGIJobManager.sol#L1011-L1014), and pause controls in [`AGIJobManager.sol`](../../contracts/AGIJobManager.sol#L705-L721).
 
 ## Runtime authorization model
 

--- a/test/operationalDurability.test.js
+++ b/test/operationalDurability.test.js
@@ -34,6 +34,8 @@ contract('operational durability', (accounts) => {
     await agiType.mint(agent, { from: owner });
     await manager.addAGIType(agiType.address, 1, { from: owner });
 
+    assert.equal((await manager.maxActiveJobsPerAgent()).toString(), '3');
+
     await expectCustomError(manager.setMaxActiveJobsPerAgent.call(0, { from: owner }), 'InvalidParameters');
     await expectCustomError(manager.setMaxActiveJobsPerAgent.call(10001, { from: owner }), 'InvalidParameters');
 


### PR DESCRIPTION
### Motivation
- Prevent operator dead-ends by documenting that `updateMerkleRoots` is an always-available owner lever for long-lived allowlist rotation (not blocked by identity lock or empty escrow). 
- Harden operational regression coverage for the owner-configurable per-agent concurrency cap to avoid accidental regressions. 
- Make minimal, surgical changes (docs + one test) so runtime bytecode and contract semantics remain unchanged.

### Description
- Updated `docs/INTEGRATIONS/ENS.md` to document that `validatorMerkleRoot` / `agentMerkleRoot` are owner-updateable at any time and added an explicit “AI agents exclusively” callout. 
- Updated `docs/INTEGRATIONS/ENS_ROBUSTNESS.md` to remove stale guidance requiring unlocked/empty-escrow for Merkle rotations and to update the incident/runbook to prefer rotating Merkle roots for continuity. 
- Added a single assertion in `test/operationalDurability.test.js` to assert the default `maxActiveJobsPerAgent` is `3` before owner reconfiguration. 
- No Solidity contract source was changed; safety-critical caps and behaviors (e.g., `MAX_VALIDATORS_PER_JOB`, `MAX_AGI_TYPES`) were preserved and no new events/errors were added.

### Testing
- Ran `npm ci` and `npm run build` successfully. 
- Ran targeted tests with `npx truffle test test/operationalDurability.test.js test/agiTypes.safety.test.js test/merkleRoots.operational.test.js --network test` and all tests passed. 
- Ran full test driver `npm test` (Truffle suite + node checks) and the suite completed successfully; the bytecode size guard `npm run size` passed (AGIJobManager runtime bytecode: 24547 bytes). 
- Regenerated and validated docs with `npm run docs:gen`, `npm run docs:ens:gen`, `npm run docs:check`, and `npm run docs:ens:check`, all of which passed. 

The changes are intentionally minimal and surgical: only docs and one test line were modified to reflect and protect current on-chain operational durability guarantees.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a403248a4833394aabb825138d9fe)