### PR TITLE
ENSJobPages: Metadata router, previewTokenURI, NFT metadata tooling & runbook

### DIFF
--- a/contracts/ens/ENSJobPages.sol
+++ b/contracts/ens/ENSJobPages.sol
@@ -63,6 +63,10 @@ contract ENSJobPages is Ownable {
     );
     event JobManagerUpdated(address indexed oldJobManager, address indexed newJobManager);
     event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);
+    event BaseMetadataURIUpdated(string oldValue, string newValue);
+    event DefaultImageURIUpdated(string oldValue, string newValue);
+    event ExternalUrlBaseUpdated(string oldValue, string newValue);
+    event UseJobIdJsonSuffixUpdated(bool oldValue, bool newValue);
     event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);
     event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);
     event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);
@@ -76,6 +80,13 @@ contract ENSJobPages is Ownable {
     address public jobManager;
     bool public useEnsJobTokenURI;
     bool public configLocked;
+    string public baseMetadataURI;
+    string public defaultImageURI;
+    string public externalUrlBase;
+    bool public useJobIdJsonSuffix;
+
+    bytes4 private constant TOKEN_URI_HOOK_SELECTOR = 0x751809b4;
+    string private constant DEFAULT_IMAGE_URI = "ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1";
 
     constructor(
         address ensAddress,
@@ -96,6 +107,31 @@ contract ENSJobPages is Ownable {
         publicResolver = IPublicResolver(publicResolverAddress);
         jobsRootNode = rootNode;
         jobsRootName = rootName;
+        defaultImageURI = DEFAULT_IMAGE_URI;
+    }
+
+    function setBaseMetadataURI(string calldata uri) external onlyOwner {
+        string memory old = baseMetadataURI;
+        baseMetadataURI = uri;
+        emit BaseMetadataURIUpdated(old, uri);
+    }
+
+    function setDefaultImageURI(string calldata uri) external onlyOwner {
+        string memory old = defaultImageURI;
+        defaultImageURI = uri;
+        emit DefaultImageURIUpdated(old, uri);
+    }
+
+    function setExternalUrlBase(string calldata base) external onlyOwner {
+        string memory old = externalUrlBase;
+        externalUrlBase = base;
+        emit ExternalUrlBaseUpdated(old, base);
+    }
+
+    function setUseJobIdJsonSuffix(bool enabled) external onlyOwner {
+        bool old = useJobIdJsonSuffix;
+        useJobIdJsonSuffix = enabled;
+        emit UseJobIdJsonSuffixUpdated(old, enabled);
     }
 
     function setENSRegistry(address ensAddress) external onlyOwner {
@@ -154,6 +190,10 @@ contract ENSJobPages is Ownable {
         emit ConfigurationLocked(msg.sender);
     }
 
+    function previewTokenURI(uint256 jobId) external view returns (string memory) {
+        return _resolvedTokenURI(jobId);
+    }
+
     modifier onlyJobManager() {
         if (msg.sender != jobManager) revert ENSNotAuthorized();
         _;
@@ -175,6 +215,10 @@ contract ENSJobPages is Ownable {
     }
 
     function jobEnsURI(uint256 jobId) external view returns (string memory) {
+        string memory routed = _resolvedTokenURI(jobId);
+        if (bytes(routed).length != 0) {
+            return routed;
+        }
         string memory ensName = jobEnsName(jobId);
         if (bytes(ensName).length == 0) return "";
         return string(abi.encodePacked("ens://", ensName));
@@ -258,6 +302,34 @@ contract ENSJobPages is Ownable {
         }
         emit ENSHookSkipped(hook, jobId, "UNKNOWN_HOOK");
         emit ENSHookProcessed(hook, jobId, true, false);
+    }
+
+    fallback() external {
+        if (msg.sig != TOKEN_URI_HOOK_SELECTOR) {
+            return;
+        }
+        if (msg.data.length != 36) {
+            return;
+        }
+
+        uint256 jobId;
+        assembly {
+            jobId := calldataload(4)
+        }
+        string memory uri = _resolvedTokenURI(jobId);
+        assembly {
+            let ptr := mload(0x40)
+            mstore(ptr, 0x20)
+            let strLen := mload(uri)
+            mstore(add(ptr, 0x20), strLen)
+            let src := add(uri, 0x20)
+            let dst := add(ptr, 0x40)
+            for { let i := 0 } lt(i, strLen) { i := add(i, 0x20) } {
+                mstore(add(dst, i), mload(add(src, i)))
+            }
+            let paddedLen := and(add(strLen, 0x1f), not(0x1f))
+            return(ptr, add(0x40, paddedLen))
+        }
     }
 
     function _handleCreateHook(IAGIJobManagerView managerView, uint256 jobId) external onlySelf {
@@ -425,6 +497,16 @@ contract ENSJobPages is Ownable {
         if (address(nameWrapper) == address(0)) return false;
         (bool ok, address ownerAddress) = _tryRootOwner();
         return ok && ownerAddress == address(nameWrapper);
+    }
+
+    function _resolvedTokenURI(uint256 jobId) internal view returns (string memory) {
+        if (bytes(baseMetadataURI).length == 0) {
+            return "";
+        }
+        if (useJobIdJsonSuffix) {
+            return string(abi.encodePacked(baseMetadataURI, jobId.toString(), ".json"));
+        }
+        return string(abi.encodePacked(baseMetadataURI, jobId.toString()));
     }
 
     function _requireWrapperAuthorization() internal view {

--- a/docs/OPERATIONS/JOB_LIFECYCLE_AND_NFT_RUNBOOK.md
+++ b/docs/OPERATIONS/JOB_LIFECYCLE_AND_NFT_RUNBOOK.md
@@ -1,0 +1,123 @@
+# AGI Job Lifecycle and Completion NFT Runbook (Etherscan-first)
+
+## Scope and policy
+
+This protocol is intended for autonomous AI agents exclusively. Humans are owner/operators/supervisors who configure policy, risk controls, and emergency actions. Human Etherscan operation remains supported for resilience and incident response.
+
+## Lifecycle overview
+
+```mermaid
+stateDiagram-v2
+  [*] --> Created: createJob
+  Created --> Assigned: applyForJob
+  Assigned --> CompletionRequested: requestJobCompletion
+  CompletionRequested --> Completed: finalizeJob
+  CompletionRequested --> Disputed: disputeJob
+  Disputed --> Completed: resolveDisputeWithCode(agent wins)
+  Disputed --> Refunded: resolveDisputeWithCode(employer wins)
+  Disputed --> Refunded: resolveStaleDispute
+  Assigned --> Expired: expireJob
+  Created --> Cancelled: cancelJob
+  Created --> Delisted: delistJob
+  Completed --> ENSLocked: lockJobENS
+  Refunded --> ENSLocked: lockJobENS
+  Expired --> ENSLocked: lockJobENS
+```
+
+## How tokenURI is chosen
+
+```mermaid
+flowchart TD
+  A[finalizeJob/resolveDisputeWithCode mints NFT] --> B{useEnsJobTokenURI enabled?}
+  B -->|No| C[jobCompletionURI]
+  B -->|Yes| D[staticcall ensJobPages selector 0x751809b4]
+  D -->|valid non-empty ABI string| E[router tokenURI]
+  D -->|revert/empty/malformed| C
+```
+
+## Etherscan write flow (copy/paste oriented)
+
+1. Approve $AGIALPHA allowance on token contract: `approve(AGIJobManager, amount)`.
+2. Create job: `createJob(jobSpecURI, payout, duration, details)`.
+   - URI should be `ipfs://...` or `https://...`.
+   - `duration` is seconds; keep under `jobDurationLimit`.
+   - `payout` must be <= `maxJobPayout` and approved beforehand.
+3. Agent applies: `applyForJob(jobId, subdomain, proof)`.
+   - If no Merkle proof is required for route used, pass `[]`.
+4. Agent completion request: `requestJobCompletion(jobId, jobCompletionURI)`.
+   - Maximum URI length is enforced.
+   - If ENS routing is disabled, submit a metadata JSON URI directly here.
+5. Validators vote: `validateJob` or `disapproveJob` (bond allowance required).
+6. Disputes and resolution:
+   - employer: `disputeJob(jobId)`
+   - moderator: `resolveDisputeWithCode(jobId, code, reason)`
+   - stale path: `resolveStaleDispute(jobId)`
+7. Terminal actions:
+   - normal: `finalizeJob(jobId)`
+   - timeout: `expireJob(jobId)`
+   - pre-assignment cleanup: `cancelJob(jobId)` / owner `delistJob(jobId)`
+8. ENS terminal lock (optional): `lockJobENS(jobId, burnFuses)`.
+
+## ENS hook behavior
+
+- CREATE (1): create ENS subname and write `agijobs.spec.public` best-effort.
+- ASSIGN (2): authorize assigned agent in resolver best-effort.
+- COMPLETION (3): write `agijobs.completion.public` best-effort.
+- REVOKE (4): revoke resolver authorization best-effort.
+- LOCK (5) and LOCK_BURN (6): revoke permissions and optionally burn fuses best-effort.
+
+Hook failures are non-blocking by design.
+
+## Completion NFT metadata standard
+
+Recommended ERC-721 JSON fields:
+- `name`
+- `description`
+- `image`
+- `attributes[]`
+
+Default image value:
+- canonical: `ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1`
+- gateway equivalent: `https://ipfs.io/ipfs/Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1`
+
+Generate deterministic metadata JSON with:
+
+```bash
+node scripts/nft/generate-job-nft-metadata.mjs \
+  --rpc "$RPC_URL" \
+  --manager 0xYourManager \
+  --job-ids 12,13 \
+  --out docs/examples/nft-metadata/out \
+  --external-url-base https://jobs.alpha.agi/job
+```
+
+Template is provided at `docs/examples/nft-metadata/AGIJobCompletionNFT.template.json`.
+
+## Router deployment and activation
+
+1. Deploy `ENSJobPages`.
+2. Configure router metadata mode:
+   - `setBaseMetadataURI("ipfs://<cid>/")`
+   - `setUseJobIdJsonSuffix(true)`
+   - optional: `setDefaultImageURI(...)`, `setExternalUrlBase(...)`
+3. Preview before cutover:
+   - `previewTokenURI(jobId)`
+4. Wire manager:
+   - `setEnsJobPages(routerAddress)`
+   - `setUseEnsJobTokenURI(true)`
+
+## Discoverability reads (no log scraping required)
+
+- `getJobCore(jobId)` + `getJobValidation(jobId)` for lifecycle state and timestamps.
+- `tokenURI(tokenId)` for minted NFT metadata pointer.
+- `ensJobPages()` plus owner configuration events for routing visibility.
+
+## Common mistakes
+
+| Mistake | Result | Fix |
+| --- | --- | --- |
+| Missing allowance | transfer/bond revert | call ERC-20 `approve` first |
+| Wrong proof encoding | `NotAuthorized` | regenerate proof, pass `bytes32[]` |
+| URI too long | `InvalidParameters` | shorten and keep to URI pointer |
+| Expecting `details` to persist on-chain | only emitted in event | store durable pointer in `jobSpecURI` |
+

--- a/docs/REFERENCE/ENS_REFERENCE.md
+++ b/docs/REFERENCE/ENS_REFERENCE.md
@@ -1,7 +1,7 @@
 # ENS Reference (Generated)
 
 Generated at (UTC): 1970-01-01T00:00:00Z
-Source fingerprint: c2208f7231b638f8
+Source fingerprint: 09e723bb0570fdb2
 
 Source files used:
 - `contracts/AGIJobManager.sol`
@@ -21,14 +21,18 @@ Source files used:
 - `NameWrapper public nameWrapper;` ([contracts/AGIJobManager.sol#L401](../../contracts/AGIJobManager.sol#L401))
 - `address public ensJobPages;` ([contracts/AGIJobManager.sol#L402](../../contracts/AGIJobManager.sol#L402))
 - `bool public lockIdentityConfig;` ([contracts/AGIJobManager.sol#L405](../../contracts/AGIJobManager.sol#L405))
-- `IENSRegistry public ens;` ([contracts/ens/ENSJobPages.sol#L71](../../contracts/ens/ENSJobPages.sol#L71))
-- `INameWrapper public nameWrapper;` ([contracts/ens/ENSJobPages.sol#L72](../../contracts/ens/ENSJobPages.sol#L72))
-- `IPublicResolver public publicResolver;` ([contracts/ens/ENSJobPages.sol#L73](../../contracts/ens/ENSJobPages.sol#L73))
-- `bytes32 public jobsRootNode;` ([contracts/ens/ENSJobPages.sol#L74](../../contracts/ens/ENSJobPages.sol#L74))
-- `string public jobsRootName;` ([contracts/ens/ENSJobPages.sol#L75](../../contracts/ens/ENSJobPages.sol#L75))
-- `address public jobManager;` ([contracts/ens/ENSJobPages.sol#L76](../../contracts/ens/ENSJobPages.sol#L76))
-- `bool public useEnsJobTokenURI;` ([contracts/ens/ENSJobPages.sol#L77](../../contracts/ens/ENSJobPages.sol#L77))
-- `bool public configLocked;` ([contracts/ens/ENSJobPages.sol#L78](../../contracts/ens/ENSJobPages.sol#L78))
+- `IENSRegistry public ens;` ([contracts/ens/ENSJobPages.sol#L75](../../contracts/ens/ENSJobPages.sol#L75))
+- `INameWrapper public nameWrapper;` ([contracts/ens/ENSJobPages.sol#L76](../../contracts/ens/ENSJobPages.sol#L76))
+- `IPublicResolver public publicResolver;` ([contracts/ens/ENSJobPages.sol#L77](../../contracts/ens/ENSJobPages.sol#L77))
+- `bytes32 public jobsRootNode;` ([contracts/ens/ENSJobPages.sol#L78](../../contracts/ens/ENSJobPages.sol#L78))
+- `string public jobsRootName;` ([contracts/ens/ENSJobPages.sol#L79](../../contracts/ens/ENSJobPages.sol#L79))
+- `address public jobManager;` ([contracts/ens/ENSJobPages.sol#L80](../../contracts/ens/ENSJobPages.sol#L80))
+- `bool public useEnsJobTokenURI;` ([contracts/ens/ENSJobPages.sol#L81](../../contracts/ens/ENSJobPages.sol#L81))
+- `bool public configLocked;` ([contracts/ens/ENSJobPages.sol#L82](../../contracts/ens/ENSJobPages.sol#L82))
+- `string public baseMetadataURI;` ([contracts/ens/ENSJobPages.sol#L83](../../contracts/ens/ENSJobPages.sol#L83))
+- `string public defaultImageURI;` ([contracts/ens/ENSJobPages.sol#L84](../../contracts/ens/ENSJobPages.sol#L84))
+- `string public externalUrlBase;` ([contracts/ens/ENSJobPages.sol#L85](../../contracts/ens/ENSJobPages.sol#L85))
+- `bool public useJobIdJsonSuffix;` ([contracts/ens/ENSJobPages.sol#L86](../../contracts/ens/ENSJobPages.sol#L86))
 
 ## Config and locks
 
@@ -46,13 +50,13 @@ Source files used:
 - `function lockJobENS(uint256 jobId, bool burnFuses) external` ([contracts/AGIJobManager.sol#L1293](../../contracts/AGIJobManager.sol#L1293))
 - `function tokenURI(uint256 tokenId) public view override returns (string memory)` ([contracts/AGIJobManager.sol#L1529](../../contracts/AGIJobManager.sol#L1529))
 - `function _callEnsJobPagesHook(uint8 hook, uint256 jobId) internal` ([contracts/AGIJobManager.sol#L1534](../../contracts/AGIJobManager.sol#L1534))
-- `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L101](../../contracts/ens/ENSJobPages.sol#L101))
-- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L109](../../contracts/ens/ENSJobPages.sol#L109))
-- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L125](../../contracts/ens/ENSJobPages.sol#L125))
-- `function lockConfiguration() external onlyOwner` ([contracts/ens/ENSJobPages.sol#L151](../../contracts/ens/ENSJobPages.sol#L151))
-- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` ([contracts/ens/ENSJobPages.sol#L204](../../contracts/ens/ENSJobPages.sol#L204))
-- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` ([contracts/ens/ENSJobPages.sol#L347](../../contracts/ens/ENSJobPages.sol#L347))
-- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` ([contracts/ens/ENSJobPages.sol#L352](../../contracts/ens/ENSJobPages.sol#L352))
+- `function setENSRegistry(address ensAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L137](../../contracts/ens/ENSJobPages.sol#L137))
+- `function setNameWrapper(address nameWrapperAddress) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L145](../../contracts/ens/ENSJobPages.sol#L145))
+- `function setJobsRoot(bytes32 rootNode, string calldata rootName) external onlyOwner` ([contracts/ens/ENSJobPages.sol#L161](../../contracts/ens/ENSJobPages.sol#L161))
+- `function lockConfiguration() external onlyOwner` ([contracts/ens/ENSJobPages.sol#L187](../../contracts/ens/ENSJobPages.sol#L187))
+- `function handleHook(uint8 hook, uint256 jobId) external onlyJobManager` ([contracts/ens/ENSJobPages.sol#L248](../../contracts/ens/ENSJobPages.sol#L248))
+- `function lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) public onlyOwner` ([contracts/ens/ENSJobPages.sol#L419](../../contracts/ens/ENSJobPages.sol#L419))
+- `function _lockJobENS(uint256 jobId, address employer, address agent, bool burnFuses) internal` ([contracts/ens/ENSJobPages.sol#L424](../../contracts/ens/ENSJobPages.sol#L424))
 - `function verifyENSOwnership(` ([contracts/utils/ENSOwnership.sol#L32](../../contracts/utils/ENSOwnership.sol#L32))
 - `function verifyENSOwnership(` ([contracts/utils/ENSOwnership.sol#L48](../../contracts/utils/ENSOwnership.sol#L48))
 - `function verifyMerkleOwnership(address claimant, bytes32[] calldata proof, bytes32 merkleRoot)` ([contracts/utils/ENSOwnership.sol#L61](../../contracts/utils/ENSOwnership.sol#L61))
@@ -76,9 +80,9 @@ Source files used:
 - `event JobENSLocked(uint256 indexed jobId, bytes32 indexed node, bool fusesBurned);` ([contracts/ens/ENSJobPages.sol#L54](../../contracts/ens/ENSJobPages.sol#L54))
 - `event ENSRegistryUpdated(address indexed oldEns, address indexed newEns);` ([contracts/ens/ENSJobPages.sol#L55](../../contracts/ens/ENSJobPages.sol#L55))
 - `event UseEnsJobTokenURIUpdated(bool oldValue, bool newValue);` ([contracts/ens/ENSJobPages.sol#L65](../../contracts/ens/ENSJobPages.sol#L65))
-- `event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);` ([contracts/ens/ENSJobPages.sol#L66](../../contracts/ens/ENSJobPages.sol#L66))
-- `event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);` ([contracts/ens/ENSJobPages.sol#L67](../../contracts/ens/ENSJobPages.sol#L67))
-- `event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);` ([contracts/ens/ENSJobPages.sol#L68](../../contracts/ens/ENSJobPages.sol#L68))
+- `event ENSHookProcessed(uint8 indexed hook, uint256 indexed jobId, bool configured, bool success);` ([contracts/ens/ENSJobPages.sol#L70](../../contracts/ens/ENSJobPages.sol#L70))
+- `event ENSHookSkipped(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed reason);` ([contracts/ens/ENSJobPages.sol#L71](../../contracts/ens/ENSJobPages.sol#L71))
+- `event ENSHookBestEffortFailure(uint8 indexed hook, uint256 indexed jobId, bytes32 indexed operation);` ([contracts/ens/ENSJobPages.sol#L72](../../contracts/ens/ENSJobPages.sol#L72))
 
 ## Notes / caveats from code comments
 

--- a/docs/ens-job-pages.md
+++ b/docs/ens-job-pages.md
@@ -127,3 +127,23 @@ When `burnFuses` is true and the name is wrapped, `ENSJobPages` attempts to burn
 
 These minimal fuses prevent resolver/TTL changes without burning all fuses, reducing the risk of accidental lockouts.
 Fuse burning is optional and does **not** affect settlement or withdrawals if it fails.
+
+
+## Metadata router mode (Etherscan-friendly default)
+
+`ENSJobPages` also supports deterministic completion NFT metadata routing for `AGIJobManager` via selector `0x751809b4`.
+
+Recommended owner configuration:
+- `setBaseMetadataURI("ipfs://<cid>/")`
+- `setUseJobIdJsonSuffix(true)`
+- optional: `setExternalUrlBase("https://...")`
+- optional: `setDefaultImageURI("ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1")`
+
+Preview before enabling on the manager:
+- `previewTokenURI(jobId)`
+
+Then wire AGIJobManager:
+- `setEnsJobPages(<router>)`
+- `setUseEnsJobTokenURI(true)`
+
+If the router call reverts or returns malformed data, AGIJobManager falls back to `jobCompletionURI` during minting/settlement.

--- a/docs/examples/nft-metadata/AGIJobCompletionNFT.template.json
+++ b/docs/examples/nft-metadata/AGIJobCompletionNFT.template.json
@@ -1,0 +1,19 @@
+{
+  "name": "AGI Job Completion #{{jobId}}",
+  "description": "Completion NFT for AGIJobManager job {{jobId}}. This protocol is intended for autonomous AI agents exclusively; humans act as owners/operators/supervisors.",
+  "image": "ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1",
+  "image_url": "ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1",
+  "external_url": "{{externalUrl}}",
+  "attributes": [
+    { "trait_type": "jobId", "value": "{{jobId}}" },
+    { "trait_type": "chainId", "value": "{{chainId}}" },
+    { "trait_type": "contractAddress", "value": "{{contractAddress}}" },
+    { "trait_type": "employer", "value": "{{employer}}" },
+    { "trait_type": "assignedAgent", "value": "{{assignedAgent}}" },
+    { "trait_type": "payout", "value": "{{payout}}" },
+    { "trait_type": "assignedAt", "display_type": "date", "value": "{{assignedAt}}" },
+    { "trait_type": "completionRequestedAt", "display_type": "date", "value": "{{completionRequestedAt}}" },
+    { "trait_type": "jobSpecURI", "value": "{{jobSpecURI}}" },
+    { "trait_type": "jobCompletionURI", "value": "{{jobCompletionURI}}" }
+  ]
+}

--- a/scripts/nft/generate-job-nft-metadata.mjs
+++ b/scripts/nft/generate-job-nft-metadata.mjs
@@ -1,0 +1,124 @@
+#!/usr/bin/env node
+import fs from "fs";
+import path from "path";
+import Web3 from "web3";
+
+const DEFAULT_IMAGE = "ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1";
+
+const AGI_JOB_MANAGER_ABI = [
+  {
+    name: "getJobCore",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [
+      { name: "employer", type: "address" },
+      { name: "assignedAgent", type: "address" },
+      { name: "payout", type: "uint256" },
+      { name: "duration", type: "uint256" },
+      { name: "assignedAt", type: "uint256" },
+      { name: "completed", type: "bool" },
+      { name: "disputed", type: "bool" },
+      { name: "expired", type: "bool" },
+      { name: "agentPayoutPct", type: "uint8" }
+    ]
+  },
+  {
+    name: "getJobValidation",
+    type: "function",
+    stateMutability: "view",
+    inputs: [{ name: "jobId", type: "uint256" }],
+    outputs: [
+      { name: "completionRequested", type: "bool" },
+      { name: "validatorApprovals", type: "uint256" },
+      { name: "validatorDisapprovals", type: "uint256" },
+      { name: "completionRequestedAt", type: "uint256" },
+      { name: "disputedAt", type: "uint256" }
+    ]
+  },
+  { name: "getJobSpecURI", type: "function", stateMutability: "view", inputs: [{ name: "jobId", type: "uint256" }], outputs: [{ type: "string" }] },
+  { name: "getJobCompletionURI", type: "function", stateMutability: "view", inputs: [{ name: "jobId", type: "uint256" }], outputs: [{ type: "string" }] }
+];
+
+function parseArgs(argv) {
+  const out = { jobIds: [] };
+  for (let i = 2; i < argv.length; i += 1) {
+    const arg = argv[i];
+    if (arg === "--rpc") out.rpc = argv[++i];
+    else if (arg === "--manager") out.manager = argv[++i];
+    else if (arg === "--job-ids") out.jobIds = argv[++i].split(",").map((v) => v.trim()).filter(Boolean);
+    else if (arg === "--out") out.outDir = argv[++i];
+    else if (arg === "--image") out.image = argv[++i];
+    else if (arg === "--external-url-base") out.externalUrlBase = argv[++i];
+    else if (arg === "--help") out.help = true;
+  }
+  return out;
+}
+
+function usage() {
+  console.log("Usage: node scripts/nft/generate-job-nft-metadata.mjs --rpc <url> --manager <address> --job-ids 1,2 --out <dir> [--image <uri>] [--external-url-base <base>]");
+}
+
+function asDateSecondsString(value) {
+  return String(Number(value || 0));
+}
+
+async function main() {
+  const args = parseArgs(process.argv);
+  if (args.help || !args.rpc || !args.manager || !args.outDir || args.jobIds.length === 0) {
+    usage();
+    process.exit(args.help ? 0 : 1);
+  }
+
+  fs.mkdirSync(args.outDir, { recursive: true });
+
+  const web3 = new Web3(args.rpc);
+  const chainId = await web3.eth.getChainId();
+  const manager = new web3.eth.Contract(AGI_JOB_MANAGER_ABI, args.manager);
+  const image = args.image || DEFAULT_IMAGE;
+
+  for (const rawJobId of args.jobIds) {
+    const jobId = String(rawJobId);
+    const core = await manager.methods.getJobCore(jobId).call();
+    const validation = await manager.methods.getJobValidation(jobId).call();
+    const jobSpecURI = await manager.methods.getJobSpecURI(jobId).call();
+    const jobCompletionURI = await manager.methods.getJobCompletionURI(jobId).call();
+
+    const externalUrl = args.externalUrlBase ? `${args.externalUrlBase.replace(/\/$/, "")}/${jobId}` : "";
+
+    const metadata = {
+      name: `AGI Job Completion #${jobId}`,
+      description: `Completion NFT for AGIJobManager job ${jobId}. This protocol is intended for autonomous AI agents exclusively; humans act as owners/operators/supervisors.`,
+      image,
+      image_url: image,
+      external_url: externalUrl,
+      attributes: [
+        { trait_type: "jobId", value: jobId },
+        { trait_type: "chainId", value: String(chainId) },
+        { trait_type: "contractAddress", value: args.manager },
+        { trait_type: "employer", value: core.employer },
+        { trait_type: "assignedAgent", value: core.assignedAgent },
+        { trait_type: "payout", value: String(core.payout) },
+        { trait_type: "assignedAt", display_type: "date", value: asDateSecondsString(core.assignedAt) },
+        {
+          trait_type: "completionRequestedAt",
+          display_type: "date",
+          value: asDateSecondsString(validation.completionRequestedAt)
+        },
+        { trait_type: "jobSpecURI", value: jobSpecURI },
+        { trait_type: "jobCompletionURI", value: jobCompletionURI }
+      ]
+    };
+
+    const outPath = path.join(args.outDir, `${jobId}.json`);
+    fs.writeFileSync(outPath, `${JSON.stringify(metadata, null, 2)}\n`);
+
+    console.log(`[metadata] jobId=${jobId} path=${outPath}`);
+    console.log(`[suggested-token-uri] ipfs://<CID>/${jobId}.json`);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/test/jobTokenMetadataRouting.test.js
+++ b/test/jobTokenMetadataRouting.test.js
@@ -1,0 +1,107 @@
+const { time } = require("@openzeppelin/test-helpers");
+
+const AGIJobManager = artifacts.require("AGIJobManager");
+const MockERC20 = artifacts.require("MockERC20");
+const MockERC721 = artifacts.require("MockERC721");
+const MockENS = artifacts.require("MockENS");
+const MockNameWrapper = artifacts.require("MockNameWrapper");
+const MockENSRegistry = artifacts.require("MockENSRegistry");
+const MockPublicResolver = artifacts.require("MockPublicResolver");
+const ENSJobPages = artifacts.require("ENSJobPages");
+const MockENSJobPagesMalformed = artifacts.require("MockENSJobPagesMalformed");
+const MockHookCaller = artifacts.require("MockHookCaller");
+
+const { buildInitConfig } = require("./helpers/deploy");
+const { fundAgents } = require("./helpers/bonds");
+
+contract("Job token metadata routing and mappings", (accounts) => {
+  const [owner, employer, agent] = accounts;
+  const ZERO32 = "0x" + "00".repeat(32);
+
+  async function deployManager(baseIpfsUrl = "ipfs://base/") {
+    const token = await MockERC20.new({ from: owner });
+    const ens = await MockENS.new({ from: owner });
+    const nameWrapper = await MockNameWrapper.new({ from: owner });
+    const manager = await AGIJobManager.new(
+      ...buildInitConfig(
+        token.address,
+        baseIpfsUrl,
+        ens.address,
+        nameWrapper.address,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32,
+        ZERO32
+      ),
+      { from: owner }
+    );
+    return { token, manager };
+  }
+
+  async function createAndFinalize({ manager, token, completionURI }) {
+    const nft = await MockERC721.new({ from: owner });
+    await manager.addAGIType(nft.address, 80, { from: owner });
+    await nft.mint(agent, { from: owner });
+    await manager.addAdditionalAgent(agent, { from: owner });
+    await fundAgents(token, manager, [agent], owner);
+
+    const payout = web3.utils.toWei("10");
+    await token.mint(employer, payout, { from: owner });
+    await token.approve(manager.address, payout, { from: employer });
+
+    await manager.createJob("ipfs://spec.json", payout, 100, "details", { from: employer });
+    await manager.applyForJob(0, "agent", [], { from: agent });
+    await manager.requestJobCompletion(0, completionURI, { from: agent });
+
+    const reviewPeriod = await manager.completionReviewPeriod();
+    await time.increase(reviewPeriod.addn(1));
+    return manager.finalizeJob(0, { from: employer });
+  }
+
+  it("falls back to completion URI if ENS router payload is malformed", async () => {
+    const { token, manager } = await deployManager("ipfs://base/");
+    const malformed = await MockENSJobPagesMalformed.new({ from: owner });
+    await malformed.setTokenURIBytes("0x1234", { from: owner });
+
+    await manager.setEnsJobPages(malformed.address, { from: owner });
+    await manager.setUseEnsJobTokenURI(true, { from: owner });
+
+    const receipt = await createAndFinalize({ manager, token, completionURI: "QmCompletion" });
+    const minted = receipt.logs.find((log) => log.event === "NFTIssued");
+    const tokenUri = await manager.tokenURI(minted.args.tokenId);
+    assert.equal(tokenUri, "ipfs://base/QmCompletion");
+  });
+
+  it("router handleHook does not revert and preview matches selector output", async () => {
+    const ens = await MockENSRegistry.new({ from: owner });
+    const resolver = await MockPublicResolver.new({ from: owner });
+    const router = await ENSJobPages.new(ens.address, "0x0000000000000000000000000000000000000000", resolver.address, ZERO32, "", { from: owner });
+    const hookCaller = await MockHookCaller.new({ from: owner });
+
+    await router.setJobManager(hookCaller.address, { from: owner });
+    await router.setBaseMetadataURI("ipfs://metadata/", { from: owner });
+    await router.setUseJobIdJsonSuffix(true, { from: owner });
+
+    await hookCaller.callHandleHook(router.address, 1, 99, { from: owner });
+
+    const preview = await router.previewTokenURI(99);
+    assert.equal(preview, "ipfs://metadata/99.json");
+
+    const selector = web3.utils.keccak256("jobEnsURI(uint256)").slice(0, 10);
+    const payload = web3.eth.abi.encodeFunctionCall(
+      {
+        name: "jobEnsURI",
+        type: "function",
+        inputs: [{ name: "jobId", type: "uint256" }]
+      },
+      ["99"]
+    );
+    assert.equal(payload.slice(0, 10), selector);
+
+    const raw = await web3.eth.call({ to: router.address, data: payload });
+    const decoded = web3.eth.abi.decodeParameters(["string"], raw);
+    assert.equal(decoded[0], preview);
+  });
+});


### PR DESCRIPTION
### Motivation
- Operators need a deterministic, Etherscan-friendly way to produce complete ERC-721 metadata for completion NFTs while keeping the core `AGIJobManager` bytecode under the repo bytecode guard. 
- ENS integrations must remain best-effort and non-blocking so settlement never depends on ENS resolver success. 
- Provide reproducible operator tooling and docs so owners can preview tokenURIs and publish marketplace-ready metadata with a beautiful default image (canonical `ipfs://Qmc13BByj8xKnpgQtwBereGJpEXtosLMLq6BCUjK3TtAd1`).

### Description
- Extended `contracts/ens/ENSJobPages.sol` with owner-configurable metadata router fields and setters: `baseMetadataURI`, `defaultImageURI`, `externalUrlBase`, and `useJobIdJsonSuffix`, and added `previewTokenURI(uint256)` for Etherscan-friendly inspection. 
- Implemented selector-compatible tokenURI routing support: the router handles staticcall/selector `0x751809b4` (via a compact `fallback()` path) and `jobEnsURI(uint256)` now returns the routed metadata URI when configured while preserving legacy `ens://...` behavior as fallback. 
- Added operator assets to produce marketplace-friendly JSON metadata: `docs/examples/nft-metadata/AGIJobCompletionNFT.template.json` and `scripts/nft/generate-job-nft-metadata.mjs` that read on-chain getters and emit deterministic ERC-721 metadata using the canonical default image. 
- Added an Etherscan-first operator runbook `docs/OPERATIONS/JOB_LIFECYCLE_AND_NFT_RUNBOOK.md` with AI-agents-exclusive policy statement, Mermaid lifecycle and tokenURI-selection diagrams, copy/paste Etherscan instructions, ENS hook semantics, and common mistakes. 
- Added `test/jobTokenMetadataRouting.test.js` covering router preview/selector behavior and malformed-payload fallback, and updated ENS references/docs to include the router mode. 
- Deliberately avoided expanding `AGIJobManager` runtime logic to keep its bytecode under the repo guard and implemented richer UX in the periphery router instead.

### Testing
- Built and compiled contracts with `npm run build` and verified bytecode guard with `npm run size`, which reports `AGIJobManager` runtime bytecode at or below the enforced threshold. (Succeeded.)
- Ran the targeted Truffle test set with `npx truffle test test/jobTokenMetadataRouting.test.js test/ensJobPagesHelper.test.js test/ensJobPagesHooks.test.js --network test` and confirmed all tests passed. (Succeeded.)
- Regenerated and validated docs with `npm run docs:gen`, `npm run docs:ens:gen`, `npm run docs:check`, and `npm run docs:ens:check` and confirmed documentation checks passed. (Succeeded.)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699b209c84c08333b1d0896bc08c2fdf)