### PR TITLE
docs: add institutional Owner Mainnet Deployment & Operations Guide (Etherscan-first)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -19,7 +19,7 @@ Institutional documentation for operators, integrators, contributors, and audito
 - [QUINTESSENTIAL_USE_CASE.md](./QUINTESSENTIAL_USE_CASE.md)
 - [ARCHITECTURE.md](./ARCHITECTURE.md)
 - [DEPLOYMENT_OPERATIONS.md](./DEPLOYMENT_OPERATIONS.md)
-- [Owner Mainnet Deployment & Operations Guide](./DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md)
+- [Owner Mainnet Deployment & Operations Guide](./DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md) (non-technical, Etherscan-first, web-only operations)
 - [SCRIPTS_REFERENCE.md](./SCRIPTS_REFERENCE.md)
 - [CONTRACTS/AGIJobManager.md](./CONTRACTS/AGIJobManager.md)
 - [CONTRACTS/INTEGRATIONS.md](./CONTRACTS/INTEGRATIONS.md)


### PR DESCRIPTION
### Motivation
- Provide a non-technical, institutional-grade Owner Deployment & Operations Guide tailored to web-only workflows (Etherscan-first) for owners who manage AGIJobManager on Ethereum Mainnet. 
- Reflect exact on-chain behavior by reading `contracts/AGIJobManager.sol` and the repo migration workflow so owner instructions match real preconditions (empty-escrow, identity lock, settlement pause, etc.).
- Keep contracts read-only and remain CI-friendly and deterministic per repository documentation conventions.

### Description
- Replaced and rewrote `docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md` with a 14-section, owner-focused guide that includes definitions, a capability table derived from contract code, Etherscan-first procedures, a Truffle migration (#6) deployment walkthrough, Mermaid diagrams, deterministic Merkle tooling references (`scripts/merkle/*`), a full parameter catalog and troubleshooting. No Solidity sources were changed. 
- Updated `docs/README.md` to surface the owner guide and label it as non-technical and Etherscan-first. 
- The guide references the actual mainnet deployment migration (`migrations/6_deploy_agijobmanager_production_operator.js`) and the config template (`migrations/config/agijobmanager.config.example.js`) and documents exact copy/paste commands for `npm ci`, `npx truffle compile`, and `npx truffle migrate --network mainnet --f 6 --to 6` along with required environment variables and dry-run options.

### Testing
- Ran `npm ci` to install dependencies successfully. 
- Ran `npm run docs:check` and received passing documentation checks (ENS checks and docs integrity passed).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6030d35883339bcdbfd8672386c4)