### PR TITLE
docs: add institutional Owner Mainnet Deployment & Operations guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ AGIJobManager is a single Solidity contract for escrowed AGI work agreements.
 - Terms & Conditions authority note: [`docs/LEGAL/TERMS_AND_CONDITIONS.md`](docs/LEGAL/TERMS_AND_CONDITIONS.md)
 - Etherscan user guide: [`docs/ETHERSCAN_GUIDE.md`](docs/ETHERSCAN_GUIDE.md)
 - Owner/operator runbook: [`docs/OWNER_RUNBOOK.md`](docs/OWNER_RUNBOOK.md)
-- Owner Mainnet Deployment & Operations Guide: [`docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md`](docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md)
+- Owner Mainnet Deployment & Operations Guide (institutional, web-only operations focus): [`docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md`](docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md)
 - Moderator runbook: [`docs/MODERATOR_RUNBOOK.md`](docs/MODERATOR_RUNBOOK.md)
 - Contract verification guide: [`docs/VERIFY_ON_ETHERSCAN.md`](docs/VERIFY_ON_ETHERSCAN.md)
 - FAQ: [`docs/FAQ.md`](docs/FAQ.md)


### PR DESCRIPTION
### Motivation
- Provide a non-technical, institutional-grade Owner Deployment & Operations Guide that explains how to deploy AGIJobManager to Ethereum Mainnet and operate owner controls safely using web UIs (Etherscan as primary reference). 
- Make owner capabilities, preconditions (empty-escrow, `lockIdentityConfig`, `paused`/`settlementPaused`), multisig vs EOA workflows, and the Truffle migration process explicit and discoverable. 
- Keep the codebase unchanged for contracts while improving on-call and handover documentation for owners and operators.

### Description
- Added `docs/DEPLOYMENT/OWNER_MAINNET_DEPLOYMENT_AND_OPERATIONS_GUIDE.md`, a complete 14-section owner guide covering purpose, glossary, owner capability table (derived from `contracts/AGIJobManager.sol`), Etherscan-first procedures, Truffle mainnet migration (production migration `6`), merkle proof workflow, parameter catalog, diagrams, and troubleshooting. 
- Updated `README.md` to reference the new guide more prominently and label it as institutional and web-operations focused. 
- Documented the production migration file as `migrations/6_deploy_agijobmanager_production_operator.js` and the config template as `migrations/config/agijobmanager.config.example.js` and the expected working config `migrations/config/agijobmanager.config.js`. 
- No Solidity or runtime logic changes were made; guide text reflects on-chain behavior discovered in `contracts/AGIJobManager.sol` (owner-only functions such as `pause`, `pauseAll`, `setSettlementPaused`, `updateMerkleRoots`, `updateRootNodes`, `updateAGITokenAddress`, `lockIdentityConfiguration`, `withdrawAGI`, `rescueERC20`, etc., and modifiers/gates like `onlyOwner`, `whenIdentityConfigurable`, `whenSettlementNotPaused`, and the `_requireEmptyEscrow()` gate). 

### Testing
- Installed dependencies with `npm ci` and succeeded. 
- Ran documentation checks with `npm run docs:check` which succeeded. 
- Generated reference docs with `npm run docs:gen` and ENS reference with `npm run docs:ens:gen` and re-ran `npm run docs:check`, all of which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699a6030d35883339bcdbfd8672386c4)